### PR TITLE
경매 데이터 캐싱 전략 적용

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/common/ViewModelFactory.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/common/ViewModelFactory.kt
@@ -18,13 +18,13 @@ val viewModelFactory = object : ViewModelProvider.Factory {
             when {
                 isAssignableFrom(MainViewModel::class.java) -> MainViewModel()
                 isAssignableFrom(HomeViewModel::class.java) -> HomeViewModel(
-                    AuctionRepositoryImpl(AuctionRetrofit.getInstance().service),
+                    AuctionRepositoryImpl.getInstance(AuctionRetrofit.getInstance().service),
                 )
                 isAssignableFrom(AuctionDetailViewModel::class.java) -> AuctionDetailViewModel(
-                    AuctionRepositoryImpl(AuctionRetrofit.getInstance().service),
+                    AuctionRepositoryImpl.getInstance(AuctionRetrofit.getInstance().service),
                 )
                 isAssignableFrom(RegisterAuctionViewModel::class.java) -> RegisterAuctionViewModel(
-                    AuctionRepositoryImpl(AuctionRetrofit.getInstance().service),
+                    AuctionRepositoryImpl.getInstance(AuctionRetrofit.getInstance().service),
                 )
                 else ->
                     throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/common/ViewModelFactory.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/common/ViewModelFactory.kt
@@ -10,6 +10,8 @@ import com.ddangddangddang.android.feature.register.RegisterAuctionViewModel
 import com.ddangddangddang.data.remote.AuctionRetrofit
 import com.ddangddangddang.data.repository.AuctionRepositoryImpl
 
+val repository = AuctionRepositoryImpl.getInstance(AuctionRetrofit.getInstance().service)
+
 @Suppress("UNCHECKED_CAST")
 val viewModelFactory = object : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T =
@@ -17,17 +19,10 @@ val viewModelFactory = object : ViewModelProvider.Factory {
             // 레포지토리 싱글톤 객체 얻어옴
             when {
                 isAssignableFrom(MainViewModel::class.java) -> MainViewModel()
-                isAssignableFrom(HomeViewModel::class.java) -> HomeViewModel(
-                    AuctionRepositoryImpl.getInstance(AuctionRetrofit.getInstance().service),
-                )
-                isAssignableFrom(AuctionDetailViewModel::class.java) -> AuctionDetailViewModel(
-                    AuctionRepositoryImpl.getInstance(AuctionRetrofit.getInstance().service),
-                )
-                isAssignableFrom(RegisterAuctionViewModel::class.java) -> RegisterAuctionViewModel(
-                    AuctionRepositoryImpl.getInstance(AuctionRetrofit.getInstance().service),
-                )
-                else ->
-                    throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+                isAssignableFrom(HomeViewModel::class.java) -> HomeViewModel(repository)
+                isAssignableFrom(AuctionDetailViewModel::class.java) -> AuctionDetailViewModel(repository)
+                isAssignableFrom(RegisterAuctionViewModel::class.java) -> RegisterAuctionViewModel(repository)
+                else -> throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
             }
         } as T
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
@@ -31,6 +31,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
             is HomeViewModel.HomeEvent.NavigateToAuctionDetail -> {
                 navigateToAuctionDetail(event.auctionId)
             }
+
             is HomeViewModel.HomeEvent.NavigateToRegisterAuction -> {
                 navigateToRegisterAuction()
             }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
     val auctions: LiveData<List<AuctionHomeModel>> =
         repository.observeAuctionPreviews().map { auctionPreviews ->
+            println("view model ${Thread.currentThread().id}")
             lastAuctionId.value = auctionPreviews.lastOrNull()?.id
             auctionPreviews.map { it.toPresentation() }
         }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
@@ -3,6 +3,7 @@ package com.ddangddangddang.android.feature.home
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.ddangddangddang.android.model.AuctionHomeModel
 import com.ddangddangddang.android.model.mapper.AuctionHomeModelMapper.toPresentation
@@ -11,23 +12,23 @@ import com.ddangddangddang.data.repository.AuctionRepository
 import kotlinx.coroutines.launch
 
 class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
-    private val _auctions: MutableLiveData<List<AuctionHomeModel>> = MutableLiveData()
-    val auctions: LiveData<List<AuctionHomeModel>>
-        get() = _auctions
+    val auctions: LiveData<List<AuctionHomeModel>> =
+        repository.observeAuctionPreviews().map { auctionPreviews ->
+            lastAuctionId.value = auctionPreviews.lastOrNull()?.id
+            auctionPreviews.map { it.toPresentation() }
+        }
 
-    private val _lastAuctionId: MutableLiveData<Long?> = MutableLiveData()
-    val lastAuctionId: LiveData<Long?>
-        get() = _lastAuctionId
+    private val lastAuctionId: MutableLiveData<Long?> = MutableLiveData()
 
     private val _event: SingleLiveEvent<HomeEvent> = SingleLiveEvent()
     val event: LiveData<HomeEvent>
         get() = _event
 
     fun loadAuctions() {
-        viewModelScope.launch {
-            val response = repository.getAuctionPreviews()
-            _auctions.value = response.toPresentation()
-            _lastAuctionId.value = response.lastAuctionId
+        if (lastAuctionId.value == null) {
+            viewModelScope.launch {
+                repository.getAuctionPreviews()
+            }
         }
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/model/mapper/AuctionHomeModelMapper.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/model/mapper/AuctionHomeModelMapper.kt
@@ -2,19 +2,17 @@ package com.ddangddangddang.android.model.mapper
 
 import com.ddangddangddang.android.model.AuctionHomeModel
 import com.ddangddangddang.android.model.AuctionHomeStatusModel
-import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
+import com.ddangddangddang.data.model.response.AuctionPreviewResponse
 
-object AuctionHomeModelMapper : Mapper<List<AuctionHomeModel>, AuctionPreviewsResponse> {
-    override fun AuctionPreviewsResponse.toPresentation(): List<AuctionHomeModel> {
-        return auctions.map {
-            AuctionHomeModel(
-                it.id,
-                it.title,
-                it.image,
-                it.auctionPrice,
-                AuctionHomeStatusModel.find(it.status),
-                it.auctioneerCount,
-            )
-        }
+object AuctionHomeModelMapper : Mapper<AuctionHomeModel, AuctionPreviewResponse> {
+    override fun AuctionPreviewResponse.toPresentation(): AuctionHomeModel {
+        return AuctionHomeModel(
+            id,
+            title,
+            image,
+            auctionPrice,
+            AuctionHomeStatusModel.find(status),
+            auctioneerCount,
+        )
     }
 }

--- a/android/app/src/test/java/com/ddangddangddang/android/LiveDataExtension.kt
+++ b/android/app/src/test/java/com/ddangddangddang/android/LiveDataExtension.kt
@@ -1,0 +1,32 @@
+package com.ddangddangddang.android
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+fun <T> LiveData<T>.getOrAwaitValue(
+    time: Long = 2,
+    timeUnit: TimeUnit = TimeUnit.SECONDS,
+): T {
+    var data: T? = null
+    val latch = CountDownLatch(1)
+    val observer = object : Observer<T> {
+        override fun onChanged(value: T) {
+            data = value
+            latch.countDown()
+            this@getOrAwaitValue.removeObserver(this)
+        }
+    }
+
+    this.observeForever(observer)
+
+    // Don't wait indefinitely if the LiveData is not set.
+    if (!latch.await(time, timeUnit)) {
+        throw TimeoutException("LiveData value was never set.")
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return data as T
+}

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionLocalDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionLocalDataSource.kt
@@ -1,0 +1,22 @@
+package com.ddangddangddang.data.datasource
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.ddangddangddang.data.model.response.AuctionPreviewResponse
+
+class AuctionLocalDataSource {
+    private val auctionPreviews: MutableLiveData<List<AuctionPreviewResponse>> = MutableLiveData()
+
+    fun observeAuctionPreviews(): LiveData<List<AuctionPreviewResponse>> {
+        return auctionPreviews
+    }
+
+    fun addAuctionPreviews(auctions: List<AuctionPreviewResponse>) {
+        auctionPreviews.value = auctionPreviews.value?.plus(auctions) ?: auctions
+    }
+
+    fun addAuctionPreview(auction: AuctionPreviewResponse) {
+        val auctions = auctionPreviews.value ?: emptyList()
+        auctionPreviews.value = listOf(auction) + auctions
+    }
+}

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
@@ -1,0 +1,34 @@
+package com.ddangddangddang.data.datasource
+
+import com.ddangddangddang.data.model.request.RegisterAuctionRequest
+import com.ddangddangddang.data.model.response.AuctionDetailResponse
+import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
+import com.ddangddangddang.data.model.response.RegisterAuctionResponse
+import com.ddangddangddang.data.remote.Service
+import java.lang.IllegalArgumentException
+
+class AuctionRemoteDataSource(private val service: Service) {
+    suspend fun getAuctionPreviews(): AuctionPreviewsResponse {
+        val response = service.fetchAuctionPreviews()
+        if (response.isSuccessful) {
+            response.body()?.let { return it }
+        }
+        throw IllegalArgumentException()
+    }
+
+    suspend fun getAuctionDetail(id: Long): AuctionDetailResponse {
+        val response = service.fetchAuctionDetail(id)
+        if (response.isSuccessful) {
+            response.body()?.let { return it }
+        }
+        throw IllegalArgumentException()
+    }
+
+    suspend fun registerAuction(auction: RegisterAuctionRequest): RegisterAuctionResponse {
+        val response = service.registerAuction(auction)
+        if (response.isSuccessful) {
+            response.body()?.let { return it }
+        }
+        throw IllegalArgumentException()
+    }
+}

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
@@ -1,12 +1,15 @@
 package com.ddangddangddang.data.repository
 
+import androidx.lifecycle.LiveData
 import com.ddangddangddang.data.model.request.RegisterAuctionRequest
 import com.ddangddangddang.data.model.response.AuctionDetailResponse
-import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
+import com.ddangddangddang.data.model.response.AuctionPreviewResponse
 import com.ddangddangddang.data.model.response.RegisterAuctionResponse
 
 interface AuctionRepository {
-    suspend fun getAuctionPreviews(): AuctionPreviewsResponse
+    fun observeAuctionPreviews(): LiveData<List<AuctionPreviewResponse>>
+
+    suspend fun getAuctionPreviews()
     suspend fun getAuctionDetail(id: Long): AuctionDetailResponse
     suspend fun registerAuction(auction: RegisterAuctionRequest): RegisterAuctionResponse
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
@@ -1,35 +1,44 @@
 package com.ddangddangddang.data.repository
 
+import androidx.lifecycle.LiveData
+import com.ddangddangddang.data.datasource.AuctionLocalDataSource
+import com.ddangddangddang.data.datasource.AuctionRemoteDataSource
 import com.ddangddangddang.data.model.request.RegisterAuctionRequest
 import com.ddangddangddang.data.model.response.AuctionDetailResponse
-import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
+import com.ddangddangddang.data.model.response.AuctionPreviewResponse
 import com.ddangddangddang.data.model.response.RegisterAuctionResponse
 import com.ddangddangddang.data.remote.Service
-import java.lang.IllegalArgumentException
 
-class AuctionRepositoryImpl private constructor(private val service: Service) : AuctionRepository {
-    override suspend fun getAuctionPreviews(): AuctionPreviewsResponse {
-        val response = service.fetchAuctionPreviews()
-        if (response.isSuccessful) {
-            response.body()?.let { return it }
-        }
-        throw IllegalArgumentException()
+class AuctionRepositoryImpl private constructor(
+    private val localDataSource: AuctionLocalDataSource,
+    private val remoteDataSource: AuctionRemoteDataSource,
+) : AuctionRepository {
+
+    override fun observeAuctionPreviews(): LiveData<List<AuctionPreviewResponse>> {
+        return localDataSource.observeAuctionPreviews()
+    }
+
+    override suspend fun getAuctionPreviews() {
+        val auctionPreviewsResponse = remoteDataSource.getAuctionPreviews()
+        localDataSource.addAuctionPreviews(auctionPreviewsResponse.auctions)
     }
 
     override suspend fun getAuctionDetail(id: Long): AuctionDetailResponse {
-        val response = service.fetchAuctionDetail(id)
-        if (response.isSuccessful) {
-            response.body()?.let { return it }
-        }
-        throw IllegalArgumentException()
+        return remoteDataSource.getAuctionDetail(id)
     }
 
     override suspend fun registerAuction(auction: RegisterAuctionRequest): RegisterAuctionResponse {
-        val response = service.registerAuction(auction)
-        if (response.isSuccessful) {
-            response.body()?.let { return it }
-        }
-        throw IllegalArgumentException()
+        val registerAuctionResponse = remoteDataSource.registerAuction(auction)
+        val auctionPreviewResponse = AuctionPreviewResponse(
+            registerAuctionResponse.id,
+            auction.title,
+            auction.images.firstOrNull() ?: "",
+            auction.startPrice,
+            "UNBIDDEN",
+            0,
+        )
+        localDataSource.addAuctionPreview(auctionPreviewResponse)
+        return registerAuctionResponse
     }
 
     companion object {
@@ -43,7 +52,10 @@ class AuctionRepositoryImpl private constructor(private val service: Service) : 
         }
 
         private fun createInstance(service: Service): AuctionRepositoryImpl {
-            return AuctionRepositoryImpl(service)
+            val localDataSource = AuctionLocalDataSource()
+            val remoteDataSource = AuctionRemoteDataSource(service)
+            return AuctionRepositoryImpl(localDataSource, remoteDataSource)
+                .also { instance = it }
         }
     }
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
@@ -7,7 +7,7 @@ import com.ddangddangddang.data.model.response.RegisterAuctionResponse
 import com.ddangddangddang.data.remote.Service
 import java.lang.IllegalArgumentException
 
-class AuctionRepositoryImpl(private val service: Service) : AuctionRepository {
+class AuctionRepositoryImpl private constructor(private val service: Service) : AuctionRepository {
     override suspend fun getAuctionPreviews(): AuctionPreviewsResponse {
         val response = service.fetchAuctionPreviews()
         if (response.isSuccessful) {
@@ -30,5 +30,20 @@ class AuctionRepositoryImpl(private val service: Service) : AuctionRepository {
             response.body()?.let { return it }
         }
         throw IllegalArgumentException()
+    }
+
+    companion object {
+        @Volatile
+        private var instance: AuctionRepositoryImpl? = null
+
+        fun getInstance(service: Service): AuctionRepositoryImpl {
+            return instance ?: synchronized(this) {
+                instance ?: createInstance(service)
+            }
+        }
+
+        private fun createInstance(service: Service): AuctionRepositoryImpl {
+            return AuctionRepositoryImpl(service)
+        }
     }
 }

--- a/android/data/src/test/java/com/ddangddangddang/data/AuctionRepositoryImplTest.kt
+++ b/android/data/src/test/java/com/ddangddangddang/data/AuctionRepositoryImplTest.kt
@@ -18,7 +18,7 @@ class AuctionRepositoryImplTest {
         .addConverterFactory(Json.asConverterFactory("application/json".toMediaType()))
         .build()
         .create(Service::class.java)
-    private val repository: AuctionRepository = AuctionRepositoryImpl(service)
+    private val repository: AuctionRepository = AuctionRepositoryImpl.getInstance(service)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test


### PR DESCRIPTION
## 📄 작업 내용 요약
경매 데이터 캐싱 전략을 적용하여 새로운 경매글을 등록했을 때 경매 목록이 자동으로 갱신되도록 함.

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드

## 📎 Issue 번호
- #117 
