### PR TITLE
경매 등록 시 갤러리에서 사진 선택하는 기능 구현

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,8 +4,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
 
     <uses-feature
         android:name="android.hardware.camera"
@@ -37,6 +35,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!--suppress AndroidDomInspection -->
+        <service android:name="com.google.android.gms.metadata.ModuleDependencies"
+            android:enabled="false"
+            android:exported="false"
+            tools:ignore="MissingClass">
+            <intent-filter>
+                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
+            </intent-filter>
+            <meta-data android:name="photopicker_activity:0:required" android:value="" />
+        </service>
     </application>
 
 </manifest>

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/common/BindingAdapter.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/common/BindingAdapter.kt
@@ -1,5 +1,6 @@
 package com.ddangddangddang.android.feature.common
 
+import android.net.Uri
 import android.view.View
 import android.widget.ImageView
 import androidx.core.view.isVisible
@@ -9,6 +10,15 @@ import com.bumptech.glide.Glide
 @BindingAdapter("imageUrl")
 fun ImageView.setImageUrl(url: String?) {
     url?.let {
+        Glide.with(context)
+            .load(it)
+            .into(this)
+    }
+}
+
+@BindingAdapter("imageUri")
+fun ImageView.setImageUrl(uri: Uri?) {
+    uri?.let {
         Glide.with(context)
             .load(it)
             .into(this)

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionImageAdapter.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionImageAdapter.kt
@@ -3,9 +3,10 @@ package com.ddangddangddang.android.feature.register
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
+import com.ddangddangddang.android.model.RegisterImageModel
 
-class RegisterAuctionImageAdapter(private val onDeleteImageListener: (String) -> Unit) :
-    ListAdapter<String, RegisterAuctionImageViewHolder>(RegisterAuctionImageDiffUtil) {
+class RegisterAuctionImageAdapter(private val onDeleteImageListener: (RegisterImageModel) -> Unit) :
+    ListAdapter<RegisterImageModel, RegisterAuctionImageViewHolder>(RegisterAuctionImageDiffUtil) {
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -18,25 +19,26 @@ class RegisterAuctionImageAdapter(private val onDeleteImageListener: (String) ->
         holder.bind(currentList[position])
     }
 
-    fun setImages(images: List<String>) {
+    fun setImages(images: List<RegisterImageModel>) {
         submitList(images)
     }
 
     companion object {
-        private val RegisterAuctionImageDiffUtil = object : DiffUtil.ItemCallback<String>() {
-            override fun areItemsTheSame(
-                oldItem: String,
-                newItem: String,
-            ): Boolean {
-                return oldItem == newItem
-            }
+        private val RegisterAuctionImageDiffUtil =
+            object : DiffUtil.ItemCallback<RegisterImageModel>() {
+                override fun areItemsTheSame(
+                    oldItem: RegisterImageModel,
+                    newItem: RegisterImageModel,
+                ): Boolean {
+                    return oldItem.id == newItem.id
+                }
 
-            override fun areContentsTheSame(
-                oldItem: String,
-                newItem: String,
-            ): Boolean {
-                return oldItem == newItem
+                override fun areContentsTheSame(
+                    oldItem: RegisterImageModel,
+                    newItem: RegisterImageModel,
+                ): Boolean {
+                    return oldItem == newItem
+                }
             }
-        }
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionImageViewHolder.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionImageViewHolder.kt
@@ -4,10 +4,11 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.ddangddangddang.android.databinding.ItemRegisterImageBinding
+import com.ddangddangddang.android.model.RegisterImageModel
 
 class RegisterAuctionImageViewHolder private constructor(
     private val binding: ItemRegisterImageBinding,
-    private val onDeleteImageListener: (String) -> Unit,
+    private val onDeleteImageListener: (RegisterImageModel) -> Unit,
 ) :
     RecyclerView.ViewHolder(binding.root) {
     init {
@@ -16,17 +17,17 @@ class RegisterAuctionImageViewHolder private constructor(
     }
 
     private fun deleteImage() {
-        binding.imageUrl?.let { onDeleteImageListener(it) }
+        binding.image?.let { onDeleteImageListener(it) }
     }
 
-    fun bind(imageUrl: String) {
-        binding.imageUrl = imageUrl
+    fun bind(image: RegisterImageModel) {
+        binding.image = image
     }
 
     companion object {
         fun create(
             parent: ViewGroup,
-            onDeleteImageListener: (String) -> Unit,
+            onDeleteImageListener: (RegisterImageModel) -> Unit,
         ): RegisterAuctionImageViewHolder {
             val layoutInflater = LayoutInflater.from(parent.context)
             val binding = ItemRegisterImageBinding.inflate(layoutInflater, parent, false)

--- a/android/app/src/main/java/com/ddangddangddang/android/model/RegisterImageModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/model/RegisterImageModel.kt
@@ -1,0 +1,5 @@
+package com.ddangddangddang.android.model
+
+import android.net.Uri
+
+data class RegisterImageModel(val id: Long = System.currentTimeMillis(), val uri: Uri)

--- a/android/app/src/main/java/com/ddangddangddang/android/util/view/SnackbarFactory.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/util/view/SnackbarFactory.kt
@@ -2,13 +2,14 @@ package com.ddangddangddang.android.util.view
 
 import android.view.View
 import androidx.annotation.StringRes
+import com.ddangddangddang.android.R
 import com.google.android.material.snackbar.Snackbar
 
 fun View.showSnackbar(
     @StringRes
     textId: Int,
     @StringRes
-    actionId: Int,
+    actionId: Int = R.string.all_snackbar_default_action,
     action: () -> Unit = {},
 ) {
     Snackbar.make(this, context.getString(textId), Snackbar.LENGTH_SHORT)

--- a/android/app/src/main/res/layout/activity_register_auction.xml
+++ b/android/app/src/main/res/layout/activity_register_auction.xml
@@ -91,7 +91,7 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@{@string/register_auction_default_image_count(viewModel.images.size, 10)}"
+                        android:text="@{@string/register_auction_default_image_count(viewModel.images.size, viewModel.MAXIMUM_IMAGE_SIZE)}"
                         android:textColor="@color/black_900"
                         android:textSize="12sp"
                         tools:text="(0/10)" />

--- a/android/app/src/main/res/layout/item_register_image.xml
+++ b/android/app/src/main/res/layout/item_register_image.xml
@@ -6,8 +6,8 @@
     <data>
 
         <variable
-            name="imageUrl"
-            type="String" />
+            name="image"
+            type="com.ddangddangddang.android.model.RegisterImageModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -39,7 +39,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 tools:src="@drawable/ic_launcher_background"
-                imageUrl="@{imageUrl}"
+                imageUri="@{image.uri}"
                 android:contentDescription="@string/register_auction_image_description" />
 
         </androidx.cardview.widget.CardView>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="all_dialog_default_title"></string>
     <string name="all_dialog_default_negative_button">취소</string>
     <string name="all_dialog_default_positive_button">확인</string>
+    <string name="all_snackbar_default_action">확인</string>
 
     <!-- home -->
     <string name="home">경매 상품 목록</string>
@@ -64,4 +65,5 @@
     <string name="register_auction_delete_image_button_description">경매에 등록할 사진 삭제 버튼</string>
     <string name="register_auction_dialog_delete_image_message">사진을 삭제하시겠습니까?</string>
     <string name="register_auction_dialog_delete_image_positive_button">삭제</string>
+    <string name="register_autcion_snackbar_image_limit">사진은 최대 10개까지 등록 가능합니다.</string>
 </resources>

--- a/android/app/src/test/java/com/ddangddangddang/android/HomeViewModelTest.kt
+++ b/android/app/src/test/java/com/ddangddangddang/android/HomeViewModelTest.kt
@@ -42,7 +42,7 @@ class HomeViewModelTest {
     fun `경매_목록을_불러오면_경매_상품과_마지막_경매_상품_아이디_값을_가져온다`() = runTest {
         // given
         val auctionPreviewsResponse = createAuctionPreviewsResponse()
-        coEvery { repository.getAuctionPreviews() } answers {
+        coEvery { repository.getAuctionPreviews(any(), any()) } answers {
             cache.value = auctionPreviewsResponse.auctions
             ApiResponse.Success(auctionPreviewsResponse)
         }


### PR DESCRIPTION
## 📄 작업 내용 요약
경매 등록 시 갤러리에서 사진을 선택하고 보여주는 기능 구현

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
API 30 이상에서 지원해주는 Photo Picker를 사용했습니다.
하위 버전에서도 동작할 수 있도록 service도 추가해주었습니다!
같은 사진이어도 중복으로 올라갈 수 있도록 하였고 업로드 시 시간을 id로 가지도록 했습니다!

## 📎 Issue 번호
- close : #142 
