### PR TITLE
지역 초기 데이터 저장

### DIFF
--- a/backend/ddang/src/main/java/com/ddang/ddang/configuration/InitializationRegionConfiguration.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/configuration/InitializationRegionConfiguration.java
@@ -1,0 +1,21 @@
+package com.ddang.ddang.configuration;
+
+import com.ddang.ddang.region.application.RegionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(name = "data.init.region.enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class InitializationRegionConfiguration implements ApplicationRunner {
+
+    private final RegionService regionService;
+
+    @Override
+    public void run(final ApplicationArguments args) {
+        regionService.createRegions();
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/configuration/RestTemplateConfiguration.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/configuration/RestTemplateConfiguration.java
@@ -1,0 +1,14 @@
+package com.ddang.ddang.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfiguration {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/region/application/RegionService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/region/application/RegionService.java
@@ -2,6 +2,7 @@ package com.ddang.ddang.region.application;
 
 import com.ddang.ddang.region.application.dto.ReadRegionDto;
 import com.ddang.ddang.region.application.exception.RegionNotFoundException;
+import com.ddang.ddang.region.domain.InitializationRegionProcessor;
 import com.ddang.ddang.region.domain.Region;
 import com.ddang.ddang.region.infrastructure.persistence.JpaRegionRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,14 @@ import java.util.List;
 public class RegionService {
 
     private final JpaRegionRepository regionRepository;
+    private final InitializationRegionProcessor regionProcessor;
+
+    @Transactional
+    public void createRegions() {
+        final List<Region> regions = regionProcessor.requestRegions();
+
+        regionRepository.saveAll(regions);
+    }
 
     public List<ReadRegionDto> readAllFirst() {
         final List<Region> firstRegions = regionRepository.findFirstAll();

--- a/backend/ddang/src/main/java/com/ddang/ddang/region/domain/InitializationRegionProcessor.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/region/domain/InitializationRegionProcessor.java
@@ -1,0 +1,8 @@
+package com.ddang.ddang.region.domain;
+
+import java.util.List;
+
+public interface InitializationRegionProcessor {
+
+    List<Region> requestRegions();
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/region/infrastructure/api/RestTemplateInitRegionProcessor.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/region/infrastructure/api/RestTemplateInitRegionProcessor.java
@@ -90,14 +90,14 @@ public class RestTemplateInitRegionProcessor implements InitializationRegionProc
         try {
             return accessTokenResponse.getResult()
                                       .get(ACCESS_TOKEN_NAME);
-        } catch (final NullPointerException e) {
+        } catch (final NullPointerException ex) {
             final String exceptionFormatter =  "API 요청 도중 문제가 발생했습니다. 코드 번호 : %s, 메세지 : %s";
             throw new RegionApiException(
                     String.format(
                             exceptionFormatter,
                             accessTokenResponse.getErrCd(),
                             accessTokenResponse.getErrMsg()
-                    ), e
+                    ), ex
             );
         }
     }
@@ -111,8 +111,8 @@ public class RestTemplateInitRegionProcessor implements InitializationRegionProc
 
         try {
             return regionResponse.getResult();
-        } catch (NullPointerException e) {
-            throw new RegionApiException("API 요청 도중 문제가 발생했습니다.", e);
+        } catch (final NullPointerException ex) {
+            throw new RegionApiException("API 요청 도중 문제가 발생했습니다.", ex);
         }
     }
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/region/infrastructure/api/RestTemplateInitRegionProcessor.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/region/infrastructure/api/RestTemplateInitRegionProcessor.java
@@ -1,0 +1,131 @@
+package com.ddang.ddang.region.infrastructure.api;
+
+import com.ddang.ddang.region.domain.InitializationRegionProcessor;
+import com.ddang.ddang.region.domain.Region;
+import com.ddang.ddang.region.infrastructure.api.dto.ApiAccessTokenResponse;
+import com.ddang.ddang.region.infrastructure.api.dto.ResultApiRegionResponse;
+import com.ddang.ddang.region.infrastructure.api.dto.TotalApiRegionResponse;
+import com.ddang.ddang.region.infrastructure.api.exception.RegionApiException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class RestTemplateInitRegionProcessor implements InitializationRegionProcessor {
+
+    private static final String REGION_API_DOMAIN = "https://sgisapi.kostat.go.kr";
+    private static final String REGION_CODE_NAME = "cd";
+    private static final String ACCESS_TOKEN_NAME = "accessToken";
+    private static final String SERVICE_KEY_NAME = "consumer_key";
+    private static final String SECRET_KEY_NAME = "consumer_secret";
+    private static final String AUTHENTICATION_URL = "/OpenAPI3/auth/authentication.json";
+    private static final String REGION_URL_NAME = "/OpenAPI3/addr/stage.json";
+
+    @Value("${open.api.region.service}")
+    private String serviceSecret;
+
+    @Value("${open.api.region.key}")
+    private String keySecret;
+
+    private final RestTemplate restTemplate;
+
+    @Override
+    public List<Region> requestRegions() {
+        final String accessToken = requestApiAccessToken();
+        final List<ResultApiRegionResponse> firstRegionsResponses = requestApiRegionResponse(
+                null,
+                accessToken
+        );
+
+        final List<Region> totalRegions = new ArrayList<>();
+
+        for (ResultApiRegionResponse firstRegionResponse : firstRegionsResponses) {
+            final Region firstRegion = firstRegionResponse.toEntity();
+            final List<ResultApiRegionResponse> secondRegionsResponses = requestApiRegionResponse(
+                    firstRegionResponse.getRegionCode(),
+                    accessToken
+            );
+
+            for (ResultApiRegionResponse secondRegionsResponse : secondRegionsResponses) {
+                final Region secondRegion = secondRegionsResponse.toEntity();
+                final List<ResultApiRegionResponse> thirdRegionsResponses = requestApiRegionResponse(
+                        secondRegionsResponse.getRegionCode(),
+                        accessToken
+                );
+
+                firstRegion.addSecondRegion(secondRegion);
+
+                for (ResultApiRegionResponse thirdRegionsResponse : thirdRegionsResponses) {
+                    final Region thirdRegion = thirdRegionsResponse.toEntity();
+                    secondRegion.addThirdRegion(thirdRegion);
+                }
+            }
+
+            totalRegions.add(firstRegion);
+        }
+
+        return totalRegions;
+    }
+
+    private String requestApiAccessToken() {
+        URI authenticationUri = UriComponentsBuilder.fromUriString(REGION_API_DOMAIN)
+                                                    .path(AUTHENTICATION_URL)
+                                                    .queryParam(SERVICE_KEY_NAME, serviceSecret)
+                                                    .queryParam(SECRET_KEY_NAME, keySecret)
+                                                    .encode()
+                                                    .build()
+                                                    .toUri();
+
+        final ApiAccessTokenResponse accessTokenResponse = restTemplate.getForObject(
+                authenticationUri,
+                ApiAccessTokenResponse.class
+        );
+        try {
+            return accessTokenResponse.getResult()
+                                      .get(ACCESS_TOKEN_NAME);
+        } catch (final NullPointerException e) {
+            final String exceptionFormatter =  "API 요청 도중 문제가 발생했습니다. 코드 번호 : %s, 메세지 : %s";
+            throw new RegionApiException(
+                    String.format(
+                            exceptionFormatter,
+                            accessTokenResponse.getErrCd(),
+                            accessTokenResponse.getErrMsg()
+                    ), e
+            );
+        }
+    }
+
+    private List<ResultApiRegionResponse> requestApiRegionResponse(final String regionCode, final String accessToken) {
+        final UriComponents regionUri = createRegionUriBuilder(accessToken, regionCode);
+        final TotalApiRegionResponse regionResponse = restTemplate.getForObject(
+                regionUri.toUri(),
+                TotalApiRegionResponse.class
+        );
+
+        try {
+            return regionResponse.getResult();
+        } catch (NullPointerException e) {
+            throw new RegionApiException("API 요청 도중 문제가 발생했습니다.", e);
+        }
+    }
+
+    private UriComponents createRegionUriBuilder(final String accessToken, final String regionCode) {
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(REGION_API_DOMAIN)
+                                                                 .path(REGION_URL_NAME)
+                                                                 .queryParam(ACCESS_TOKEN_NAME, accessToken);
+
+        if (regionCode != null && !regionCode.isEmpty()) {
+            builder.queryParam(REGION_CODE_NAME, regionCode);
+        }
+
+        return builder.encode()
+                      .build();
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/region/infrastructure/api/RestTemplateInitRegionProcessor.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/region/infrastructure/api/RestTemplateInitRegionProcessor.java
@@ -46,14 +46,14 @@ public class RestTemplateInitRegionProcessor implements InitializationRegionProc
 
         final List<Region> totalRegions = new ArrayList<>();
 
-        for (ResultApiRegionResponse firstRegionResponse : firstRegionsResponses) {
+        for (final ResultApiRegionResponse firstRegionResponse : firstRegionsResponses) {
             final Region firstRegion = firstRegionResponse.toEntity();
             final List<ResultApiRegionResponse> secondRegionsResponses = requestApiRegionResponse(
                     firstRegionResponse.getRegionCode(),
                     accessToken
             );
 
-            for (ResultApiRegionResponse secondRegionsResponse : secondRegionsResponses) {
+            for (final ResultApiRegionResponse secondRegionsResponse : secondRegionsResponses) {
                 final Region secondRegion = secondRegionsResponse.toEntity();
                 final List<ResultApiRegionResponse> thirdRegionsResponses = requestApiRegionResponse(
                         secondRegionsResponse.getRegionCode(),
@@ -62,7 +62,7 @@ public class RestTemplateInitRegionProcessor implements InitializationRegionProc
 
                 firstRegion.addSecondRegion(secondRegion);
 
-                for (ResultApiRegionResponse thirdRegionsResponse : thirdRegionsResponses) {
+                for (final ResultApiRegionResponse thirdRegionsResponse : thirdRegionsResponses) {
                     final Region thirdRegion = thirdRegionsResponse.toEntity();
                     secondRegion.addThirdRegion(thirdRegion);
                 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/region/infrastructure/api/RestTemplateInitRegionProcessor.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/region/infrastructure/api/RestTemplateInitRegionProcessor.java
@@ -75,7 +75,7 @@ public class RestTemplateInitRegionProcessor implements InitializationRegionProc
     }
 
     private String requestApiAccessToken() {
-        URI authenticationUri = UriComponentsBuilder.fromUriString(REGION_API_DOMAIN)
+        final URI authenticationUri = UriComponentsBuilder.fromUriString(REGION_API_DOMAIN)
                                                     .path(AUTHENTICATION_URL)
                                                     .queryParam(SERVICE_KEY_NAME, serviceSecret)
                                                     .queryParam(SECRET_KEY_NAME, keySecret)

--- a/backend/ddang/src/main/java/com/ddang/ddang/region/infrastructure/api/dto/ApiAccessTokenResponse.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/region/infrastructure/api/dto/ApiAccessTokenResponse.java
@@ -1,0 +1,21 @@
+package com.ddang.ddang.region.infrastructure.api.dto;
+
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ApiAccessTokenResponse {
+
+    private String id;
+    private Map<String, String> result;
+    private String errMsg;
+    private String errCd;
+    private String trId;
+
+    public ApiAccessTokenResponse(final Map<String, String> result) {
+        this.result = result;
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/region/infrastructure/api/dto/ResultApiRegionResponse.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/region/infrastructure/api/dto/ResultApiRegionResponse.java
@@ -1,0 +1,36 @@
+package com.ddang.ddang.region.infrastructure.api.dto;
+
+import com.ddang.ddang.region.domain.Region;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ResultApiRegionResponse {
+
+    @JsonProperty("y_coor")
+    private String latitude;
+
+    @JsonProperty("full_addr")
+    private String fullAddress;
+
+    @JsonProperty("x_coor")
+    private String longitude;
+
+    @JsonProperty("addr_name")
+    private String regionName;
+
+    @JsonProperty("cd")
+    private String regionCode;
+
+    public ResultApiRegionResponse(final String regionName, final String regionCode) {
+        this.regionName = regionName;
+        this.regionCode = regionCode;
+    }
+
+    public Region toEntity() {
+        return new Region(regionName);
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/region/infrastructure/api/dto/TotalApiRegionResponse.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/region/infrastructure/api/dto/TotalApiRegionResponse.java
@@ -1,0 +1,18 @@
+package com.ddang.ddang.region.infrastructure.api.dto;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class TotalApiRegionResponse {
+
+    private String id;
+    private List<ResultApiRegionResponse> result;
+
+    public TotalApiRegionResponse(final List<ResultApiRegionResponse> result) {
+        this.result = result;
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/region/infrastructure/api/exception/RegionApiException.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/region/infrastructure/api/exception/RegionApiException.java
@@ -1,0 +1,8 @@
+package com.ddang.ddang.region.infrastructure.api.exception;
+
+public class RegionApiException extends IllegalStateException {
+
+    public RegionApiException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/ddang/src/main/resources/application-local.yml
+++ b/backend/ddang/src/main/resources/application-local.yml
@@ -28,4 +28,4 @@ open:
 data:
   init:
     region:
-      enabled: true
+      enabled: false

--- a/backend/ddang/src/main/resources/application-local.yml
+++ b/backend/ddang/src/main/resources/application-local.yml
@@ -24,3 +24,8 @@ open:
     region:
       service: service_secret
       key: key_secret
+
+data:
+  init:
+    region:
+      enabled: true

--- a/backend/ddang/src/main/resources/application-local.yml
+++ b/backend/ddang/src/main/resources/application-local.yml
@@ -13,6 +13,7 @@ spring:
         dialect: org.hibernate.dialect.H2Dialect
         show_sql: true
         use_sql_comments: true
+        default_batch_fetch_size: 5000
     open-in-view: false
 
   flyway:

--- a/backend/ddang/src/main/resources/application-local.yml
+++ b/backend/ddang/src/main/resources/application-local.yml
@@ -17,3 +17,9 @@ spring:
 
   flyway:
     enabled: false
+
+open:
+  api:
+    region:
+      service: service_secret
+      key: key_secret

--- a/backend/ddang/src/test/java/com/ddang/ddang/configuration/DatabaseCleanListener.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/configuration/DatabaseCleanListener.java
@@ -47,7 +47,7 @@ public class DatabaseCleanListener extends AbstractTestExecutionListener {
         em.flush();
         em.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
 
-        for (String tableName : tableNames) {
+        for (final String tableName : tableNames) {
             em.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
             em.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN id RESTART WITH 1").executeUpdate();
         }

--- a/backend/ddang/src/test/java/com/ddang/ddang/region/infrastructure/api/RestTemplateInitRegionProcessorTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/region/infrastructure/api/RestTemplateInitRegionProcessorTest.java
@@ -120,7 +120,10 @@ class RestTemplateInitRegionProcessorTest {
 
         mockRestServiceServer
                 .expect(requestTo(thirdRegionUri))
-                .andRespond(withSuccess(objectMapper.writeValueAsString(thirdOpenApiResultApiRegionResponse), MediaType.APPLICATION_JSON));
+                .andRespond(withSuccess(
+                        objectMapper.writeValueAsString(thirdOpenApiResultApiRegionResponse),
+                        MediaType.APPLICATION_JSON
+                ));
 
         // when
         final List<Region> actual = regionProcessor.requestRegions();

--- a/backend/ddang/src/test/java/com/ddang/ddang/region/infrastructure/api/RestTemplateInitRegionProcessorTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/region/infrastructure/api/RestTemplateInitRegionProcessorTest.java
@@ -33,15 +33,16 @@ import org.springframework.web.client.RestTemplate;
 @SuppressWarnings("NonAsciiCharacters")
 class RestTemplateInitRegionProcessorTest {
 
-    private MockRestServiceServer mockRestServiceServer;
+    MockRestServiceServer mockRestServiceServer;
 
     @Autowired
-    private RestTemplate restTemplate;
+    RestTemplate restTemplate;
 
     @Autowired
-    private RestTemplateInitRegionProcessor regionProcessor;
+    RestTemplateInitRegionProcessor regionProcessor;
 
-    ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {

--- a/backend/ddang/src/test/java/com/ddang/ddang/region/infrastructure/api/RestTemplateInitRegionProcessorTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/region/infrastructure/api/RestTemplateInitRegionProcessorTest.java
@@ -1,0 +1,196 @@
+package com.ddang.ddang.region.infrastructure.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.ddang.ddang.configuration.RestTemplateConfiguration;
+import com.ddang.ddang.region.domain.Region;
+import com.ddang.ddang.region.infrastructure.api.dto.ApiAccessTokenResponse;
+import com.ddang.ddang.region.infrastructure.api.dto.ResultApiRegionResponse;
+import com.ddang.ddang.region.infrastructure.api.dto.TotalApiRegionResponse;
+import com.ddang.ddang.region.infrastructure.api.exception.RegionApiException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+@RestClientTest({RestTemplateInitRegionProcessor.class})
+@Import(RestTemplateConfiguration.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class RestTemplateInitRegionProcessorTest {
+
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Autowired
+    private RestTemplateInitRegionProcessor regionProcessor;
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockRestServiceServer = MockRestServiceServer.createServer(restTemplate);
+    }
+
+    @Test
+    void API_요청을_통해_대한민국_전국_지역을_조회한다() throws Exception {
+        // given
+        final String accessToken = "accessToken";
+        final ApiAccessTokenResponse accessTokenResponse = new ApiAccessTokenResponse(
+                Collections.singletonMap("accessToken", accessToken)
+        );
+
+        mockRestServiceServer
+                .expect(requestTo(matchesPattern(
+                        "https://sgisapi.kostat.go.kr/OpenAPI3/auth/authentication.json.*"
+                )))
+                .andRespond(withSuccess(
+                        objectMapper.writeValueAsString(accessTokenResponse),
+                        MediaType.APPLICATION_JSON
+                ));
+
+        final String firstRegionUri = "https://sgisapi.kostat.go.kr/OpenAPI3/addr/stage.json?" +
+                "accessToken=" +
+                accessToken;
+        final ResultApiRegionResponse firstResultApiRegionResponse = new ResultApiRegionResponse(
+                "서울특별시",
+                "11"
+        );
+        final TotalApiRegionResponse openApiResultApiRegionResponse = new TotalApiRegionResponse(
+                List.of(firstResultApiRegionResponse)
+        );
+
+        mockRestServiceServer
+                .expect(requestTo(firstRegionUri))
+                .andRespond(withSuccess(
+                        objectMapper.writeValueAsString(openApiResultApiRegionResponse),
+                        MediaType.APPLICATION_JSON
+                ));
+
+        final String secondRegionCode = "11";
+        final String secondRegionUri = "https://sgisapi.kostat.go.kr/OpenAPI3/addr/stage.json?" +
+                "accessToken=" +
+                accessToken +
+                "&cd=" +
+                secondRegionCode;
+        final ResultApiRegionResponse secondResultApiRegionResponse = new ResultApiRegionResponse(
+                "강남구",
+                "11230"
+        );
+        final TotalApiRegionResponse secondOpenApiResultApiRegionResponse = new TotalApiRegionResponse(
+                List.of(secondResultApiRegionResponse)
+        );
+
+        mockRestServiceServer
+                .expect(requestTo(secondRegionUri))
+                .andRespond(withSuccess(
+                        objectMapper.writeValueAsString(secondOpenApiResultApiRegionResponse),
+                        MediaType.APPLICATION_JSON)
+                );
+
+        final String thirdRegionCode = "11230";
+        final String thirdRegionUri = "https://sgisapi.kostat.go.kr/OpenAPI3/addr/stage.json?" +
+                "accessToken=" +
+                accessToken +
+                "&cd=" +
+                thirdRegionCode;
+        final ResultApiRegionResponse thirdResultApiRegionResponse = new ResultApiRegionResponse(
+                "개포1동",
+                "11230680"
+        );
+        final TotalApiRegionResponse thirdOpenApiResultApiRegionResponse = new TotalApiRegionResponse(
+                List.of(thirdResultApiRegionResponse)
+        );
+
+        mockRestServiceServer
+                .expect(requestTo(thirdRegionUri))
+                .andRespond(withSuccess(objectMapper.writeValueAsString(thirdOpenApiResultApiRegionResponse), MediaType.APPLICATION_JSON));
+
+        // when
+        final List<Region> actual = regionProcessor.requestRegions();
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).hasSize(1);
+
+            final Region actualFirstRegion = actual.get(0);
+            softAssertions.assertThat(actualFirstRegion.getName()).isEqualTo(firstResultApiRegionResponse.getRegionName());
+            softAssertions.assertThat(actualFirstRegion.getSecondRegions()).hasSize(1);
+
+            final Region actualSecondRegion = actualFirstRegion.getSecondRegions().get(0);
+            softAssertions.assertThat(actualSecondRegion.getName()).isEqualTo(secondResultApiRegionResponse.getRegionName());
+            softAssertions.assertThat(actualSecondRegion.getThirdRegions()).hasSize(1);
+
+            final Region actualThirdRegion = actualSecondRegion.getThirdRegions().get(0);
+            assertThat(actualThirdRegion.getName()).isEqualTo(thirdResultApiRegionResponse.getRegionName());
+        });
+    }
+
+    @Test
+    void service키나_secret키가_유효하지_않은_경우_예외가_발생한다() throws Exception {
+        // given
+        final ApiAccessTokenResponse invalidAccessTokenResponse = new ApiAccessTokenResponse(null);
+
+        mockRestServiceServer
+                .expect(requestTo(matchesPattern(
+                        "https://sgisapi.kostat.go.kr/OpenAPI3/auth/authentication.json.*"
+                )))
+                .andRespond(withSuccess(
+                        objectMapper.writeValueAsString(invalidAccessTokenResponse),
+                        MediaType.APPLICATION_JSON
+                ));
+
+        // when & then
+        assertThatThrownBy(() -> regionProcessor.requestRegions())
+                .isInstanceOf(RegionApiException.class)
+                .hasMessageContaining("API 요청 도중 문제가 발생했습니다.");
+    }
+
+    @Test
+    void 단계별_주소_조회_API_요청에_실패하면_예외가_발생한다() throws Exception {
+        // given
+        final String accessToken = "accessToken";
+        final ApiAccessTokenResponse accessTokenResponse = new ApiAccessTokenResponse(
+                Collections.singletonMap("accessToken", accessToken)
+        );
+
+        mockRestServiceServer
+                .expect(requestTo(matchesPattern(
+                        "https://sgisapi.kostat.go.kr/OpenAPI3/auth/authentication.json.*"
+                )))
+                .andRespond(withSuccess(
+                        objectMapper.writeValueAsString(accessTokenResponse),
+                        MediaType.APPLICATION_JSON
+                ));
+
+        mockRestServiceServer
+                .expect(requestTo(matchesPattern(
+                        "https://sgisapi.kostat.go.kr/OpenAPI3/addr/stage.json.*"
+                )))
+                .andRespond(withSuccess(
+                        objectMapper.writeValueAsString(null),
+                        MediaType.APPLICATION_JSON
+                ));
+
+        // when & then
+        assertThatThrownBy(() -> regionProcessor.requestRegions())
+                .isInstanceOf(RegionApiException.class)
+                .hasMessageContaining("API 요청 도중 문제가 발생했습니다.");
+    }
+}

--- a/backend/ddang/src/test/resources/application.yml
+++ b/backend/ddang/src/test/resources/application.yml
@@ -17,3 +17,9 @@ spring:
 
   flyway:
     enabled: false
+
+open:
+  api:
+    region:
+      service: service_secret
+      key: key_secret


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->
지역 초기 데이터 저장
## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

- InitializationRegionProcessor & RestTemplateInitRegionProcessor
  - 특정 기술 스택과 API(RestTemplate, 단계별 주소 조회 API)에 종속적이지 않도록 추상화
 - InitializationRegionConfiguration
   - ApplicationRunner로 애플리케이션 초기화 시 실행되도록 하기 위함
   - 운영 서버에서까지 사용해야 하지만, DB 상황에 따라 사용 유무가 갈리므로 @ConditionalOnProperty를 통해 외부 설정을 통한 분기처리
 - RegionService
   - 다른 초기 데이터 설정과는 달리 운영 서버에서도 사용될 것이기 때문에 트랜잭션을 직접 InitializationRegionConfiguration에서 관리하지 않고 RegionService에서 트랜잭션을 관리하도록 함
     - 추후 CQRS를 도입한다면 지역 읽기와 지역 초기화로 분리할 수도? 있을듯 
- RestTemplateInitRegionProcessorTest
  - 어노테이션이랑 Mock 서버를 활용한 테스트

[링크](https://github.com/woowacourse-teams/2023-3-ddang/discussions/114) 참고

---

현재 애플리케이션 실행 시 실행되지 않고 예외가 발생하는데, 그 이유는 `application-local.yml`에 `open.api.region`의 `service`와 `secret`이 필요하기 때문입니다.
이 정보는 민감한 부분이라 여기서는 대충 더미 데이터를 넣었고, 이후 서브모듈에서 실제 key를 지정하는 방향으로 가게 될 것 같습니다.
로컬에서 실행하는 경우 `data.init.region.enabled`의 값을 `false`로 두면 지역 초기화 동작을 비활성화 할 수 있으니, 이런 방식으로 진행해주시면 될 것 같습니다.

## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
- closed #111 
<!-- closed #번호 --> 
