### PR TITLE
경매 이미지 엔티티, 카테고리 엔티티, 경매 엔티티 연동

### DIFF
--- a/backend/ddang/build.gradle
+++ b/backend/ddang/build.gradle
@@ -84,7 +84,8 @@ jacocoTestReport {
                             '**/*Request*',
                             '**/*Dto*',
                             '**/*Configuration*',
-                            '**/*Appender*'
+                            '**/*Appender*',
+                            '**/*Helper*'
                     ] + Qdomains)
         }))
     }
@@ -120,7 +121,8 @@ jacocoTestCoverageVerification {
                     '*.*Application*',
                     '*.*Dto*',
                     '*.*Configuration*',
-                    '*.*Appender*'
+                    '*.*Appender*',
+                    '*.*Helper*'
             ] + Qdomains
         }
     }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
@@ -1,6 +1,7 @@
 package com.ddang.ddang.auction.application;
 
 import com.ddang.ddang.auction.application.dto.CreateAuctionDto;
+import com.ddang.ddang.auction.application.dto.CreateInfoAuctionDto;
 import com.ddang.ddang.auction.application.dto.ReadAuctionDto;
 import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
 import com.ddang.ddang.auction.domain.Auction;
@@ -31,15 +32,17 @@ public class AuctionService {
     private final StoreImageProcessor imageProcessor;
 
     @Transactional
-    public Long create(final CreateAuctionDto dto) {
+    public CreateInfoAuctionDto create(final CreateAuctionDto dto) {
         final Auction auction = convertAuction(dto);
         final List<AuctionRegion> auctionRegions = convertAuctionRegions(dto);
         final List<AuctionImage> auctionImages = convertAuctionImage(dto);
 
         auction.addAuctionRegions(auctionRegions);
         auction.addAuctionImages(auctionImages);
-        return auctionRepository.save(auction)
-                                .getId();
+
+        final Auction persistAuction = auctionRepository.save(auction);
+
+        return CreateInfoAuctionDto.from(persistAuction);
     }
 
     private List<AuctionImage> convertAuctionImage(final CreateAuctionDto dto) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
@@ -1,7 +1,6 @@
 package com.ddang.ddang.auction.application;
 
 import com.ddang.ddang.auction.application.dto.CreateAuctionDto;
-import com.ddang.ddang.auction.application.dto.CreateRegionDto;
 import com.ddang.ddang.auction.application.dto.ReadAuctionDto;
 import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
 import com.ddang.ddang.auction.domain.Auction;
@@ -14,11 +13,10 @@ import com.ddang.ddang.region.domain.AuctionRegion;
 import com.ddang.ddang.region.domain.Region;
 import com.ddang.ddang.region.infrastructure.persistence.JpaRegionRepository;
 import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -51,8 +49,8 @@ public class AuctionService {
     private List<AuctionRegion> convertToAuctionRegions(final CreateAuctionDto dto) {
         final List<AuctionRegion> auctionRegions = new ArrayList<>();
 
-        for (final CreateRegionDto regionDto : dto.createRegionDtos()) {
-            final Region thirdRegion = regionRepository.findThirdRegionById(regionDto.thirdRegionId())
+        for (final Long thirdRegionId : dto.thirdRegionIds()) {
+            final Region thirdRegion = regionRepository.findThirdRegionById(thirdRegionId)
                                                        .orElseThrow(() -> new RegionNotFoundException(
                                                                "지정한 세 번째 지역이 없거나 세 번째 지역이 아닙니다."
                                                        ));

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
@@ -37,7 +37,7 @@ public class AuctionService {
     public CreateInfoAuctionDto create(final CreateAuctionDto dto) {
         final Auction auction = convertAuction(dto);
         final List<AuctionRegion> auctionRegions = convertAuctionRegions(dto);
-        final List<AuctionImage> auctionImages = convertAuctionImage(dto);
+        final List<AuctionImage> auctionImages = convertAuctionImages(dto);
 
         auction.addAuctionRegions(auctionRegions);
         auction.addAuctionImages(auctionImages);
@@ -45,13 +45,6 @@ public class AuctionService {
         final Auction persistAuction = auctionRepository.save(auction);
 
         return CreateInfoAuctionDto.from(persistAuction);
-    }
-
-    private List<AuctionImage> convertAuctionImage(final CreateAuctionDto dto) {
-        return imageProcessor.storeImageFiles(dto.auctionImages())
-                             .stream()
-                             .map(imageDto -> new AuctionImage(imageDto.uploadName(), imageDto.storeName()))
-                             .toList();
     }
 
     private Auction convertAuction(final CreateAuctionDto dto) {
@@ -75,6 +68,13 @@ public class AuctionService {
         }
 
         return auctionRegions;
+    }
+
+    private List<AuctionImage> convertAuctionImages(final CreateAuctionDto dto) {
+        return imageProcessor.storeImageFiles(dto.auctionImages())
+                             .stream()
+                             .map(imageDto -> new AuctionImage(imageDto.uploadName(), imageDto.storeName()))
+                             .toList();
     }
 
     public ReadAuctionDto readByAuctionId(final Long auctionId) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
@@ -78,7 +78,7 @@ public class AuctionService {
     }
 
     public ReadAuctionDto readByAuctionId(final Long auctionId) {
-        final Auction auction = auctionRepository.findAuctionWithRegionsById(auctionId)
+        final Auction auction = auctionRepository.findAuctionById(auctionId)
                                                  .orElseThrow(() -> new AuctionNotFoundException(
                                                          "지정한 아이디에 대한 경매를 찾을 수 없습니다."
                                                  ));

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
@@ -12,6 +12,7 @@ import com.ddang.ddang.category.domain.Category;
 import com.ddang.ddang.category.infrastructure.persistence.JpaCategoryRepository;
 import com.ddang.ddang.image.domain.AuctionImage;
 import com.ddang.ddang.image.domain.StoreImageProcessor;
+import com.ddang.ddang.image.domain.dto.StoreImageDto;
 import com.ddang.ddang.region.application.exception.RegionNotFoundException;
 import com.ddang.ddang.region.domain.AuctionRegion;
 import com.ddang.ddang.region.domain.Region;
@@ -73,7 +74,7 @@ public class AuctionService {
     private List<AuctionImage> convertAuctionImages(final CreateAuctionDto dto) {
         return imageProcessor.storeImageFiles(dto.auctionImages())
                              .stream()
-                             .map(imageDto -> new AuctionImage(imageDto.uploadName(), imageDto.storeName()))
+                             .map(StoreImageDto::toEntity)
                              .toList();
     }
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
@@ -3,6 +3,7 @@ package com.ddang.ddang.auction.application;
 import com.ddang.ddang.auction.application.dto.CreateAuctionDto;
 import com.ddang.ddang.auction.application.dto.CreateInfoAuctionDto;
 import com.ddang.ddang.auction.application.dto.ReadAuctionDto;
+import com.ddang.ddang.auction.application.dto.ReadAuctionsDto;
 import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
 import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.infrastructure.persistence.JpaAuctionRepository;
@@ -18,6 +19,7 @@ import com.ddang.ddang.region.infrastructure.persistence.JpaRegionRepository;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -84,12 +86,10 @@ public class AuctionService {
         return ReadAuctionDto.from(auction);
     }
 
-    public List<ReadAuctionDto> readAllByLastAuctionId(final Long lastAuctionId, final int size) {
-        final List<Auction> auctions = auctionRepository.findAuctionsAllByLastAuctionId(lastAuctionId, size);
+    public ReadAuctionsDto readAllByLastAuctionId(final Long lastAuctionId, final int size) {
+        final Slice<Auction> auctions = auctionRepository.findAuctionsAllByLastAuctionId(lastAuctionId, size);
 
-        return auctions.stream()
-                       .map(ReadAuctionDto::from)
-                       .toList();
+        return ReadAuctionsDto.from(auctions);
     }
 
     @Transactional

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/CreateAuctionDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/CreateAuctionDto.java
@@ -30,7 +30,7 @@ public record CreateAuctionDto(
                 request.closingTime(),
                 calculateThirdRegionIds(request),
                 request.subCategoryId(),
-                request.auctionImages()
+                request.images()
         );
     }
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/CreateAuctionDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/CreateAuctionDto.java
@@ -4,6 +4,7 @@ import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.domain.BidUnit;
 import com.ddang.ddang.auction.domain.Price;
 import com.ddang.ddang.auction.presentation.dto.request.CreateAuctionRequest;
+import com.ddang.ddang.category.domain.Category;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -18,8 +19,7 @@ public record CreateAuctionDto(
 
         // TODO 2차 데모데이 이후 리펙터링 예정
         String image,
-        String mainCategory,
-        String subCategory
+        Long subCategoryId
 ) {
 
     public static CreateAuctionDto from(final CreateAuctionRequest request) {
@@ -32,8 +32,7 @@ public record CreateAuctionDto(
                 convertCreateRegionDto(request),
                 // TODO 2차 데모데이 이후 리펙터링 예정
                 request.images().get(0),
-                request.category().main(),
-                request.category().sub()
+                request.subCategoryId()
         );
     }
 
@@ -44,17 +43,16 @@ public record CreateAuctionDto(
                       .toList();
     }
 
-    public Auction toEntity() {
+    public Auction toEntity(final Category subCategory) {
         return Auction.builder()
                       .title(title)
                       .description(description)
                       .bidUnit(new BidUnit(bidUnit))
                       .startPrice(new Price(startPrice))
                       .closingTime(closingTime)
+                      .subCategory(subCategory)
                       // TODO 2차 데모데이 이후 리펙터링 예정
                       .image(image)
-                      .mainCategory(mainCategory)
-                      .subCategory(subCategory)
                       .build();
     }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/CreateAuctionDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/CreateAuctionDto.java
@@ -6,6 +6,7 @@ import com.ddang.ddang.auction.domain.Price;
 import com.ddang.ddang.auction.presentation.dto.request.CreateAuctionRequest;
 import com.ddang.ddang.category.domain.Category;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 
 public record CreateAuctionDto(
@@ -14,12 +15,11 @@ public record CreateAuctionDto(
         int bidUnit,
         int startPrice,
         LocalDateTime closingTime,
-
-        List<CreateRegionDto> createRegionDtos,
+        List<Long> thirdRegionIds,
+        Long subCategoryId,
 
         // TODO 2차 데모데이 이후 리펙터링 예정
-        String image,
-        Long subCategoryId
+        String image
 ) {
 
     public static CreateAuctionDto from(final CreateAuctionRequest request) {
@@ -29,18 +29,19 @@ public record CreateAuctionDto(
                 request.bidUnit(),
                 request.startPrice(),
                 request.closingTime(),
-                convertCreateRegionDto(request),
+                calculateThirdRegionIds(request),
+                request.subCategoryId(),
                 // TODO 2차 데모데이 이후 리펙터링 예정
-                request.images().get(0),
-                request.subCategoryId()
+                request.images().get(0)
         );
     }
 
-    private static List<CreateRegionDto> convertCreateRegionDto(final CreateAuctionRequest request) {
-        return request.directRegions()
-                      .stream()
-                      .map(CreateRegionDto::from)
-                      .toList();
+    private static List<Long> calculateThirdRegionIds(final CreateAuctionRequest request) {
+        if (request.thirdRegionIds() == null) {
+            return Collections.emptyList();
+        }
+
+        return request.thirdRegionIds();
     }
 
     public Auction toEntity(final Category subCategory) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/CreateAuctionDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/CreateAuctionDto.java
@@ -8,6 +8,7 @@ import com.ddang.ddang.category.domain.Category;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 public record CreateAuctionDto(
         String title,
@@ -17,9 +18,7 @@ public record CreateAuctionDto(
         LocalDateTime closingTime,
         List<Long> thirdRegionIds,
         Long subCategoryId,
-
-        // TODO 2차 데모데이 이후 리펙터링 예정
-        String image
+        List<MultipartFile> auctionImages
 ) {
 
     public static CreateAuctionDto from(final CreateAuctionRequest request) {
@@ -31,8 +30,7 @@ public record CreateAuctionDto(
                 request.closingTime(),
                 calculateThirdRegionIds(request),
                 request.subCategoryId(),
-                // TODO 2차 데모데이 이후 리펙터링 예정
-                request.images().get(0)
+                request.auctionImages()
         );
     }
 
@@ -52,8 +50,6 @@ public record CreateAuctionDto(
                       .startPrice(new Price(startPrice))
                       .closingTime(closingTime)
                       .subCategory(subCategory)
-                      // TODO 2차 데모데이 이후 리펙터링 예정
-                      .image(image)
                       .build();
     }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/CreateInfoAuctionDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/CreateInfoAuctionDto.java
@@ -1,0 +1,20 @@
+package com.ddang.ddang.auction.application.dto;
+
+import com.ddang.ddang.auction.domain.Auction;
+
+public record CreateInfoAuctionDto(
+        Long id,
+        String title,
+        Long auctionImageId,
+        int startPrice
+) {
+
+    public static CreateInfoAuctionDto from(final Auction auction) {
+        return new CreateInfoAuctionDto(
+                auction.getId(),
+                auction.getTitle(),
+                auction.getAuctionImages().get(0).getId(),
+                auction.getStartPrice().getValue()
+        );
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/ReadAuctionDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/ReadAuctionDto.java
@@ -37,8 +37,8 @@ public record ReadAuctionDto(
                 auction.getClosingTime(),
                 convertReadRegionsDto(auction),
                 auction.getImage(),
-                auction.getMainCategory(),
-                auction.getSubCategory()
+                auction.getSubCategory().getMainCategory().getName(),
+                auction.getSubCategory().getName()
         );
     }
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/ReadAuctionDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/ReadAuctionDto.java
@@ -2,6 +2,7 @@ package com.ddang.ddang.auction.application.dto;
 
 import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.domain.Price;
+import com.ddang.ddang.image.domain.AuctionImage;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -17,8 +18,7 @@ public record ReadAuctionDto(
         LocalDateTime registerTime,
         LocalDateTime closingTime,
         List<ReadRegionsDto> auctionRegions,
-        // TODO 2차 데모데이 이후 리펙터링 예정
-        String image,
+        List<Long> auctionImageIds,
         String mainCategory,
         String subCategory
 ) {
@@ -36,10 +36,17 @@ public record ReadAuctionDto(
                 auction.getCreatedTime(),
                 auction.getClosingTime(),
                 convertReadRegionsDto(auction),
-                auction.getImage(),
+                convertImageUrls(auction),
                 auction.getSubCategory().getMainCategory().getName(),
                 auction.getSubCategory().getName()
         );
+    }
+
+    private static List<Long> convertImageUrls(final Auction auction) {
+        return auction.getAuctionImages()
+                .stream()
+                .map(AuctionImage::getId)
+                .toList();
     }
 
     private static Integer convertPrice(final Price price) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/ReadAuctionsDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/ReadAuctionsDto.java
@@ -1,0 +1,17 @@
+package com.ddang.ddang.auction.application.dto;
+
+import com.ddang.ddang.auction.domain.Auction;
+import java.util.List;
+import org.springframework.data.domain.Slice;
+
+public record ReadAuctionsDto(List<ReadAuctionDto> readAuctionDtos, boolean isLast) {
+
+    public static ReadAuctionsDto from(final Slice<Auction> auctions) {
+        final List<ReadAuctionDto> readAuctionDtos = auctions.getContent()
+                                                             .stream()
+                                                             .map(ReadAuctionDto::from)
+                                                             .toList();
+
+        return new ReadAuctionsDto(readAuctionDtos, !auctions.hasNext());
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
@@ -2,6 +2,7 @@ package com.ddang.ddang.auction.domain;
 
 import com.ddang.ddang.category.domain.Category;
 import com.ddang.ddang.common.entity.BaseTimeEntity;
+import com.ddang.ddang.image.domain.AuctionImage;
 import com.ddang.ddang.region.domain.AuctionRegion;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.CascadeType;
@@ -74,8 +75,8 @@ public class Auction extends BaseTimeEntity {
     @JoinColumn(name = "sub_category_id", foreignKey = @ForeignKey(name = "fk_auction_sub_category"))
     private Category subCategory;
 
-    // TODO 2차 데모데이 이후 리펙터링 예정
-    private String image;
+    @OneToMany(mappedBy = "auction", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    private List<AuctionImage> auctionImages = new ArrayList<>();
 
     @Builder
     private Auction(
@@ -84,8 +85,7 @@ public class Auction extends BaseTimeEntity {
             final BidUnit bidUnit,
             final Price startPrice,
             final LocalDateTime closingTime,
-            final Category subCategory,
-            final String image
+            final Category subCategory
     ) {
         this.title = title;
         this.description = description;
@@ -93,7 +93,6 @@ public class Auction extends BaseTimeEntity {
         this.startPrice = startPrice;
         this.closingTime = closingTime;
         this.subCategory = subCategory;
-        this.image = image;
     }
 
     public void delete() {
@@ -105,5 +104,10 @@ public class Auction extends BaseTimeEntity {
             this.auctionRegions.add(auctionRegion);
             auctionRegion.initAuction(this);
         }
+    }
+
+    public void addAuctionImage(final AuctionImage auctionImage) {
+        auctionImages.add(auctionImage);
+        auctionImage.initAuction(this);
     }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
@@ -1,5 +1,6 @@
 package com.ddang.ddang.auction.domain;
 
+import com.ddang.ddang.category.domain.Category;
 import com.ddang.ddang.common.entity.BaseTimeEntity;
 import com.ddang.ddang.region.domain.AuctionRegion;
 import jakarta.persistence.AttributeOverride;
@@ -7,10 +8,14 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -65,12 +70,12 @@ public class Auction extends BaseTimeEntity {
     @OneToMany(mappedBy = "auction", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<AuctionRegion> auctionRegions = new ArrayList<>();
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sub_category_id", foreignKey = @ForeignKey(name = "fk_auction_sub_category"))
+    private Category subCategory;
+
     // TODO 2차 데모데이 이후 리펙터링 예정
     private String image;
-
-    private String mainCategory;
-
-    private String subCategory;
 
     @Builder
     private Auction(
@@ -79,18 +84,16 @@ public class Auction extends BaseTimeEntity {
             final BidUnit bidUnit,
             final Price startPrice,
             final LocalDateTime closingTime,
-            final String image,
-            final String mainCategory,
-            final String subCategory
+            final Category subCategory,
+            final String image
     ) {
         this.title = title;
         this.description = description;
         this.bidUnit = bidUnit;
         this.startPrice = startPrice;
         this.closingTime = closingTime;
-        this.image = image;
-        this.mainCategory = mainCategory;
         this.subCategory = subCategory;
+        this.image = image;
     }
 
     public void delete() {

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
@@ -106,8 +106,10 @@ public class Auction extends BaseTimeEntity {
         }
     }
 
-    public void addAuctionImage(final AuctionImage auctionImage) {
-        auctionImages.add(auctionImage);
-        auctionImage.initAuction(this);
+    public void addAuctionImages(final List<AuctionImage> auctionImages) {
+        for (final AuctionImage auctionImage : auctionImages) {
+            this.auctionImages.add(auctionImage);
+            auctionImage.initAuction(this);
+        }
     }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepository.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepository.java
@@ -8,5 +8,5 @@ public interface QuerydslAuctionRepository {
 
     Slice<Auction> findAuctionsAllByLastAuctionId(final Long lastAuctionId, final int size);
 
-    Optional<Auction> findAuctionWithRegionsById(final Long auctionId);
+    Optional<Auction> findAuctionById(final Long auctionId);
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepository.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepository.java
@@ -1,13 +1,12 @@
 package com.ddang.ddang.auction.infrastructure.persistence;
 
 import com.ddang.ddang.auction.domain.Auction;
-
-import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Slice;
 
 public interface QuerydslAuctionRepository {
 
-    List<Auction> findAuctionsAllByLastAuctionId(final Long lastAuctionId, final int size);
+    Slice<Auction> findAuctionsAllByLastAuctionId(final Long lastAuctionId, final int size);
 
     Optional<Auction> findAuctionWithRegionsById(final Long auctionId);
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImpl.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImpl.java
@@ -6,11 +6,13 @@ import static com.ddang.ddang.region.domain.QAuctionRegion.auctionRegion;
 import static com.ddang.ddang.region.domain.QRegion.region;
 
 import com.ddang.ddang.auction.domain.Auction;
+import com.ddang.ddang.configuration.QuerydslSliceHelper;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -20,13 +22,15 @@ public class QuerydslAuctionRepositoryImpl implements QuerydslAuctionRepository 
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Auction> findAuctionsAllByLastAuctionId(final Long lastAuctionId, final int size) {
-        return queryFactory
+    public Slice<Auction> findAuctionsAllByLastAuctionId(final Long lastAuctionId, final int size) {
+        final List<Auction> auctions = queryFactory
                 .selectFrom(auction)
                 .where(auction.deleted.isFalse(), lessThanLastAuctionId(lastAuctionId))
                 .orderBy(auction.id.desc())
                 .limit(size + 1L)
                 .fetch();
+
+        return QuerydslSliceHelper.toSlice(auctions, size);
     }
 
     private BooleanExpression lessThanLastAuctionId(final Long lastAuctionId) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImpl.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImpl.java
@@ -25,6 +25,12 @@ public class QuerydslAuctionRepositoryImpl implements QuerydslAuctionRepository 
     public Slice<Auction> findAuctionsAllByLastAuctionId(final Long lastAuctionId, final int size) {
         final List<Auction> auctions = queryFactory
                 .selectFrom(auction)
+                .leftJoin(auction.auctionRegions, auctionRegion).fetchJoin()
+                .leftJoin(auctionRegion.thirdRegion, region).fetchJoin()
+                .leftJoin(region.firstRegion).fetchJoin()
+                .leftJoin(region.secondRegion).fetchJoin()
+                .leftJoin(auction.subCategory, category).fetchJoin()
+                .leftJoin(category.mainCategory).fetchJoin()
                 .where(auction.deleted.isFalse(), lessThanLastAuctionId(lastAuctionId))
                 .orderBy(auction.id.desc())
                 .limit(size + 1L)

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImpl.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImpl.java
@@ -48,7 +48,7 @@ public class QuerydslAuctionRepositoryImpl implements QuerydslAuctionRepository 
     }
 
     @Override
-    public Optional<Auction> findAuctionWithRegionsById(final Long auctionId) {
+    public Optional<Auction> findAuctionById(final Long auctionId) {
         final Auction findAuction = queryFactory
                 .selectFrom(auction)
                 .leftJoin(auction.auctionRegions, auctionRegion).fetchJoin()

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImpl.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImpl.java
@@ -6,7 +6,7 @@ import static com.ddang.ddang.region.domain.QAuctionRegion.auctionRegion;
 import static com.ddang.ddang.region.domain.QRegion.region;
 
 import com.ddang.ddang.auction.domain.Auction;
-import com.ddang.ddang.configuration.QuerydslSliceHelper;
+import com.ddang.ddang.common.helper.QuerydslSliceHelper;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImpl.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.ddang.ddang.auction.infrastructure.persistence;
 
 import static com.ddang.ddang.auction.domain.QAuction.auction;
+import static com.ddang.ddang.category.domain.QCategory.category;
 import static com.ddang.ddang.region.domain.QAuctionRegion.auctionRegion;
 import static com.ddang.ddang.region.domain.QRegion.region;
 
@@ -44,6 +45,8 @@ public class QuerydslAuctionRepositoryImpl implements QuerydslAuctionRepository 
                 .leftJoin(auctionRegion.thirdRegion, region).fetchJoin()
                 .leftJoin(region.firstRegion).fetchJoin()
                 .leftJoin(region.secondRegion).fetchJoin()
+                .leftJoin(auction.subCategory, category).fetchJoin()
+                .leftJoin(category.mainCategory).fetchJoin()
                 .where(auction.deleted.isFalse(), auction.id.eq(auctionId))
                 .fetchOne();
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImpl.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImpl.java
@@ -25,7 +25,7 @@ public class QuerydslAuctionRepositoryImpl implements QuerydslAuctionRepository 
                 .selectFrom(auction)
                 .where(auction.deleted.isFalse(), lessThanLastAuctionId(lastAuctionId))
                 .orderBy(auction.id.desc())
-                .limit(size)
+                .limit(size + 1L)
                 .fetch();
     }
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
@@ -35,11 +35,7 @@ public class AuctionController {
     @PostMapping
     public ResponseEntity<CreateAuctionResponse> create(@ModelAttribute @Valid final CreateAuctionRequest request) {
         final CreateInfoAuctionDto createInfoAuctionDto = auctionService.create(CreateAuctionDto.from(request));
-        final String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath()
-                                                          .build()
-                                                          .toUriString()
-                                                          .concat(AUCTIONS_IMAGE_BASE_URL);
-        final CreateAuctionResponse response = CreateAuctionResponse.of(createInfoAuctionDto, baseUrl);
+        final CreateAuctionResponse response = CreateAuctionResponse.of(createInfoAuctionDto, calculateBaseImageUrl());
 
         return ResponseEntity.created(URI.create("/auctions/" + createInfoAuctionDto.id()))
                              .body(response);
@@ -48,11 +44,10 @@ public class AuctionController {
     @GetMapping("/{auctionId}")
     public ResponseEntity<ReadAuctionDetailResponse> read(@PathVariable final Long auctionId) {
         final ReadAuctionDto readAuctionDto = auctionService.readByAuctionId(auctionId);
-        final String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath()
-                                                          .build()
-                                                          .toUriString()
-                                                          .concat(AUCTIONS_IMAGE_BASE_URL);
-        final ReadAuctionDetailResponse response = ReadAuctionDetailResponse.from(readAuctionDto, baseUrl);
+        final ReadAuctionDetailResponse response = ReadAuctionDetailResponse.from(
+                readAuctionDto,
+                calculateBaseImageUrl()
+        );
 
         return ResponseEntity.ok(response);
     }
@@ -63,11 +58,7 @@ public class AuctionController {
             @RequestParam(required = false, defaultValue = "10") final int size
     ) {
         final ReadAuctionsDto readAuctionsDto = auctionService.readAllByLastAuctionId(lastAuctionId, size);
-        final String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath()
-                                                          .build()
-                                                          .toUriString()
-                                                          .concat(AUCTIONS_IMAGE_BASE_URL);
-        final ReadAuctionsResponse response = ReadAuctionsResponse.of(readAuctionsDto, baseUrl);
+        final ReadAuctionsResponse response = ReadAuctionsResponse.of(readAuctionsDto, calculateBaseImageUrl());
 
         return ResponseEntity.ok(response);
     }
@@ -78,5 +69,12 @@ public class AuctionController {
 
         return ResponseEntity.noContent()
                              .build();
+    }
+
+    private String calculateBaseImageUrl() {
+        return ServletUriComponentsBuilder.fromCurrentContextPath()
+                                          .build()
+                                          .toUriString()
+                                          .concat(AUCTIONS_IMAGE_BASE_URL);
     }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
@@ -42,7 +42,10 @@ public class AuctionController {
     @GetMapping("/{auctionId}")
     public ResponseEntity<ReadAuctionDetailResponse> read(@PathVariable final Long auctionId) {
         final ReadAuctionDto readAuctionDto = auctionService.readByAuctionId(auctionId);
-        final String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
+        final String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath()
+                                                          .build()
+                                                          .toUriString()
+                                                          .concat("/auctions/images/");
         final ReadAuctionDetailResponse response = ReadAuctionDetailResponse.from(readAuctionDto, baseUrl);
 
         return ResponseEntity.ok(response);
@@ -54,13 +57,15 @@ public class AuctionController {
             @RequestParam(required = false, defaultValue = "10") final int size
     ) {
         final List<ReadAuctionDto> readAuctionDtos = auctionService.readAllByLastAuctionId(lastAuctionId, size);
-        final String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
+        final String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath()
+                                                          .build()
+                                                          .toUriString()
+                                                          .concat("/auctions/images/");
         final List<ReadAuctionResponse> readAuctionResponses = readAuctionDtos.stream()
                                                                               .map(dto -> ReadAuctionResponse.of(
                                                                                       dto, baseUrl
                                                                               ))
                                                                               .toList();
-
         final ReadAuctionsResponse response = new ReadAuctionsResponse(
                 readAuctionResponses,
                 findLastAuctionId(readAuctionResponses)

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
@@ -2,6 +2,7 @@ package com.ddang.ddang.auction.presentation;
 
 import com.ddang.ddang.auction.application.AuctionService;
 import com.ddang.ddang.auction.application.dto.CreateAuctionDto;
+import com.ddang.ddang.auction.application.dto.CreateInfoAuctionDto;
 import com.ddang.ddang.auction.application.dto.ReadAuctionDto;
 import com.ddang.ddang.auction.presentation.dto.request.CreateAuctionRequest;
 import com.ddang.ddang.auction.presentation.dto.response.CreateAuctionResponse;
@@ -28,14 +29,20 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 @RequiredArgsConstructor
 public class AuctionController {
 
+    private static final String AUCTIONS_IMAGE_BASE_URL = "/auctions/images/";
+
     private final AuctionService auctionService;
 
     @PostMapping
     public ResponseEntity<CreateAuctionResponse> create(@ModelAttribute @Valid final CreateAuctionRequest request) {
-        final Long auctionId = auctionService.create(CreateAuctionDto.from(request));
-        final CreateAuctionResponse response = new CreateAuctionResponse(auctionId);
+        final CreateInfoAuctionDto createInfoAuctionDto = auctionService.create(CreateAuctionDto.from(request));
+        final String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath()
+                                                          .build()
+                                                          .toUriString()
+                                                          .concat(AUCTIONS_IMAGE_BASE_URL);
+        final CreateAuctionResponse response = CreateAuctionResponse.of(createInfoAuctionDto, baseUrl);
 
-        return ResponseEntity.created(URI.create("/auctions/" + auctionId))
+        return ResponseEntity.created(URI.create("/auctions/" + createInfoAuctionDto.id()))
                              .body(response);
     }
 
@@ -45,7 +52,7 @@ public class AuctionController {
         final String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath()
                                                           .build()
                                                           .toUriString()
-                                                          .concat("/auctions/images/");
+                                                          .concat(AUCTIONS_IMAGE_BASE_URL);
         final ReadAuctionDetailResponse response = ReadAuctionDetailResponse.from(readAuctionDto, baseUrl);
 
         return ResponseEntity.ok(response);
@@ -60,7 +67,7 @@ public class AuctionController {
         final String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath()
                                                           .build()
                                                           .toUriString()
-                                                          .concat("/auctions/images/");
+                                                          .concat(AUCTIONS_IMAGE_BASE_URL);
         final List<ReadAuctionResponse> readAuctionResponses = readAuctionDtos.stream()
                                                                               .map(dto -> ReadAuctionResponse.of(
                                                                                       dto, baseUrl

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
@@ -4,14 +4,13 @@ import com.ddang.ddang.auction.application.AuctionService;
 import com.ddang.ddang.auction.application.dto.CreateAuctionDto;
 import com.ddang.ddang.auction.application.dto.CreateInfoAuctionDto;
 import com.ddang.ddang.auction.application.dto.ReadAuctionDto;
+import com.ddang.ddang.auction.application.dto.ReadAuctionsDto;
 import com.ddang.ddang.auction.presentation.dto.request.CreateAuctionRequest;
 import com.ddang.ddang.auction.presentation.dto.response.CreateAuctionResponse;
 import com.ddang.ddang.auction.presentation.dto.response.ReadAuctionDetailResponse;
-import com.ddang.ddang.auction.presentation.dto.response.ReadAuctionResponse;
 import com.ddang.ddang.auction.presentation.dto.response.ReadAuctionsResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -63,17 +62,12 @@ public class AuctionController {
             @RequestParam(required = false) final Long lastAuctionId,
             @RequestParam(required = false, defaultValue = "10") final int size
     ) {
-        final List<ReadAuctionDto> readAuctionDtos = auctionService.readAllByLastAuctionId(lastAuctionId, size);
+        final ReadAuctionsDto readAuctionsDto = auctionService.readAllByLastAuctionId(lastAuctionId, size);
         final String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath()
                                                           .build()
                                                           .toUriString()
                                                           .concat(AUCTIONS_IMAGE_BASE_URL);
-        final List<ReadAuctionResponse> readAuctionResponses = readAuctionDtos.stream()
-                                                                              .map(dto -> ReadAuctionResponse.of(
-                                                                                      dto, baseUrl
-                                                                              ))
-                                                                              .toList();
-        final ReadAuctionsResponse response = ReadAuctionsResponse.of(readAuctionResponses, size);
+        final ReadAuctionsResponse response = ReadAuctionsResponse.of(readAuctionsDto, baseUrl);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
@@ -66,21 +66,9 @@ public class AuctionController {
                                                                                       dto, baseUrl
                                                                               ))
                                                                               .toList();
-        final ReadAuctionsResponse response = new ReadAuctionsResponse(
-                readAuctionResponses,
-                findLastAuctionId(readAuctionResponses)
-        );
+        final ReadAuctionsResponse response = ReadAuctionsResponse.of(readAuctionResponses, size);
 
         return ResponseEntity.ok(response);
-    }
-
-    private Long findLastAuctionId(final List<ReadAuctionResponse> readAuctionResponses) {
-        if (readAuctionResponses.isEmpty()) {
-            return null;
-        }
-
-        return readAuctionResponses.get(readAuctionResponses.size() - 1)
-                                   .id();
     }
 
     @DeleteMapping("/{auctionId}")

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/request/CreateAuctionCategoryRequest.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/request/CreateAuctionCategoryRequest.java
@@ -1,4 +1,0 @@
-package com.ddang.ddang.auction.presentation.dto.request;
-
-public record CreateAuctionCategoryRequest(String main, String sub) {
-}

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/request/CreateAuctionRequest.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/request/CreateAuctionRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Positive;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 public record CreateAuctionRequest(
         @NotEmpty(message = "제목이 입력되지 않았습니다.")
@@ -33,8 +34,7 @@ public record CreateAuctionRequest(
 
         List<Long> thirdRegionIds,
 
-        // TODO 2차 데모데이 이후 리펙터링 예정
-        List<String> images
+        List<MultipartFile> auctionImages
 ) {
 
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/request/CreateAuctionRequest.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/request/CreateAuctionRequest.java
@@ -34,6 +34,7 @@ public record CreateAuctionRequest(
 
         List<Long> thirdRegionIds,
 
+        @NotEmpty(message = "이미지를 1장 이상 등록해주세요.")
         List<MultipartFile> images
 ) {
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/request/CreateAuctionRequest.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/request/CreateAuctionRequest.java
@@ -27,11 +27,13 @@ public record CreateAuctionRequest(
         @FutureOrPresent(message = "마감 시간은 과거를 입력할 수 없습니다.")
         LocalDateTime closingTime,
 
+        Long subCategoryId,
+
         // TODO 2차 데모데이 이후 리펙터링 예정
         List<String> images,
 
-        List<CreateDirectRegionRequest> directRegions,
-        
-        CreateAuctionCategoryRequest category
+        List<CreateDirectRegionRequest> directRegions
+
+
 ) {
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/request/CreateAuctionRequest.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/request/CreateAuctionRequest.java
@@ -34,7 +34,7 @@ public record CreateAuctionRequest(
 
         List<Long> thirdRegionIds,
 
-        List<MultipartFile> auctionImages
+        List<MultipartFile> images
 ) {
 
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/request/CreateAuctionRequest.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/request/CreateAuctionRequest.java
@@ -27,13 +27,14 @@ public record CreateAuctionRequest(
         @FutureOrPresent(message = "마감 시간은 과거를 입력할 수 없습니다.")
         LocalDateTime closingTime,
 
+        @NotNull(message = "하위 카테고리가 입력되지 않았습니다.")
+        @Positive(message = "카테고리 아이디는 음수 또는 0을 입력할 수 없습니다.")
         Long subCategoryId,
 
+        List<Long> thirdRegionIds,
+
         // TODO 2차 데모데이 이후 리펙터링 예정
-        List<String> images,
-
-        List<CreateDirectRegionRequest> directRegions
-
-
+        List<String> images
 ) {
+
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/response/AuctionDetailResponse.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/response/AuctionDetailResponse.java
@@ -36,11 +36,10 @@ public record AuctionDetailResponse(
         int auctioneerCount
 ) {
 
-    public static AuctionDetailResponse from(final ReadAuctionDto dto) {
-        // TODO 2차 데모데이 이후 리펙터링 예정
+    public static AuctionDetailResponse of(final ReadAuctionDto dto, final String baseUrl) {
         return new AuctionDetailResponse(
                 dto.id(),
-                List.of(dto.image()),
+                convertImageUrls(dto, baseUrl),
                 dto.title(),
                 new CategoryResponse(dto.mainCategory(), dto.subCategory()),
                 dto.description(),
@@ -53,6 +52,13 @@ public record AuctionDetailResponse(
                 convertDirectRegionsResponse(dto),
                 0
         );
+    }
+
+    private static List<String> convertImageUrls(final ReadAuctionDto dto, final String baseUrl) {
+        return dto.auctionImageIds()
+                  .stream()
+                  .map(id -> baseUrl.concat(String.valueOf(id)))
+                  .toList();
     }
 
     private static List<DirectRegionResponse> convertDirectRegionsResponse(final ReadAuctionDto dto) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/response/CreateAuctionResponse.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/response/CreateAuctionResponse.java
@@ -1,4 +1,25 @@
 package com.ddang.ddang.auction.presentation.dto.response;
 
-public record CreateAuctionResponse(Long id) {
+import com.ddang.ddang.auction.application.dto.CreateInfoAuctionDto;
+
+public record CreateAuctionResponse(
+        Long id,
+        String title,
+        String image,
+        int auctionPrice,
+        String status,
+        int auctioneerCount
+) {
+
+    public static CreateAuctionResponse of(final CreateInfoAuctionDto dto, final String baseUrl) {
+        return new CreateAuctionResponse(
+                dto.id(),
+                dto.title(),
+                baseUrl.concat(String.valueOf(dto.auctionImageId())),
+                dto.startPrice(),
+                // TODO 2차 데모데이 이후 enum으로 처리
+                "UNBIDDEN",
+                0
+        );
+    }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/response/ReadAuctionDetailResponse.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/response/ReadAuctionDetailResponse.java
@@ -4,8 +4,8 @@ import com.ddang.ddang.auction.application.dto.ReadAuctionDto;
 
 public record ReadAuctionDetailResponse(AuctionDetailResponse auction, SellerResponse seller) {
 
-    public static ReadAuctionDetailResponse from(final ReadAuctionDto dto) {
-        final AuctionDetailResponse auctionDetailResponse = AuctionDetailResponse.from(dto);
+    public static ReadAuctionDetailResponse from(final ReadAuctionDto dto, final String baseUrl) {
+        final AuctionDetailResponse auctionDetailResponse = AuctionDetailResponse.of(dto, baseUrl);
         final SellerResponse sellerResponse = new SellerResponse(
                 1L,
                 "https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/7r5X/image/9djEiPBPMLu_IvCYyvRPwmZkM1g.jpg",

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/response/ReadAuctionResponse.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/response/ReadAuctionResponse.java
@@ -1,10 +1,8 @@
 package com.ddang.ddang.auction.presentation.dto.response;
 
 import com.ddang.ddang.auction.application.dto.ReadAuctionDto;
-
 import java.time.LocalDateTime;
 
-// TODO 2차 데모데이 이후 리팩토링 예정
 public record ReadAuctionResponse(
         Long id,
         String title,
@@ -14,15 +12,19 @@ public record ReadAuctionResponse(
         int auctioneerCount
 ) {
 
-    public static ReadAuctionResponse from(final ReadAuctionDto dto) {
+    public static ReadAuctionResponse of(final ReadAuctionDto dto, final String baseUrl) {
         return new ReadAuctionResponse(
                 dto.id(),
                 dto.title(),
-                dto.image(),
+                convertImageUrl(dto, baseUrl),
                 processAuctionPrice(dto.startPrice(), dto.lastBidPrice()),
                 processAuctionStatus(dto.closingTime(), dto.lastBidPrice()),
                 0
         );
+    }
+
+    private static String convertImageUrl(final ReadAuctionDto dto, final String baseUrl) {
+        return baseUrl.concat(String.valueOf(dto.auctionImageIds().get(0)));
     }
 
     private static int processAuctionPrice(final Integer startPrice, final Integer lastBidPrice) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/response/ReadAuctionsResponse.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/response/ReadAuctionsResponse.java
@@ -1,13 +1,18 @@
 package com.ddang.ddang.auction.presentation.dto.response;
 
+import com.ddang.ddang.auction.application.dto.ReadAuctionsDto;
 import java.util.List;
 
 public record ReadAuctionsResponse(List<ReadAuctionResponse> auctions, boolean isLast) {
 
-    public static ReadAuctionsResponse of(final List<ReadAuctionResponse> auctions, final int size) {
-        if (auctions.size() > size) {
-            return new ReadAuctionsResponse(auctions, false);
-        }
-        return new ReadAuctionsResponse(auctions, true);
+    public static ReadAuctionsResponse of(final ReadAuctionsDto readAuctionsDto, final String baseUrl) {
+        final List<ReadAuctionResponse> readAuctionResponses = readAuctionsDto.readAuctionDtos()
+                                                                              .stream()
+                                                                              .map(dto -> ReadAuctionResponse.of(
+                                                                                      dto, baseUrl
+                                                                              ))
+                                                                              .toList();
+
+        return new ReadAuctionsResponse(readAuctionResponses, readAuctionsDto.isLast());
     }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/response/ReadAuctionsResponse.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/response/ReadAuctionsResponse.java
@@ -2,5 +2,12 @@ package com.ddang.ddang.auction.presentation.dto.response;
 
 import java.util.List;
 
-public record ReadAuctionsResponse(List<ReadAuctionResponse> auctions, Long lastAuctionId) {
+public record ReadAuctionsResponse(List<ReadAuctionResponse> auctions, boolean isLast) {
+
+    public static ReadAuctionsResponse of(final List<ReadAuctionResponse> auctions, final int size) {
+        if (auctions.size() > size) {
+            return new ReadAuctionsResponse(auctions, false);
+        }
+        return new ReadAuctionsResponse(auctions, true);
+    }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/category/infrastructure/persistence/JpaCategoryRepository.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/category/infrastructure/persistence/JpaCategoryRepository.java
@@ -1,13 +1,17 @@
 package com.ddang.ddang.category.infrastructure.persistence;
 
 import com.ddang.ddang.category.domain.Category;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface JpaCategoryRepository extends JpaRepository<Category, Long> {
 
     List<Category> findMainAllByMainCategoryIsNull();
 
-    List<Category> findSubAllByMainCategoryId(Long mainCategoryId);
+    List<Category> findSubAllByMainCategoryId(final Long mainCategoryId);
+
+    @Query("select c from Category c where c.id = :subCategoryId and c.mainCategory.id is not null")
+    Optional<Category> findSubCategoryById(final Long subCategoryId);
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/common/helper/QuerydslSliceHelper.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/common/helper/QuerydslSliceHelper.java
@@ -1,4 +1,4 @@
-package com.ddang.ddang.configuration;
+package com.ddang.ddang.common.helper;
 
 import java.util.List;
 import org.springframework.data.domain.PageRequest;
@@ -7,6 +7,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
 public class QuerydslSliceHelper {
+
+    private QuerydslSliceHelper() {
+    }
 
     public static <T> Slice<T> toSlice(List<T> contents, int size) {
         final boolean hasNext = isContentSizeGreaterThanPageSize(contents, size);

--- a/backend/ddang/src/main/java/com/ddang/ddang/configuration/ImageConfiguration.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/configuration/ImageConfiguration.java
@@ -1,0 +1,30 @@
+package com.ddang.ddang.configuration;
+
+import jakarta.servlet.MultipartConfigElement;
+import org.springframework.boot.web.servlet.MultipartConfigFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.multipart.MultipartResolver;
+import org.springframework.web.multipart.support.StandardServletMultipartResolver;
+
+@Configuration
+public class ImageConfiguration {
+
+    private static final long MAXIMUM_FILE_SIZE = 10L;
+
+    @Bean
+    public MultipartConfigElement multipartConfigElement() {
+        MultipartConfigFactory factory = new MultipartConfigFactory();
+
+        factory.setMaxFileSize(DataSize.ofMegabytes(MAXIMUM_FILE_SIZE));
+        factory.setMaxRequestSize(DataSize.ofMegabytes(MAXIMUM_FILE_SIZE));
+
+        return factory.createMultipartConfig();
+    }
+
+    @Bean
+    public MultipartResolver multipartResolver() {
+        return new StandardServletMultipartResolver();
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/configuration/ImageConfiguration.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/configuration/ImageConfiguration.java
@@ -12,13 +12,14 @@ import org.springframework.web.multipart.support.StandardServletMultipartResolve
 public class ImageConfiguration {
 
     private static final long MAXIMUM_FILE_SIZE = 10L;
+    private static final long MAXIMUM_REQUEST_SIZE = 110L;
 
     @Bean
     public MultipartConfigElement multipartConfigElement() {
         MultipartConfigFactory factory = new MultipartConfigFactory();
 
         factory.setMaxFileSize(DataSize.ofMegabytes(MAXIMUM_FILE_SIZE));
-        factory.setMaxRequestSize(DataSize.ofMegabytes(MAXIMUM_FILE_SIZE));
+        factory.setMaxRequestSize(DataSize.ofMegabytes(MAXIMUM_REQUEST_SIZE));
 
         return factory.createMultipartConfig();
     }

--- a/backend/ddang/src/main/java/com/ddang/ddang/configuration/InitializationAuctionConfiguration.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/configuration/InitializationAuctionConfiguration.java
@@ -4,6 +4,8 @@ import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.domain.BidUnit;
 import com.ddang.ddang.auction.domain.Price;
 import com.ddang.ddang.auction.infrastructure.persistence.JpaAuctionRepository;
+import com.ddang.ddang.category.domain.Category;
+import com.ddang.ddang.category.infrastructure.persistence.JpaCategoryRepository;
 import com.ddang.ddang.region.domain.AuctionRegion;
 import com.ddang.ddang.region.domain.Region;
 import com.ddang.ddang.region.infrastructure.persistence.JpaRegionRepository;
@@ -23,6 +25,7 @@ public class InitializationAuctionConfiguration implements ApplicationRunner {
 
     private final JpaAuctionRepository auctionRepository;
     private final JpaRegionRepository regionRepository;
+    private final JpaCategoryRepository categoryRepository;
 
     @Override
     @Transactional
@@ -37,6 +40,13 @@ public class InitializationAuctionConfiguration implements ApplicationRunner {
         final AuctionRegion auctionRegion1 = new AuctionRegion(thirdRegion);
         final AuctionRegion auctionRegion2 = new AuctionRegion(thirdRegion);
 
+        final Category main = new Category("전자기기");
+        final Category sub = new Category("노트북");
+
+        main.addSubCategory(sub);
+
+        categoryRepository.save(main);
+
         final Auction auction1 = Auction.builder()
                                         .title("맥북 2021 13인치")
                                         .description("맥북 2021 13인치 팝니다. 애플 감성 안 맞아요.")
@@ -44,8 +54,7 @@ public class InitializationAuctionConfiguration implements ApplicationRunner {
                                         .startPrice(new Price(1_000_000))
                                         .closingTime(LocalDateTime.now())
                                         .image("https://www.apple.com/newsroom/images/product/mac/standard/Apple_MacBook-Pro_14-16-inch_10182021_big.jpg.large.jpg")
-                                        .mainCategory("전자기기")
-                                        .subCategory("노트북")
+                                        .subCategory(sub)
                                         .build();
         auction1.addAuctionRegions(List.of(auctionRegion1));
 
@@ -57,8 +66,7 @@ public class InitializationAuctionConfiguration implements ApplicationRunner {
                                         .closingTime(LocalDateTime.now()
                                                                   .plusDays(5L))
                                         .image("https://www.apple.com/newsroom/images/product/mac/standard/Apple_MacBook-Pro_14-16-inch_10182021_big.jpg.large.jpg")
-                                        .mainCategory("전자기기")
-                                        .subCategory("노트북")
+                                        .subCategory(sub)
                                         .build();
         auction2.addAuctionRegions(List.of(auctionRegion2));
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/configuration/InitializationAuctionConfiguration.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/configuration/InitializationAuctionConfiguration.java
@@ -53,7 +53,6 @@ public class InitializationAuctionConfiguration implements ApplicationRunner {
                                         .bidUnit(new BidUnit(1_000))
                                         .startPrice(new Price(1_000_000))
                                         .closingTime(LocalDateTime.now())
-                                        .image("https://www.apple.com/newsroom/images/product/mac/standard/Apple_MacBook-Pro_14-16-inch_10182021_big.jpg.large.jpg")
                                         .subCategory(sub)
                                         .build();
         auction1.addAuctionRegions(List.of(auctionRegion1));
@@ -65,7 +64,6 @@ public class InitializationAuctionConfiguration implements ApplicationRunner {
                                         .startPrice(new Price(900_000))
                                         .closingTime(LocalDateTime.now()
                                                                   .plusDays(5L))
-                                        .image("https://www.apple.com/newsroom/images/product/mac/standard/Apple_MacBook-Pro_14-16-inch_10182021_big.jpg.large.jpg")
                                         .subCategory(sub)
                                         .build();
         auction2.addAuctionRegions(List.of(auctionRegion2));

--- a/backend/ddang/src/main/java/com/ddang/ddang/configuration/QuerydslSliceHelper.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/configuration/QuerydslSliceHelper.java
@@ -1,0 +1,29 @@
+package com.ddang.ddang.configuration;
+
+import java.util.List;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+public class QuerydslSliceHelper {
+
+    public static <T> Slice<T> toSlice(List<T> contents, int size) {
+        final boolean hasNext = isContentSizeGreaterThanPageSize(contents, size);
+        final Pageable pageable = PageRequest.ofSize(size);
+
+        if (hasNext) {
+            return new SliceImpl<>(subListLastContent(contents, size), pageable, hasNext);
+        }
+
+        return new SliceImpl<>(contents, pageable, hasNext);
+    }
+
+    private static <T> boolean isContentSizeGreaterThanPageSize(List<T> content, int size) {
+        return content.size() > size;
+    }
+
+    private static <T> List<T> subListLastContent(List<T> content, int size) {
+        return content.subList(0, size);
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/image/application/ImageService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/image/application/ImageService.java
@@ -1,0 +1,37 @@
+package com.ddang.ddang.image.application;
+
+import com.ddang.ddang.image.application.exception.ImageNotFoundException;
+import com.ddang.ddang.image.domain.AuctionImage;
+import com.ddang.ddang.image.infrastructure.persistence.JpaAuctionImageRepository;
+import java.net.MalformedURLException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ImageService {
+
+    @Value("${image.store.dir}")
+    private String imageStoreDir;
+
+    private final JpaAuctionImageRepository auctionImageRepository;
+
+    public Resource readAuctionImage(final Long id) throws MalformedURLException {
+        final AuctionImage auctionImage = auctionImageRepository.findById(id)
+                                                                .orElseThrow(() -> new ImageNotFoundException(
+                                                                        "지정한 이미지를 찾을 수 없습니다."
+                                                                ));
+        final String fullPath = findFullPath(auctionImage.getStoreName());
+
+        return new UrlResource("file:" + fullPath);
+    }
+
+    private String findFullPath(String storeImageFileName) {
+        return imageStoreDir + storeImageFileName;
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/image/application/exception/ImageNotFoundException.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/image/application/exception/ImageNotFoundException.java
@@ -1,0 +1,8 @@
+package com.ddang.ddang.image.application.exception;
+
+public class ImageNotFoundException extends IllegalArgumentException {
+
+    public ImageNotFoundException(final String message) {
+        super(message);
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/image/application/exception/InvalidImagePathException.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/image/application/exception/InvalidImagePathException.java
@@ -1,0 +1,8 @@
+package com.ddang.ddang.image.application.exception;
+
+public class InvalidImagePathException extends IllegalStateException {
+
+    public InvalidImagePathException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/image/domain/AuctionImage.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/image/domain/AuctionImage.java
@@ -9,7 +9,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -17,7 +16,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Entity
-@Table(name = "auction_image")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @EqualsAndHashCode(of = "id")

--- a/backend/ddang/src/main/java/com/ddang/ddang/image/domain/AuctionImage.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/image/domain/AuctionImage.java
@@ -1,0 +1,49 @@
+package com.ddang.ddang.image.domain;
+
+import com.ddang.ddang.auction.domain.Auction;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table(name = "auction_image")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode(of = "id")
+@ToString(of = {"id", "uploadName", "storeName", "authenticated"})
+public class AuctionImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String uploadName;
+
+    private String storeName;
+
+    private boolean authenticated = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "auction_id", foreignKey = @ForeignKey(name = "fk_auction_image"))
+    private Auction auction;
+
+    public AuctionImage(final String uploadName, final String storeName) {
+        this.uploadName = uploadName;
+        this.storeName = storeName;
+    }
+
+    public void initAuction(final Auction auction) {
+        this.auction = auction;
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/image/domain/StoreImageProcessor.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/image/domain/StoreImageProcessor.java
@@ -1,0 +1,10 @@
+package com.ddang.ddang.image.domain;
+
+import com.ddang.ddang.image.domain.dto.StoreImageDto;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface StoreImageProcessor {
+
+    List<StoreImageDto> storeImageFiles(List<MultipartFile> imageFiles);
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/image/domain/dto/StoreImageDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/image/domain/dto/StoreImageDto.java
@@ -1,0 +1,10 @@
+package com.ddang.ddang.image.domain.dto;
+
+import com.ddang.ddang.image.domain.AuctionImage;
+
+public record StoreImageDto(String uploadName, String storeName) {
+
+    public AuctionImage toEntity() {
+        return new AuctionImage(uploadName, storeName);
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/image/infrastructure/local/LocalStoreImageProcessor.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/image/infrastructure/local/LocalStoreImageProcessor.java
@@ -1,0 +1,80 @@
+package com.ddang.ddang.image.infrastructure.local;
+
+import com.ddang.ddang.image.domain.StoreImageProcessor;
+import com.ddang.ddang.image.domain.dto.StoreImageDto;
+import com.ddang.ddang.image.infrastructure.local.exception.EmptyImageException;
+import com.ddang.ddang.image.infrastructure.local.exception.StoreImageException;
+import com.ddang.ddang.image.infrastructure.local.exception.UnsupportedImageFileExtensionException;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class LocalStoreImageProcessor implements StoreImageProcessor {
+
+    private static final List<String> WHITE_IMAGE_EXTENSION = List.of("jpg", "jpeg", "png");
+    private static final String EXTENSION_FILE_CHARACTER = ".";
+
+    @Value("${image.store.dir}")
+    private String imageStoreDir;
+
+    @Override
+    public List<StoreImageDto> storeImageFiles(final List<MultipartFile> imageFiles) {
+        final List<StoreImageDto> storeImageDtos = new ArrayList<>();
+
+        try {
+            for (MultipartFile imageFile : imageFiles) {
+                if (imageFile.isEmpty()) {
+                    throw new EmptyImageException("이미지 파일의 데이터가 비어 있습니다.");
+                }
+
+                storeImageDtos.add(storeImageFile(imageFile));
+            }
+
+            return storeImageDtos;
+        } catch (IOException e) {
+            throw new StoreImageException("이미지 저장에 실패했습니다.", e);
+        }
+    }
+
+    private StoreImageDto storeImageFile(MultipartFile imageFile) throws IOException {
+        final String originalImageFileName = imageFile.getOriginalFilename();
+        final String storeImageFileName = createStoreImageFileName(originalImageFileName);
+        final String fullPath = findFullPath(storeImageFileName);
+
+        imageFile.transferTo(new File(fullPath));
+
+        return new StoreImageDto(originalImageFileName, storeImageFileName);
+    }
+
+    private String findFullPath(String storeImageFileName) {
+        return imageStoreDir + storeImageFileName;
+    }
+
+    private String createStoreImageFileName(String originalFilename) {
+        final String extension = extractExtension(originalFilename);
+
+        validateImageFileExtension(extension);
+
+        final String uuid = UUID.randomUUID().toString();
+
+        return uuid + EXTENSION_FILE_CHARACTER + extension;
+    }
+
+    private String extractExtension(String originalFilename) {
+        int position = originalFilename.lastIndexOf(EXTENSION_FILE_CHARACTER);
+
+        return originalFilename.substring(position + 1);
+    }
+
+    private void validateImageFileExtension(final String extension) {
+        if (!WHITE_IMAGE_EXTENSION.contains(extension)) {
+            throw new UnsupportedImageFileExtensionException("지원하지 않는 확장자입니다. : " + extension);
+        }
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/image/infrastructure/local/exception/EmptyImageException.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/image/infrastructure/local/exception/EmptyImageException.java
@@ -1,0 +1,8 @@
+package com.ddang.ddang.image.infrastructure.local.exception;
+
+public class EmptyImageException extends IllegalArgumentException {
+
+    public EmptyImageException(final String message) {
+        super(message);
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/image/infrastructure/local/exception/StoreImageException.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/image/infrastructure/local/exception/StoreImageException.java
@@ -1,0 +1,8 @@
+package com.ddang.ddang.image.infrastructure.local.exception;
+
+public class StoreImageException extends IllegalStateException {
+
+    public StoreImageException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/image/infrastructure/local/exception/UnsupportedImageFileExtensionException.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/image/infrastructure/local/exception/UnsupportedImageFileExtensionException.java
@@ -1,0 +1,8 @@
+package com.ddang.ddang.image.infrastructure.local.exception;
+
+public class UnsupportedImageFileExtensionException extends IllegalArgumentException {
+
+    public UnsupportedImageFileExtensionException(final String message) {
+        super(message);
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/image/infrastructure/persistence/JpaAuctionImageRepository.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/image/infrastructure/persistence/JpaAuctionImageRepository.java
@@ -1,0 +1,8 @@
+package com.ddang.ddang.image.infrastructure.persistence;
+
+import com.ddang.ddang.image.domain.AuctionImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaAuctionImageRepository extends JpaRepository<AuctionImage, Long> {
+
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/image/presentation/ImageController.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/image/presentation/ImageController.java
@@ -1,0 +1,30 @@
+package com.ddang.ddang.image.presentation;
+
+import com.ddang.ddang.image.application.ImageService;
+import java.net.MalformedURLException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @GetMapping("/auctions/images/{id}")
+    public ResponseEntity<Resource> downloadImage(@PathVariable Long id) throws MalformedURLException {
+        final Resource resource = imageService.readAuctionImage(id);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.IMAGE_PNG);
+
+        return new ResponseEntity<>(resource, headers, HttpStatus.OK);
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/region/domain/AuctionRegion.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/region/domain/AuctionRegion.java
@@ -9,14 +9,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-@Table(name = "auction_region")
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter

--- a/backend/ddang/src/main/resources/application-local.yml
+++ b/backend/ddang/src/main/resources/application-local.yml
@@ -31,3 +31,7 @@ data:
       enabled: false
     auction:
       enabled: false
+
+image:
+  store:
+    dir: ./

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ddang.ddang.auction.application.dto.CreateAuctionDto;
+import com.ddang.ddang.auction.application.dto.CreateInfoAuctionDto;
 import com.ddang.ddang.auction.application.dto.ReadAuctionDto;
 import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
 import com.ddang.ddang.auction.domain.Auction;
@@ -81,10 +82,10 @@ class AuctionServiceTest {
         );
 
         // when
-        final Long actual = auctionService.create(createAuctionDto);
+        final CreateInfoAuctionDto actual = auctionService.create(createAuctionDto);
 
         // then
-        assertThat(actual).isPositive();
+        assertThat(actual.id()).isPositive();
     }
 
     @Test
@@ -266,10 +267,10 @@ class AuctionServiceTest {
                 List.of(auctionImage)
         );
 
-        final Long savedAuctionId = auctionService.create(createAuctionDto);
+        final CreateInfoAuctionDto createInfoAuctionDto = auctionService.create(createAuctionDto);
 
         // when
-        final ReadAuctionDto actual = auctionService.readByAuctionId(savedAuctionId);
+        final ReadAuctionDto actual = auctionService.readByAuctionId(createInfoAuctionDto.id());
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
@@ -388,13 +389,13 @@ class AuctionServiceTest {
                 List.of(auctionImage)
         );
 
-        final Long savedAuctionId = auctionService.create(createAuctionDto);
+        final CreateInfoAuctionDto createInfoAuctionDto = auctionService.create(createAuctionDto);
 
         // when
-        auctionService.deleteByAuctionId(savedAuctionId);
+        auctionService.deleteByAuctionId(createInfoAuctionDto.id());
 
         // then
-        final Optional<Auction> actual = auctionRepository.findById(savedAuctionId);
+        final Optional<Auction> actual = auctionRepository.findById(createInfoAuctionDto.id());
 
         SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(actual).isPresent();

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ddang.ddang.auction.application.dto.CreateAuctionDto;
-import com.ddang.ddang.auction.application.dto.CreateRegionDto;
 import com.ddang.ddang.auction.application.dto.ReadAuctionDto;
 import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
 import com.ddang.ddang.auction.domain.Auction;
@@ -57,12 +56,6 @@ class AuctionServiceTest {
 
         regionRepository.save(firstRegion);
 
-        final CreateRegionDto createRegionDto = new CreateRegionDto(
-                firstRegion.getId(),
-                secondRegion.getId(),
-                thirdRegion.getId()
-        );
-
         final Category main = new Category("main");
         final Category sub = new Category("sub");
 
@@ -75,10 +68,10 @@ class AuctionServiceTest {
                 1_000,
                 1_000,
                 LocalDateTime.now(),
-                List.of(createRegionDto),
+                List.of(thirdRegion.getId()),
+                sub.getId(),
                 // TODO 2차 데모데이 이후 리펙토링 예정
-                "",
-                sub.getId()
+                ""
         );
 
         // when
@@ -91,12 +84,6 @@ class AuctionServiceTest {
     @Test
     void 지정한_아이디에_해당하는_지역이_없을때_경매를_등록하면_예외가_발생한다() {
         // given
-        final CreateRegionDto createRegionDto = new CreateRegionDto(
-                1L,
-                2L,
-                3L
-        );
-
         final Category main = new Category("main");
         final Category sub = new Category("sub");
 
@@ -109,10 +96,10 @@ class AuctionServiceTest {
                 1_000,
                 1_000,
                 LocalDateTime.now(),
-                List.of(createRegionDto),
+                List.of(3L),
+                sub.getId(),
                 // TODO 2차 데모데이 이후 리펙토링 예정
-                "",
-                sub.getId()
+                ""
         );
 
         // when & then
@@ -133,12 +120,6 @@ class AuctionServiceTest {
 
         regionRepository.save(firstRegion);
 
-        final CreateRegionDto createRegionDto = new CreateRegionDto(
-                firstRegion.getId(),
-                thirdRegion.getId(),
-                secondRegion.getId()
-        );
-
         final Category main = new Category("main");
         final Category sub = new Category("sub");
 
@@ -151,10 +132,10 @@ class AuctionServiceTest {
                 1_000,
                 1_000,
                 LocalDateTime.now(),
-                List.of(createRegionDto),
+                List.of(secondRegion.getId()),
+                sub.getId(),
                 // TODO 2차 데모데이 이후 리펙토링 예정
-                "",
-                sub.getId()
+                ""
         );
 
         // when & then
@@ -175,22 +156,16 @@ class AuctionServiceTest {
 
         regionRepository.save(firstRegion);
 
-        final CreateRegionDto createRegionDto = new CreateRegionDto(
-                firstRegion.getId(),
-                secondRegion.getId(),
-                thirdRegion.getId()
-        );
-
         final CreateAuctionDto createAuctionDto = new CreateAuctionDto(
                 "경매 상품 1",
                 "이것은 경매 상품 1 입니다.",
                 1_000,
                 1_000,
                 LocalDateTime.now(),
-                List.of(createRegionDto),
+                List.of(thirdRegion.getId()),
+                1L,
                 // TODO 2차 데모데이 이후 리펙토링 예정
-                "",
-                1L
+                ""
         );
 
         // when & then
@@ -211,12 +186,6 @@ class AuctionServiceTest {
 
         regionRepository.save(firstRegion);
 
-        final CreateRegionDto createRegionDto = new CreateRegionDto(
-                firstRegion.getId(),
-                secondRegion.getId(),
-                thirdRegion.getId()
-        );
-
         final Category main = new Category("main");
         final Category sub = new Category("sub");
 
@@ -229,10 +198,10 @@ class AuctionServiceTest {
                 1_000,
                 1_000,
                 LocalDateTime.now(),
-                List.of(createRegionDto),
+                List.of(thirdRegion.getId()),
+                main.getId(),
                 // TODO 2차 데모데이 이후 리펙토링 예정
-                "",
-                main.getId()
+                ""
         );
 
         // when & then
@@ -253,12 +222,6 @@ class AuctionServiceTest {
 
         regionRepository.save(firstRegion);
 
-        final CreateRegionDto createRegionDto = new CreateRegionDto(
-                firstRegion.getId(),
-                secondRegion.getId(),
-                thirdRegion.getId()
-        );
-
         final Category main = new Category("main");
         final Category sub = new Category("sub");
 
@@ -271,10 +234,10 @@ class AuctionServiceTest {
                 1_000,
                 1_000,
                 LocalDateTime.now(),
-                List.of(createRegionDto),
+                List.of(thirdRegion.getId()),
+                sub.getId(),
                 // TODO 2차 데모데이 이후 리펙토링 예정
-                "",
-                sub.getId()
+                ""
         );
 
         final Long savedAuctionId = auctionService.create(createAuctionDto);
@@ -319,12 +282,6 @@ class AuctionServiceTest {
 
         regionRepository.save(firstRegion);
 
-        final CreateRegionDto createRegionDto = new CreateRegionDto(
-                firstRegion.getId(),
-                secondRegion.getId(),
-                thirdRegion.getId()
-        );
-
         final Category main = new Category("main");
         final Category sub = new Category("sub");
 
@@ -337,10 +294,10 @@ class AuctionServiceTest {
                 1_000,
                 1_000,
                 LocalDateTime.now(),
-                List.of(createRegionDto),
+                List.of(thirdRegion.getId()),
+                sub.getId(),
                 // TODO 2차 데모데이 이후 리펙토링 예정
-                "",
-                sub.getId()
+                ""
         );
 
         final CreateAuctionDto createAuctionDto2 = new CreateAuctionDto(
@@ -349,10 +306,10 @@ class AuctionServiceTest {
                 1_000,
                 1_000,
                 LocalDateTime.now(),
-                List.of(createRegionDto),
+                List.of(thirdRegion.getId()),
+                sub.getId(),
                 // TODO 2차 데모데이 이후 리펙토링 예정
-                "",
-                sub.getId()
+                ""
         );
 
         auctionService.create(createAuctionDto1);
@@ -380,12 +337,6 @@ class AuctionServiceTest {
 
         regionRepository.save(firstRegion);
 
-        final CreateRegionDto createRegionDto = new CreateRegionDto(
-                firstRegion.getId(),
-                secondRegion.getId(),
-                thirdRegion.getId()
-        );
-
         final Category main = new Category("main");
         final Category sub = new Category("sub");
 
@@ -398,10 +349,10 @@ class AuctionServiceTest {
                 1_000,
                 1_000,
                 LocalDateTime.now(),
-                List.of(createRegionDto),
+                List.of(thirdRegion.getId()),
+                sub.getId(),
                 // TODO 2차 데모데이 이후 리펙토링 예정
-                "",
-                sub.getId()
+                ""
         );
 
         final Long savedAuctionId = auctionService.create(createAuctionDto);

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
@@ -348,8 +348,9 @@ class AuctionServiceTest {
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
-            softAssertions.assertThat(actual).hasSize(1);
+            softAssertions.assertThat(actual).hasSize(2);
             softAssertions.assertThat(actual.get(0).title()).isEqualTo(createAuctionDto2.title());
+            softAssertions.assertThat(actual.get(1).title()).isEqualTo(createAuctionDto1.title());
         });
     }
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
@@ -2,6 +2,8 @@ package com.ddang.ddang.auction.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 import com.ddang.ddang.auction.application.dto.CreateAuctionDto;
 import com.ddang.ddang.auction.application.dto.CreateInfoAuctionDto;
@@ -12,6 +14,8 @@ import com.ddang.ddang.auction.infrastructure.persistence.JpaAuctionRepository;
 import com.ddang.ddang.category.application.exception.CategoryNotFoundException;
 import com.ddang.ddang.category.domain.Category;
 import com.ddang.ddang.category.infrastructure.persistence.JpaCategoryRepository;
+import com.ddang.ddang.image.domain.StoreImageProcessor;
+import com.ddang.ddang.image.domain.dto.StoreImageDto;
 import com.ddang.ddang.region.application.exception.RegionNotFoundException;
 import com.ddang.ddang.region.domain.Region;
 import com.ddang.ddang.region.infrastructure.persistence.JpaRegionRepository;
@@ -25,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,6 +39,9 @@ import org.springframework.transaction.annotation.Transactional;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class AuctionServiceTest {
+
+    @MockBean
+    StoreImageProcessor imageProcessor;
 
     @Autowired
     AuctionService auctionService;
@@ -50,6 +58,10 @@ class AuctionServiceTest {
     @Test
     void 경매를_등록한다() {
         // given
+        final StoreImageDto storeImageDto = new StoreImageDto("upload.png", "store.png");
+
+        given(imageProcessor.storeImageFiles(any())).willReturn(List.of(storeImageDto));
+
         final Region firstRegion = new Region("first");
         final Region secondRegion = new Region("second");
         final Region thirdRegion = new Region("third");
@@ -236,6 +248,10 @@ class AuctionServiceTest {
     @Test
     void 지정한_아이디에_해당하는_경매를_조회한다() {
         // given
+        final StoreImageDto storeImageDto = new StoreImageDto("upload.png", "store.png");
+
+        given(imageProcessor.storeImageFiles(any())).willReturn(List.of(storeImageDto));
+
         final Region firstRegion = new Region("first");
         final Region secondRegion = new Region("second");
         final Region thirdRegion = new Region("third");
@@ -300,6 +316,10 @@ class AuctionServiceTest {
     @Test
     void 첫번째_페이지의_경매_목록을_조회한다() {
         // given
+        final StoreImageDto storeImageDto = new StoreImageDto("upload.png", "store.png");
+
+        given(imageProcessor.storeImageFiles(any())).willReturn(List.of(storeImageDto));
+
         final Region firstRegion = new Region("first");
         final Region secondRegion = new Region("second");
         final Region thirdRegion = new Region("third");
@@ -358,6 +378,10 @@ class AuctionServiceTest {
     @Test
     void 지정한_아이디에_해당하는_경매를_삭제한다() {
         // given
+        final StoreImageDto storeImageDto = new StoreImageDto("upload.png", "store.png");
+
+        given(imageProcessor.storeImageFiles(any())).willReturn(List.of(storeImageDto));
+
         final Region firstRegion = new Region("first");
         final Region secondRegion = new Region("second");
         final Region thirdRegion = new Region("third");

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -62,6 +64,11 @@ class AuctionServiceTest {
         main.addSubCategory(sub);
         categoryRepository.save(main);
 
+        final MockMultipartFile auctionImage = new MockMultipartFile(
+                "image.png",
+                "image.png",
+                MediaType.IMAGE_PNG.toString(),
+                new byte[]{1});
         final CreateAuctionDto createAuctionDto = new CreateAuctionDto(
                 "경매 상품 1",
                 "이것은 경매 상품 1 입니다.",
@@ -70,8 +77,7 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(thirdRegion.getId()),
                 sub.getId(),
-                // TODO 2차 데모데이 이후 리펙토링 예정
-                ""
+                List.of(auctionImage)
         );
 
         // when
@@ -90,6 +96,11 @@ class AuctionServiceTest {
         main.addSubCategory(sub);
         categoryRepository.save(main);
 
+        final MockMultipartFile auctionImage = new MockMultipartFile(
+                "image.png",
+                "image.png",
+                MediaType.IMAGE_PNG.toString(),
+                new byte[]{1});
         final CreateAuctionDto createAuctionDto = new CreateAuctionDto(
                 "경매 상품 1",
                 "이것은 경매 상품 1 입니다.",
@@ -98,8 +109,7 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(3L),
                 sub.getId(),
-                // TODO 2차 데모데이 이후 리펙토링 예정
-                ""
+                List.of(auctionImage)
         );
 
         // when & then
@@ -126,6 +136,11 @@ class AuctionServiceTest {
         main.addSubCategory(sub);
         categoryRepository.save(main);
 
+        final MockMultipartFile auctionImage = new MockMultipartFile(
+                "image.png",
+                "image.png",
+                MediaType.IMAGE_PNG.toString(),
+                new byte[]{1});
         final CreateAuctionDto createAuctionDto = new CreateAuctionDto(
                 "경매 상품 1",
                 "이것은 경매 상품 1 입니다.",
@@ -134,8 +149,7 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(secondRegion.getId()),
                 sub.getId(),
-                // TODO 2차 데모데이 이후 리펙토링 예정
-                ""
+                List.of(auctionImage)
         );
 
         // when & then
@@ -156,6 +170,11 @@ class AuctionServiceTest {
 
         regionRepository.save(firstRegion);
 
+        final MockMultipartFile auctionImage = new MockMultipartFile(
+                "image.png",
+                "image.png",
+                MediaType.IMAGE_PNG.toString(),
+                new byte[]{1});
         final CreateAuctionDto createAuctionDto = new CreateAuctionDto(
                 "경매 상품 1",
                 "이것은 경매 상품 1 입니다.",
@@ -164,8 +183,7 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(thirdRegion.getId()),
                 1L,
-                // TODO 2차 데모데이 이후 리펙토링 예정
-                ""
+                List.of(auctionImage)
         );
 
         // when & then
@@ -192,6 +210,11 @@ class AuctionServiceTest {
         main.addSubCategory(sub);
         categoryRepository.save(main);
 
+        final MockMultipartFile auctionImage = new MockMultipartFile(
+                "image.png",
+                "image.png",
+                MediaType.IMAGE_PNG.toString(),
+                new byte[]{1});
         final CreateAuctionDto createAuctionDto = new CreateAuctionDto(
                 "경매 상품 1",
                 "이것은 경매 상품 1 입니다.",
@@ -200,8 +223,7 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(thirdRegion.getId()),
                 main.getId(),
-                // TODO 2차 데모데이 이후 리펙토링 예정
-                ""
+                List.of(auctionImage)
         );
 
         // when & then
@@ -228,6 +250,11 @@ class AuctionServiceTest {
         main.addSubCategory(sub);
         categoryRepository.save(main);
 
+        final MockMultipartFile auctionImage = new MockMultipartFile(
+                "image.png",
+                "image.png",
+                MediaType.IMAGE_PNG.toString(),
+                new byte[]{1});
         final CreateAuctionDto createAuctionDto = new CreateAuctionDto(
                 "경매 상품 1",
                 "이것은 경매 상품 1 입니다.",
@@ -236,8 +263,7 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(thirdRegion.getId()),
                 sub.getId(),
-                // TODO 2차 데모데이 이후 리펙토링 예정
-                ""
+                List.of(auctionImage)
         );
 
         final Long savedAuctionId = auctionService.create(createAuctionDto);
@@ -288,6 +314,11 @@ class AuctionServiceTest {
         main.addSubCategory(sub);
         categoryRepository.save(main);
 
+        final MockMultipartFile auctionImage = new MockMultipartFile(
+                "image.png",
+                "image.png",
+                MediaType.IMAGE_PNG.toString(),
+                new byte[]{1});
         final CreateAuctionDto createAuctionDto1 = new CreateAuctionDto(
                 "경매 상품 1",
                 "이것은 경매 상품 1 입니다.",
@@ -296,10 +327,8 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(thirdRegion.getId()),
                 sub.getId(),
-                // TODO 2차 데모데이 이후 리펙토링 예정
-                ""
+                List.of(auctionImage)
         );
-
         final CreateAuctionDto createAuctionDto2 = new CreateAuctionDto(
                 "경매 상품 2",
                 "이것은 경매 상품 2 입니다.",
@@ -308,8 +337,7 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(thirdRegion.getId()),
                 sub.getId(),
-                // TODO 2차 데모데이 이후 리펙토링 예정
-                ""
+                List.of(auctionImage)
         );
 
         auctionService.create(createAuctionDto1);
@@ -343,6 +371,11 @@ class AuctionServiceTest {
         main.addSubCategory(sub);
         categoryRepository.save(main);
 
+        final MockMultipartFile auctionImage = new MockMultipartFile(
+                "image.png",
+                "image.png",
+                MediaType.IMAGE_PNG.toString(),
+                new byte[]{1});
         final CreateAuctionDto createAuctionDto = new CreateAuctionDto(
                 "경매 상품 1",
                 "이것은 경매 상품 1 입니다.",
@@ -351,8 +384,7 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(thirdRegion.getId()),
                 sub.getId(),
-                // TODO 2차 데모데이 이후 리펙토링 예정
-                ""
+                List.of(auctionImage)
         );
 
         final Long savedAuctionId = auctionService.create(createAuctionDto);

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.given;
 import com.ddang.ddang.auction.application.dto.CreateAuctionDto;
 import com.ddang.ddang.auction.application.dto.CreateInfoAuctionDto;
 import com.ddang.ddang.auction.application.dto.ReadAuctionDto;
+import com.ddang.ddang.auction.application.dto.ReadAuctionsDto;
 import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
 import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.infrastructure.persistence.JpaAuctionRepository;
@@ -365,13 +366,13 @@ class AuctionServiceTest {
         auctionService.create(createAuctionDto2);
 
         // when
-        final List<ReadAuctionDto> actual = auctionService.readAllByLastAuctionId(null, 1);
+        final ReadAuctionsDto actual = auctionService.readAllByLastAuctionId(null, 1);
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
-            softAssertions.assertThat(actual).hasSize(2);
-            softAssertions.assertThat(actual.get(0).title()).isEqualTo(createAuctionDto2.title());
-            softAssertions.assertThat(actual.get(1).title()).isEqualTo(createAuctionDto1.title());
+            final List<ReadAuctionDto> actualReadAuctionDtos = actual.readAuctionDtos();
+            softAssertions.assertThat(actualReadAuctionDtos).hasSize(1);
+            softAssertions.assertThat(actualReadAuctionDtos.get(0).title()).isEqualTo(createAuctionDto2.title());
         });
     }
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/domain/AuctionTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/domain/AuctionTest.java
@@ -61,7 +61,7 @@ class AuctionTest {
         final AuctionImage auctionImage = new AuctionImage("image.png", "image.png");
 
         // when
-        auction.addAuctionImage(auctionImage);
+        auction.addAuctionImages(List.of(auctionImage));
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/domain/AuctionTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/domain/AuctionTest.java
@@ -2,9 +2,11 @@ package com.ddang.ddang.auction.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.ddang.ddang.image.domain.AuctionImage;
 import com.ddang.ddang.region.domain.AuctionRegion;
 import com.ddang.ddang.region.domain.Region;
 import java.util.List;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -48,5 +50,23 @@ class AuctionTest {
 
         // then
         assertThat(auction.getAuctionRegions()).hasSize(1);
+    }
+
+    @Test
+    void 경매_이미지_연관_관계를_세팅한다() {
+        // given
+        final Auction auction = Auction.builder()
+                                       .title("title")
+                                       .build();
+        final AuctionImage auctionImage = new AuctionImage("image.png", "image.png");
+
+        // when
+        auction.addAuctionImage(auctionImage);
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(auction.getAuctionImages()).isNotEmpty();
+            softAssertions.assertThat(auctionImage.getAuction()).isNotNull();
+        });
     }
 }

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImplTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImplTest.java
@@ -15,6 +15,8 @@ import com.ddang.ddang.region.infrastructure.persistence.JpaRegionRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,9 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-
-import java.time.LocalDateTime;
-import java.util.List;
+import org.springframework.data.domain.Slice;
 
 @DataJpaTest
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -163,13 +163,14 @@ class QuerydslAuctionRepositoryImplTest {
         em.clear();
 
         // when
-        final List<Auction> actual = auctionRepository.findAuctionsAllByLastAuctionId(null, 1);
+        final Slice<Auction> actual = auctionRepository.findAuctionsAllByLastAuctionId(null, 1);
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
-            softAssertions.assertThat(actual).hasSize(2);
-            softAssertions.assertThat(actual.get(0).getTitle()).isEqualTo(auction3.getTitle());
-            softAssertions.assertThat(actual.get(1).getTitle()).isEqualTo(auction2.getTitle());
+            softAssertions.assertThat(actual).hasSize(1);
+
+            final List<Auction> actualAuctions = actual.getContent();
+            softAssertions.assertThat(actualAuctions.get(0).getTitle()).isEqualTo(auction3.getTitle());
         });
     }
 
@@ -206,13 +207,14 @@ class QuerydslAuctionRepositoryImplTest {
         em.clear();
 
         // when
-        final List<Auction> actual = auctionRepository.findAuctionsAllByLastAuctionId(auction3.getId(), 1);
+        final Slice<Auction> actual = auctionRepository.findAuctionsAllByLastAuctionId(auction3.getId(), 1);
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
-            softAssertions.assertThat(actual).hasSize(2);
-            softAssertions.assertThat(actual.get(0).getTitle()).isEqualTo(auction2.getTitle());
-            softAssertions.assertThat(actual.get(1).getTitle()).isEqualTo(auction1.getTitle());
+            softAssertions.assertThat(actual).hasSize(1);
+
+            final List<Auction> actualAuctions = actual.getContent();
+            softAssertions.assertThat(actualAuctions.get(0).getTitle()).isEqualTo(auction2.getTitle());
         });
     }
 
@@ -251,12 +253,14 @@ class QuerydslAuctionRepositoryImplTest {
         em.clear();
 
         // when
-        final List<Auction> actual = auctionRepository.findAuctionsAllByLastAuctionId(auction3.getId(), 1);
+        final Slice<Auction> actual = auctionRepository.findAuctionsAllByLastAuctionId(auction3.getId(), 1);
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(actual).hasSize(1);
-            softAssertions.assertThat(actual.get(0).getTitle()).isEqualTo(auction1.getTitle());
+
+            final List<Auction> actualAuctions = actual.getContent();
+            softAssertions.assertThat(actualAuctions.get(0).getTitle()).isEqualTo(auction1.getTitle());
         });
     }
 }

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImplTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImplTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.domain.BidUnit;
 import com.ddang.ddang.auction.domain.Price;
+import com.ddang.ddang.category.domain.Category;
+import com.ddang.ddang.category.infrastructure.persistence.JpaCategoryRepository;
 import com.ddang.ddang.configuration.JpaConfiguration;
 import com.ddang.ddang.configuration.QuerydslConfiguration;
 import com.ddang.ddang.region.domain.AuctionRegion;
@@ -41,6 +43,9 @@ class QuerydslAuctionRepositoryImplTest {
     @Autowired
     JpaRegionRepository regionRepository;
 
+    @Autowired
+    JpaCategoryRepository categoryRepository;
+
     QuerydslAuctionRepository querydslAuctionRepository;
 
     @BeforeEach
@@ -51,6 +56,22 @@ class QuerydslAuctionRepositoryImplTest {
     @Test
     void 지정한_아이디에_대한_경매를_조회한다() {
         // given
+        final Category main = new Category("main");
+        final Category sub = new Category("sub");
+
+        main.addSubCategory(sub);
+
+        categoryRepository.save(main);
+
+        final Auction auction = Auction.builder()
+                                       .title("경매 상품 1")
+                                       .description("이것은 경매 상품 1 입니다.")
+                                       .bidUnit(new BidUnit(1_000))
+                                       .startPrice(new Price(1_000))
+                                       .closingTime(LocalDateTime.now())
+                                       .subCategory(sub)
+                                       .build();
+
         final Region firstRegion = new Region("서울특별시");
         final Region secondRegion = new Region("강남구");
         final Region thirdRegion = new Region("개포1동");
@@ -61,13 +82,6 @@ class QuerydslAuctionRepositoryImplTest {
         regionRepository.save(firstRegion);
         final AuctionRegion auctionRegion = new AuctionRegion(thirdRegion);
 
-        final Auction auction = Auction.builder()
-                                       .title("경매 상품 1")
-                                       .description("이것은 경매 상품 1 입니다.")
-                                       .bidUnit(new BidUnit(1_000))
-                                       .startPrice(new Price(1_000))
-                                       .closingTime(LocalDateTime.now())
-                                       .build();
         auction.addAuctionRegions(List.of(auctionRegion));
 
         auctionRepository.save(auction);
@@ -95,6 +109,12 @@ class QuerydslAuctionRepositoryImplTest {
 
             final Region actualFirstRegion = actualSecondRegion.getFirstRegion();
             softAssertions.assertThat(actualFirstRegion.getName()).isEqualTo(firstRegion.getName());
+
+            final Category subCategory = actual.get().getSubCategory();
+            softAssertions.assertThat(subCategory).isEqualTo(sub);
+
+            final Category mainCategory = subCategory.getMainCategory();
+            softAssertions.assertThat(mainCategory).isEqualTo(main);
         });
     }
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImplTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImplTest.java
@@ -167,8 +167,9 @@ class QuerydslAuctionRepositoryImplTest {
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
-            softAssertions.assertThat(actual).hasSize(1);
+            softAssertions.assertThat(actual).hasSize(2);
             softAssertions.assertThat(actual.get(0).getTitle()).isEqualTo(auction3.getTitle());
+            softAssertions.assertThat(actual.get(1).getTitle()).isEqualTo(auction2.getTitle());
         });
     }
 
@@ -209,8 +210,9 @@ class QuerydslAuctionRepositoryImplTest {
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
-            softAssertions.assertThat(actual).hasSize(1);
+            softAssertions.assertThat(actual).hasSize(2);
             softAssertions.assertThat(actual.get(0).getTitle()).isEqualTo(auction2.getTitle());
+            softAssertions.assertThat(actual.get(1).getTitle()).isEqualTo(auction1.getTitle());
         });
     }
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImplTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImplTest.java
@@ -90,7 +90,7 @@ class QuerydslAuctionRepositoryImplTest {
         em.clear();
 
         // when
-        final Optional<Auction> actual = querydslAuctionRepository.findAuctionWithRegionsById(auction.getId());
+        final Optional<Auction> actual = querydslAuctionRepository.findAuctionById(auction.getId());
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
@@ -124,7 +124,7 @@ class QuerydslAuctionRepositoryImplTest {
         final Long invalidId = -999L;
 
         // when
-        final Optional<Auction> actual = querydslAuctionRepository.findAuctionWithRegionsById(invalidId);
+        final Optional<Auction> actual = querydslAuctionRepository.findAuctionById(invalidId);
 
         // then
         assertThat(actual).isEmpty();

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
@@ -20,7 +20,6 @@ import com.ddang.ddang.auction.application.dto.ReadAuctionDto;
 import com.ddang.ddang.auction.application.dto.ReadRegionDto;
 import com.ddang.ddang.auction.application.dto.ReadRegionsDto;
 import com.ddang.ddang.auction.presentation.dto.request.CreateAuctionRequest;
-import com.ddang.ddang.auction.presentation.dto.request.CreateDirectRegionRequest;
 import com.ddang.ddang.exception.GlobalExceptionHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
@@ -73,8 +72,8 @@ class AuctionControllerTest {
                              .plusDays(3L),
                 2L,
                 // TODO 2차 데모데이 이후 리펙토링 예정
-                List.of(""),
-                List.of(new CreateDirectRegionRequest(1L, 2L, 3L))
+                List.of(3L),
+                List.of("")
         );
 
         given(auctionService.create(any(CreateAuctionDto.class))).willReturn(1L);

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
@@ -19,7 +19,6 @@ import com.ddang.ddang.auction.application.dto.CreateAuctionDto;
 import com.ddang.ddang.auction.application.dto.ReadAuctionDto;
 import com.ddang.ddang.auction.application.dto.ReadRegionDto;
 import com.ddang.ddang.auction.application.dto.ReadRegionsDto;
-import com.ddang.ddang.auction.presentation.dto.request.CreateAuctionCategoryRequest;
 import com.ddang.ddang.auction.presentation.dto.request.CreateAuctionRequest;
 import com.ddang.ddang.auction.presentation.dto.request.CreateDirectRegionRequest;
 import com.ddang.ddang.exception.GlobalExceptionHandler;
@@ -72,10 +71,10 @@ class AuctionControllerTest {
                 1_000,
                 LocalDateTime.now()
                              .plusDays(3L),
+                2L,
                 // TODO 2차 데모데이 이후 리펙토링 예정
                 List.of(""),
-                List.of(new CreateDirectRegionRequest(1L, 2L, 3L)),
-                new CreateAuctionCategoryRequest("", "")
+                List.of(new CreateDirectRegionRequest(1L, 2L, 3L))
         );
 
         given(auctionService.create(any(CreateAuctionDto.class))).willReturn(1L);

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
@@ -18,6 +18,7 @@ import com.ddang.ddang.auction.application.AuctionService;
 import com.ddang.ddang.auction.application.dto.CreateAuctionDto;
 import com.ddang.ddang.auction.application.dto.CreateInfoAuctionDto;
 import com.ddang.ddang.auction.application.dto.ReadAuctionDto;
+import com.ddang.ddang.auction.application.dto.ReadAuctionsDto;
 import com.ddang.ddang.auction.application.dto.ReadRegionDto;
 import com.ddang.ddang.auction.application.dto.ReadRegionsDto;
 import com.ddang.ddang.exception.GlobalExceptionHandler;
@@ -177,7 +178,8 @@ class AuctionControllerTest {
                 "sub2"
         );
 
-        given(auctionService.readAllByLastAuctionId(any(), anyInt())).willReturn(List.of(auction2, auction1));
+        final ReadAuctionsDto readAuctionsDto = new ReadAuctionsDto(List.of(auction2, auction1), true);
+        given(auctionService.readAllByLastAuctionId(any(), anyInt())).willReturn(readAuctionsDto);
 
         // when & then
         mockMvc.perform(get("/auctions").contentType(MediaType.APPLICATION_JSON))

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.ddang.ddang.auction.application.AuctionService;
 import com.ddang.ddang.auction.application.dto.CreateAuctionDto;
+import com.ddang.ddang.auction.application.dto.CreateInfoAuctionDto;
 import com.ddang.ddang.auction.application.dto.ReadAuctionDto;
 import com.ddang.ddang.auction.application.dto.ReadRegionDto;
 import com.ddang.ddang.auction.application.dto.ReadRegionsDto;
@@ -69,8 +70,9 @@ class AuctionControllerTest {
                 MediaType.IMAGE_PNG.toString(),
                 new byte[]{1}
         );
+        final CreateInfoAuctionDto createInfoAuctionDto = new CreateInfoAuctionDto(1L, "title", 1L, 1_000);
 
-        given(auctionService.create(any(CreateAuctionDto.class))).willReturn(1L);
+        given(auctionService.create(any(CreateAuctionDto.class))).willReturn(createInfoAuctionDto);
 
         // when & then
         mockMvc.perform(multipart("/auctions")

--- a/backend/ddang/src/test/java/com/ddang/ddang/category/infrastructure/persistence/JpaCategoryRepositoryTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/category/infrastructure/persistence/JpaCategoryRepositoryTest.java
@@ -1,19 +1,20 @@
 package com.ddang.ddang.category.infrastructure.persistence;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.ddang.ddang.category.domain.Category;
 import com.ddang.ddang.configuration.QuerydslConfiguration;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -69,5 +70,52 @@ class JpaCategoryRepositoryTest {
 
         // then
         assertThat(actual).hasSize(2);
+    }
+
+    @Test
+    void 하위_카테고리를_조회한다() {
+        // given
+        final Category main = new Category("main");
+        final Category sub1 = new Category("sub1");
+        final Category sub2 = new Category("sub2");
+
+        main.addSubCategory(sub1);
+        main.addSubCategory(sub2);
+
+        categoryRepository.save(main);
+
+        em.flush();
+        em.clear();
+
+        // when
+        final Optional<Category> actual = categoryRepository.findSubCategoryById(sub1.getId());
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).isPresent();
+            softAssertions.assertThat(actual.get()).isEqualTo(sub1);
+        });
+    }
+
+    @Test
+    void 하위_카테고리가_아닌_아이디를_전달하면_빈_Optional을_반환한다() {
+        // given
+        final Category main = new Category("main");
+        final Category sub1 = new Category("sub1");
+        final Category sub2 = new Category("sub2");
+
+        main.addSubCategory(sub1);
+        main.addSubCategory(sub2);
+
+        categoryRepository.save(main);
+
+        em.flush();
+        em.clear();
+
+        // when
+        final Optional<Category> actual = categoryRepository.findSubCategoryById(main.getId());
+
+        // then
+        assertThat(actual).isEmpty();
     }
 }

--- a/backend/ddang/src/test/java/com/ddang/ddang/image/application/ImageServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/image/application/ImageServiceTest.java
@@ -1,0 +1,54 @@
+package com.ddang.ddang.image.application;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ddang.ddang.image.application.exception.ImageNotFoundException;
+import com.ddang.ddang.image.domain.AuctionImage;
+import com.ddang.ddang.image.infrastructure.persistence.JpaAuctionImageRepository;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.Resource;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ImageServiceTest {
+
+    @Autowired
+    ImageService imageService;
+
+    @Autowired
+    JpaAuctionImageRepository auctionImageRepository;
+
+    @Test
+    void 지정한_아이디에_해당하는_경매_이미지를_조회한다() throws Exception {
+        // given
+        final AuctionImage auctionImage = new AuctionImage("image.png", "image.png");
+
+        auctionImageRepository.save(auctionImage);
+
+        // when
+        final Resource actual = imageService.readAuctionImage(auctionImage.getId());
+
+        // then
+        assertThat(actual.getFilename()).isEqualTo("image.png");
+    }
+
+    @Test
+    void 지정한_아이디에_해당하는_경매_이미지가_없는_경우_예외가_발생한다() {
+        // given
+        final Long invalidAuctionImageId = -999L;
+
+        // when & then
+        assertThatThrownBy(() -> imageService.readAuctionImage(invalidAuctionImageId))
+                .isInstanceOf(ImageNotFoundException.class)
+                .hasMessage("지정한 이미지를 찾을 수 없습니다.");
+    }
+}

--- a/backend/ddang/src/test/java/com/ddang/ddang/image/domain/AuctionImageTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/image/domain/AuctionImageTest.java
@@ -1,0 +1,28 @@
+package com.ddang.ddang.image.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ddang.ddang.auction.domain.Auction;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AuctionImageTest {
+
+    @Test
+    void 경매_연관_관계를_세팅한다() {
+        // given
+        final AuctionImage auctionImage = new AuctionImage("image.png", "image.png");
+        final Auction auction = Auction.builder()
+                                       .title("title")
+                                       .build();
+
+        // when
+        auctionImage.initAuction(auction);
+
+        // then
+        assertThat(auctionImage.getAuction()).isNotNull();
+    }
+}

--- a/backend/ddang/src/test/java/com/ddang/ddang/image/infrastructure/local/LocalStoreImageProcessorTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/image/infrastructure/local/LocalStoreImageProcessorTest.java
@@ -1,0 +1,87 @@
+package com.ddang.ddang.image.infrastructure.local;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+
+import com.ddang.ddang.image.domain.dto.StoreImageDto;
+import com.ddang.ddang.image.infrastructure.local.exception.EmptyImageException;
+import com.ddang.ddang.image.infrastructure.local.exception.StoreImageException;
+import com.ddang.ddang.image.infrastructure.local.exception.UnsupportedImageFileExtensionException;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class LocalStoreImageProcessorTest {
+
+    LocalStoreImageProcessor imageProcessor = new LocalStoreImageProcessor();
+
+    @Test
+    void 이미지_파일이_비어_있는_경우_예외가_발생한다() {
+        // given
+        final MockMultipartFile imageFile = new MockMultipartFile("image.png", new byte[0]);
+
+        // when & then
+        assertThatThrownBy(() -> imageProcessor.storeImageFiles(List.of(imageFile)))
+                .isInstanceOf(EmptyImageException.class)
+                .hasMessage("이미지 파일의 데이터가 비어 있습니다.");
+    }
+
+    @Test
+    void 이미지_저장에_실패한_경우_예외가_발생한다() throws Exception {
+        // given
+        final MultipartFile imageFile = mock(MultipartFile.class);
+
+        given(imageFile.getOriginalFilename()).willReturn("image.png");
+        willThrow(IOException.class).given(imageFile).transferTo(any(File.class));
+
+        // when & then
+        assertThatThrownBy(() -> imageProcessor.storeImageFiles(List.of(imageFile)))
+                .isInstanceOf(StoreImageException.class)
+                .hasMessage("이미지 저장에 실패했습니다.");
+    }
+
+    @Test
+    void 허용되지_않은_확장자의_이미지_파일인_경우_예외가_발생한다() {
+        // given
+        final MultipartFile imageFile = mock(MultipartFile.class);
+
+        given(imageFile.getOriginalFilename()).willReturn("image.gif");
+
+        // when & then
+        assertThatThrownBy(() -> imageProcessor.storeImageFiles(List.of(imageFile)))
+                .isInstanceOf(UnsupportedImageFileExtensionException.class)
+                .hasMessageContaining("지원하지 않는 확장자입니다.");
+    }
+
+    @Test
+    void 유효한_이미지_파일인_경우_이미지_파일을_저장한다() throws Exception {
+        // given
+        final MultipartFile imageFile = mock(MultipartFile.class);
+        final String imageFileName = "image.png";
+
+        given(imageFile.getOriginalFilename()).willReturn(imageFileName);
+        willDoNothing().given(imageFile).transferTo(any(File.class));
+
+        // when
+        final List<StoreImageDto> actual = imageProcessor.storeImageFiles(List.of(imageFile));
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).hasSize(1);
+            softAssertions.assertThat(actual.get(0).storeName()).isNotBlank();
+            softAssertions.assertThat(actual.get(0).uploadName()).isEqualTo(imageFileName);
+        });
+    }
+}

--- a/backend/ddang/src/test/java/com/ddang/ddang/image/infrastructure/persistence/JpaAuctionImageRepositoryTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/image/infrastructure/persistence/JpaAuctionImageRepositoryTest.java
@@ -1,0 +1,61 @@
+package com.ddang.ddang.image.infrastructure.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ddang.ddang.configuration.QuerydslConfiguration;
+import com.ddang.ddang.image.domain.AuctionImage;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.Optional;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@Import(QuerydslConfiguration.class)
+class JpaAuctionImageRepositoryTest {
+
+    @PersistenceContext
+    EntityManager em;
+
+    @Autowired
+    JpaAuctionImageRepository auctionImageRepository;
+
+    @Test
+    void 지정한_아이디에_해당하는_경매_이미지를_조회한다() {
+        // given
+        final AuctionImage auctionImage = new AuctionImage("uploadName", "storeName");
+
+        auctionImageRepository.save(auctionImage);
+
+        em.flush();
+        em.clear();
+
+        // when
+        final Optional<AuctionImage> actual = auctionImageRepository.findById(auctionImage.getId());
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).isPresent();
+            softAssertions.assertThat(actual.get()).isEqualTo(auctionImage);
+        });
+    }
+
+    @Test
+    void 지정한_아이디에_해당하는_경매_이미지가_없는_경우_빈_Optional을_반환한다() {
+        // given
+        final Long invalidAuctionImageId = -999L;
+
+        // when
+        final Optional<AuctionImage> actual = auctionImageRepository.findById(invalidAuctionImageId);
+
+        // then
+        assertThat(actual).isEmpty();
+    }
+}

--- a/backend/ddang/src/test/java/com/ddang/ddang/image/presentation/ImageControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/image/presentation/ImageControllerTest.java
@@ -1,0 +1,56 @@
+package com.ddang.ddang.image.presentation;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ddang.ddang.image.application.ImageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@WebMvcTest(controllers = ImageController.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ImageControllerTest {
+
+    @MockBean
+    ImageService imageService;
+
+    @Autowired
+    ImageController imageController;
+
+    MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(imageController)
+                                 .alwaysDo(print())
+                                 .build();
+    }
+
+    @Test
+    void 지정한_아이디에_대한_경매_이미지를_조회한다() throws Exception {
+        final byte[] imageBytes = "이것은 이미지 파일의 바이트 코드입니다.".getBytes();
+        final Resource mockResource = new ByteArrayResource(imageBytes);
+
+        when(imageService.readAuctionImage(anyLong())).thenReturn(mockResource);
+
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/auctions/images/{id}", 1L))
+               .andExpect(status().isOk())
+               .andExpect(content().contentType(MediaType.IMAGE_PNG))
+               .andExpect(content().bytes(imageBytes));
+    }
+}

--- a/backend/ddang/src/test/resources/application.yml
+++ b/backend/ddang/src/test/resources/application.yml
@@ -23,3 +23,7 @@ open:
     region:
       service: service_secret
       key: key_secret
+
+image:
+  store:
+    dir: ./


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->

- 경매 이미지 엔티티, 카테고리 엔티티, 경매 엔티티 연동
  - 연동 과정 중 컴파일 에러가 발생하는 프로덕션, 테스트 영역 코드 리펙토링
- API 명세 변경에 따른 프로덕션, 테스트 영역 코드 리펙토링

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

- QuerydslSliceHelper
  - No-Offset 기반 목록 조회 시 반환 타입을 List에서 Slice로 변경하는 역할
- QuerydslAuctionRepositoryImpl.findAuctionsAllByLastAuctionId
  - List 대신 Slice 반환
  - Region, Category fetch join
- QuerydslAuctionRepositoryImpl.findAuctionWithRegionsById
  - Region, Category fetch join
- StoreImageProcessor
  - 이미지를 저장하는 것 자체는 도메인 기능이라고 판단, 인터페이스로 분리
  - 실제 로컬에 데이터를 저장하는 기능을 수행하는 대상은 LocalStoreImageProcessor
- AuctionImage 관련 테스트 코드

[디스커션 링크](https://github.com/woowacourse-teams/2023-3-ddang/discussions/150) 참고

---

고민 사항이 있는데, ImageConfiguration입니다.
여기서 MultipartResolver로 StandardServletMultipartResolver를 명시적으로 지정을 해 줬습니다.
MultipartFile 설정 등록하면서 그냥 명시적으로 해주는게 좋겠다 싶어서 이렇게 했는데, 사실 multipart/form-data로 요청 오면은 스프링 부트가 알아서 StandardServletMultipartResolver로 요청을 파싱하게 됩니다.
그래서 사실 명시할 필요는 없어서...이걸 명시할지 삭제할지 다른 분들의 생각이 궁금합니다

---

테스트와 문서화는 별도의 이슈를 등록해서 진행하도록 하겠습니다...

## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

- closed #140 

<!-- closed #번호 --> 
