### PR TITLE
경매 목록 무한 스크롤 구현

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
@@ -19,22 +19,29 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
             auctionPreviews.map { it.toPresentation() }
         }
 
-    private val lastAuctionId: MutableLiveData<Long?> = MutableLiveData()
+    val lastAuctionId: MutableLiveData<Long?> = MutableLiveData()
+
+    private var _loadingAuctionsInProgress: Boolean = false
+    val loadingAuctionInProgress: Boolean
+        get() = _loadingAuctionsInProgress
 
     private val _event: SingleLiveEvent<HomeEvent> = SingleLiveEvent()
     val event: LiveData<HomeEvent>
         get() = _event
 
     fun loadAuctions() {
-        if (lastAuctionId.value == null) {
-            viewModelScope.launch {
-                when (val response = repository.getAuctionPreviews()) {
-                    is ApiResponse.Success -> {}
-                    is ApiResponse.Failure -> {}
-                    is ApiResponse.NetworkError -> {}
-                    is ApiResponse.Unexpected -> {}
-                }
+        _loadingAuctionsInProgress = true
+        viewModelScope.launch {
+            when (
+                val response =
+                    repository.getAuctionPreviews(lastAuctionId.value, SIZE_AUCTION_LOAD)
+            ) {
+                is ApiResponse.Success -> {}
+                is ApiResponse.Failure -> {}
+                is ApiResponse.NetworkError -> {}
+                is ApiResponse.Unexpected -> {}
             }
+            _loadingAuctionsInProgress = false
         }
     }
 
@@ -49,5 +56,9 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
     sealed class HomeEvent {
         data class NavigateToAuctionDetail(val auctionId: Long) : HomeEvent()
         object NavigateToRegisterAuction : HomeEvent()
+    }
+
+    companion object {
+        private val SIZE_AUCTION_LOAD = 10
     }
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
@@ -8,8 +8,8 @@ import com.ddangddangddang.data.remote.ApiResponse
 import com.ddangddangddang.data.remote.Service
 
 class AuctionRemoteDataSource(private val service: Service) {
-    suspend fun getAuctionPreviews(): ApiResponse<AuctionPreviewsResponse> =
-        service.fetchAuctionPreviews()
+    suspend fun getAuctionPreviews(lastAuctionId: Long?, size: Int): ApiResponse<AuctionPreviewsResponse> =
+        service.fetchAuctionPreviews(lastAuctionId, size)
 
     suspend fun getAuctionDetail(id: Long): ApiResponse<AuctionDetailResponse> =
         service.fetchAuctionDetail(id)

--- a/android/data/src/main/java/com/ddangddangddang/data/remote/Service.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/remote/Service.kt
@@ -8,10 +8,14 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface Service {
     @GET("/auctions")
-    suspend fun fetchAuctionPreviews(): ApiResponse<AuctionPreviewsResponse>
+    suspend fun fetchAuctionPreviews(
+        @Query("lastAuctionId") id: Long?,
+        @Query("size") size: Int,
+    ): ApiResponse<AuctionPreviewsResponse>
 
     @GET("/auctions/{id}")
     suspend fun fetchAuctionDetail(@Path("id") id: Long): ApiResponse<AuctionDetailResponse>

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
@@ -11,7 +11,7 @@ import com.ddangddangddang.data.remote.ApiResponse
 interface AuctionRepository {
     fun observeAuctionPreviews(): LiveData<List<AuctionPreviewResponse>>
 
-    suspend fun getAuctionPreviews(): ApiResponse<AuctionPreviewsResponse>
+    suspend fun getAuctionPreviews(lastAuctionId: Long?, size: Int): ApiResponse<AuctionPreviewsResponse>
     suspend fun getAuctionDetail(id: Long): ApiResponse<AuctionDetailResponse>
     suspend fun registerAuction(auction: RegisterAuctionRequest): ApiResponse<RegisterAuctionResponse>
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
@@ -20,8 +20,8 @@ class AuctionRepositoryImpl private constructor(
         return localDataSource.observeAuctionPreviews()
     }
 
-    override suspend fun getAuctionPreviews(): ApiResponse<AuctionPreviewsResponse> {
-        val response = remoteDataSource.getAuctionPreviews()
+    override suspend fun getAuctionPreviews(lastAuctionId: Long?, size: Int): ApiResponse<AuctionPreviewsResponse> {
+        val response = remoteDataSource.getAuctionPreviews(lastAuctionId, size)
         if (response is ApiResponse.Success) {
             localDataSource.addAuctionPreviews(response.body.auctions)
         }


### PR DESCRIPTION
## 📄 작업 내용 요약
경매 목록 무한 스크롤 구현

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
리사이클러뷰 스크롤 리스너 로직 확인 부탁드려요~!
현재 로직은 화면에 보여진 마지막 아이템의 포지션이 전체 경매 아이템 수보다 5개 이하로 적으면 새로운 경매 아이템을 불러오고 있습니다!

## 📎 Issue 번호
- #126 
