### PR TITLE
경매 상품 선택 시 경매 상세를 보여주는 기능 구현

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/AuctionAdapter.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/AuctionAdapter.kt
@@ -5,9 +5,10 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.ddangddangddang.android.model.AuctionHomeModel
 
-class AuctionAdapter : ListAdapter<AuctionHomeModel, AuctionViewHolder>(AuctionDiffUtil) {
+class AuctionAdapter(private val onItemClick: (Long) -> Unit) :
+    ListAdapter<AuctionHomeModel, AuctionViewHolder>(AuctionDiffUtil) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AuctionViewHolder {
-        return AuctionViewHolder.create(parent)
+        return AuctionViewHolder.create(parent, onItemClick)
     }
 
     override fun onBindViewHolder(holder: AuctionViewHolder, position: Int) {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/AuctionViewHolder.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/AuctionViewHolder.kt
@@ -6,17 +6,25 @@ import androidx.recyclerview.widget.RecyclerView
 import com.ddangddangddang.android.databinding.ItemHomeAuctionBinding
 import com.ddangddangddang.android.model.AuctionHomeModel
 
-class AuctionViewHolder private constructor(private val binding: ItemHomeAuctionBinding) :
-    RecyclerView.ViewHolder(binding.root) {
+class AuctionViewHolder private constructor(
+    private val binding: ItemHomeAuctionBinding,
+    private val onItemClick: (Long) -> Unit,
+) : RecyclerView.ViewHolder(binding.root) {
+    init {
+        binding.clAuctionItem.setOnClickListener {
+            binding.auction?.let { onItemClick(it.id) }
+        }
+    }
+
     fun bind(auction: AuctionHomeModel) {
         binding.auction = auction
     }
 
     companion object {
-        fun create(parent: ViewGroup): AuctionViewHolder {
+        fun create(parent: ViewGroup, onItemClick: (Long) -> Unit): AuctionViewHolder {
             val layoutInflater = LayoutInflater.from(parent.context)
             val binding = ItemHomeAuctionBinding.inflate(layoutInflater, parent, false)
-            return AuctionViewHolder(binding)
+            return AuctionViewHolder(binding, onItemClick)
         }
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.viewModels
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.FragmentHomeBinding
 import com.ddangddangddang.android.feature.common.viewModelFactory
+import com.ddangddangddang.android.feature.detail.AuctionDetailActivity
 import com.ddangddangddang.android.util.binding.BindingFragment
 
 class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home) {
@@ -13,13 +14,33 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setupViewModel()
         setupAuctionRecyclerView()
+    }
+
+    private fun setupViewModel() {
+        viewModel.event.observe(viewLifecycleOwner) { handleEvent(it) }
+    }
+
+    private fun handleEvent(event: HomeViewModel.HomeEvent) {
+        when (event) {
+            is HomeViewModel.HomeEvent.NavigateToAuctionDetail -> {
+                navigateToAuctionDetail(event.auctionId)
+            }
+        }
     }
 
     private fun setupAuctionRecyclerView() {
         with(binding.rvAuction) {
-            adapter = AuctionAdapter().apply { setAuctions(viewModel.auctions) }
+            adapter = AuctionAdapter { auctionId ->
+                viewModel.navigateToAuctionDetail(auctionId)
+            }.apply { setAuctions(viewModel.auctions) }
             addItemDecoration(AuctionSpaceItemDecoration(spanCount = 2, space = 20))
         }
+    }
+
+    private fun navigateToAuctionDetail(auctionId: Long) {
+        val intent = AuctionDetailActivity.getIntent(requireContext(), auctionId)
+        startActivity(intent)
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
@@ -1,8 +1,10 @@
 package com.ddangddangddang.android.feature.home
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import com.ddangddangddang.android.model.AuctionHomeModel
 import com.ddangddangddang.android.model.AuctionHomeStatusModel
+import com.ddangddangddang.android.util.livedata.SingleLiveEvent
 
 class HomeViewModel : ViewModel() {
     val auctions: List<AuctionHomeModel> = listOf(
@@ -55,4 +57,16 @@ class HomeViewModel : ViewModel() {
             2000,
         ),
     )
+
+    private val _event: SingleLiveEvent<HomeEvent> = SingleLiveEvent()
+    val event: LiveData<HomeEvent>
+        get() = _event
+
+    fun navigateToAuctionDetail(auctionId: Long) {
+        _event.value = HomeEvent.NavigateToAuctionDetail(auctionId)
+    }
+
+    sealed class HomeEvent {
+        data class NavigateToAuctionDetail(val auctionId: Long) : HomeEvent()
+    }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/model/AuctionHomeStatusModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/model/AuctionHomeStatusModel.kt
@@ -5,8 +5,8 @@ import androidx.annotation.StringRes
 import com.ddangddangddang.android.R
 
 enum class AuctionHomeStatusModel(
-    @StringRes val priceStatus: Int,
-    @StringRes val progressStatus: Int,
+    @StringRes val priceStatusId: Int,
+    @StringRes val progressStatusId: Int,
     @ColorRes val colorId: Int,
 ) {
     ONGOING(R.string.all_current_price, R.string.all_auction_ongoing, R.color.red_100),

--- a/android/app/src/main/res/layout/item_home_auction.xml
+++ b/android/app/src/main/res/layout/item_home_auction.xml
@@ -72,7 +72,7 @@
             tools:backgroundTint="@color/red_100"
             android:textSize="12sp"
             android:layout_marginTop="4dp"
-            android:text="@{context.getString(auction.status.priceStatus)}"
+            android:text="@{context.getString(auction.status.priceStatusId)}"
             android:backgroundTint="@{context.getColor(auction.status.colorId)}" />
 
         <TextView

--- a/android/app/src/main/res/layout/item_home_auction.xml
+++ b/android/app/src/main/res/layout/item_home_auction.xml
@@ -5,13 +5,16 @@
     xmlns:bind="http://schemas.android.com/apk/res-auto">
 
     <data>
+
         <import type="com.ddangddangddang.android.model.AuctionHomeStatusModel" />
+
         <variable
             name="auction"
             type="com.ddangddangddang.android.model.AuctionHomeModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_auction_item"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 

--- a/android/app/src/main/res/layout/view_auction_image_cover_with_status.xml
+++ b/android/app/src/main/res/layout/view_auction_image_cover_with_status.xml
@@ -43,7 +43,7 @@
             app:layout_constraintStart_toStartOf="@id/v_auction_status"
             app:layout_constraintEnd_toEndOf="@id/v_auction_status"
             tools:text="낙찰 완료"
-            android:text="@{context.getString(auctionStatus.progressStatus)}"
+            android:text="@{context.getString(auctionStatus.progressStatusId)}"
             android:textColor="@color/white"
             android:textSize="14sp" />
 


### PR DESCRIPTION
## 📄 작업 내용 요약
경매 상품 목록에서 특정 경매 상품 선택 시 경매 상세 페이지로 이동한다.

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
ViewModel의 event를 observe해서 이벤트를 발생시키는 부분을 처음 짜봐서 확인 부탁드려요~!
Adapter에 ViewModel의 함수를 생성자 주입하고 경매 상품이 선택되었을 때 ViewModel의 함수가 호출되고 이를 observe해서 Fragment에 정의된 경매 상세 페이지 이동 함수를 호출하도록 했어요!
ViewModel의 데이터가 이벤트 발생에 필요하지 않지만 ViewModel을 거친 이유는 뷰에서 발생하는 모든 유저 이벤트를 ViewModel에서 처리하고 observe하도록 통일하기 위함입니다!
또한 지금 당장은 ViewModel의 데이터가 필요하지 않지만 추후에 필요하게 되었을 때 뷰 계층의 코드 수정이 최대한 없게 하기 위함도 있어요! 

## 📎 Issue 번호
close #59 