### PR TITLE
채팅 전송 API 추가

### DIFF
--- a/backend/ddang/src/main/java/com/ddang/ddang/bid/application/BidService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/bid/application/BidService.java
@@ -7,6 +7,7 @@ import com.ddang.ddang.auction.domain.exception.InvalidPriceValueException;
 import com.ddang.ddang.auction.infrastructure.persistence.JpaAuctionRepository;
 import com.ddang.ddang.bid.application.dto.CreateBidDto;
 import com.ddang.ddang.bid.application.dto.LoginUserDto;
+import com.ddang.ddang.bid.application.dto.ReadBidDto;
 import com.ddang.ddang.bid.application.exception.InvalidAuctionToBidException;
 import com.ddang.ddang.bid.application.exception.InvalidBidPriceException;
 import com.ddang.ddang.bid.application.exception.InvalidBidderException;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -105,5 +107,17 @@ public class BidService {
         } catch (final InvalidPriceValueException ex) {
             throw new InvalidBidPriceException("입찰 금액이 잘못되었습니다");
         }
+    }
+
+    public List<ReadBidDto> readAllByAuctionId(final Long auctionId) {
+        if (auctionRepository.existsById(auctionId)) {
+            final List<Bid> bids = bidRepository.findByAuctionId(auctionId);
+
+            return bids.stream()
+                       .map(ReadBidDto::from)
+                       .toList();
+        }
+
+        throw new AuctionNotFoundException("해당 경매를 찾을 수 없습니다.");
     }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/bid/application/dto/CreateBidDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/bid/application/dto/CreateBidDto.java
@@ -3,7 +3,7 @@ package com.ddang.ddang.bid.application.dto;
 import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.domain.Price;
 import com.ddang.ddang.bid.domain.Bid;
-import com.ddang.ddang.bid.presentation.dto.CreateBidRequest;
+import com.ddang.ddang.bid.presentation.dto.request.CreateBidRequest;
 import com.ddang.ddang.user.domain.User;
 
 public record CreateBidDto(Long auctionId, int price) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/bid/application/dto/LoginUserDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/bid/application/dto/LoginUserDto.java
@@ -1,6 +1,6 @@
 package com.ddang.ddang.bid.application.dto;
 
-import com.ddang.ddang.bid.presentation.dto.LoginUserRequest;
+import com.ddang.ddang.bid.presentation.dto.request.LoginUserRequest;
 
 public record LoginUserDto(Long usedId) {
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/bid/application/dto/ReadBidDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/bid/application/dto/ReadBidDto.java
@@ -1,0 +1,25 @@
+package com.ddang.ddang.bid.application.dto;
+
+import com.ddang.ddang.bid.domain.Bid;
+import com.ddang.ddang.user.domain.User;
+
+import java.time.LocalDateTime;
+
+public record ReadBidDto(
+        String name,
+        String profileImage,
+        int price,
+        LocalDateTime bidTime
+) {
+
+    public static ReadBidDto from(final Bid bid) {
+        final User bidder = bid.getBidder();
+
+        return new ReadBidDto(
+                bidder.getName(),
+                bidder.getProfileImage(),
+                bid.getPrice().getValue(),
+                bid.getCreatedTime()
+        );
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/bid/presentation/BidController.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/bid/presentation/BidController.java
@@ -3,18 +3,24 @@ package com.ddang.ddang.bid.presentation;
 import com.ddang.ddang.bid.application.BidService;
 import com.ddang.ddang.bid.application.dto.CreateBidDto;
 import com.ddang.ddang.bid.application.dto.LoginUserDto;
-import com.ddang.ddang.bid.presentation.dto.CreateBidRequest;
-import com.ddang.ddang.bid.presentation.dto.LoginUserRequest;
+import com.ddang.ddang.bid.application.dto.ReadBidDto;
+import com.ddang.ddang.bid.presentation.dto.request.CreateBidRequest;
+import com.ddang.ddang.bid.presentation.dto.request.LoginUserRequest;
+import com.ddang.ddang.bid.presentation.dto.response.ReadBidResponse;
+import com.ddang.ddang.bid.presentation.dto.response.ReadBidsResponse;
 import com.ddang.ddang.bid.presentation.resolver.LoginUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/bids")
@@ -32,5 +38,17 @@ public class BidController {
 
         return ResponseEntity.created(URI.create("/auctions/" + bidRequest.auctionId()))
                              .build();
+    }
+
+    @GetMapping("/{auctionId}")
+    private ResponseEntity<ReadBidsResponse> readAllByAuctionId(@PathVariable final Long auctionId) {
+        final List<ReadBidDto> readBidDtos = bidService.readAllByAuctionId(auctionId);
+        final List<ReadBidResponse> readBidResponses = readBidDtos.stream()
+                                                                  .map(ReadBidResponse::from)
+                                                                  .toList();
+
+        final ReadBidsResponse response = new ReadBidsResponse(readBidResponses);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/bid/presentation/dto/LoginUserRequest.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/bid/presentation/dto/LoginUserRequest.java
@@ -1,4 +1,0 @@
-package com.ddang.ddang.bid.presentation.dto;
-
-public record LoginUserRequest(Long userId) {
-}

--- a/backend/ddang/src/main/java/com/ddang/ddang/bid/presentation/dto/request/CreateBidRequest.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/bid/presentation/dto/request/CreateBidRequest.java
@@ -1,4 +1,4 @@
-package com.ddang.ddang.bid.presentation.dto;
+package com.ddang.ddang.bid.presentation.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;

--- a/backend/ddang/src/main/java/com/ddang/ddang/bid/presentation/dto/request/LoginUserRequest.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/bid/presentation/dto/request/LoginUserRequest.java
@@ -1,0 +1,4 @@
+package com.ddang.ddang.bid.presentation.dto.request;
+
+public record LoginUserRequest(Long userId) {
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/bid/presentation/dto/response/ReadBidResponse.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/bid/presentation/dto/response/ReadBidResponse.java
@@ -1,0 +1,20 @@
+package com.ddang.ddang.bid.presentation.dto.response;
+
+import com.ddang.ddang.bid.application.dto.ReadBidDto;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record ReadBidResponse(
+        String name,
+        String profileImage,
+        int price,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+        LocalDateTime bidTime
+) {
+
+    public static ReadBidResponse from(final ReadBidDto dto) {
+        return new ReadBidResponse(dto.name(), dto.profileImage(), dto.price(), dto.bidTime());
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/bid/presentation/dto/response/ReadBidsResponse.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/bid/presentation/dto/response/ReadBidsResponse.java
@@ -1,0 +1,6 @@
+package com.ddang.ddang.bid.presentation.dto.response;
+
+import java.util.List;
+
+public record ReadBidsResponse(List<ReadBidResponse> bids) {
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/bid/presentation/resolver/LoginUserArgumentResolver.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/bid/presentation/resolver/LoginUserArgumentResolver.java
@@ -1,6 +1,6 @@
 package com.ddang.ddang.bid.presentation.resolver;
 
-import com.ddang.ddang.bid.presentation.dto.LoginUserRequest;
+import com.ddang.ddang.bid.presentation.dto.request.LoginUserRequest;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.support.WebDataBinderFactory;

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/application/MessageService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/application/MessageService.java
@@ -1,0 +1,47 @@
+package com.ddang.ddang.chat.application;
+
+import com.ddang.ddang.chat.application.dto.CreateMessageDto;
+import com.ddang.ddang.chat.application.exception.ChatRoomNotFoundException;
+import com.ddang.ddang.chat.application.exception.UserNotFoundException;
+import com.ddang.ddang.chat.domain.ChatRoom;
+import com.ddang.ddang.chat.domain.Message;
+import com.ddang.ddang.chat.infrastructure.persistence.JpaChatRoomRepository;
+import com.ddang.ddang.chat.infrastructure.persistence.JpaMessageRepository;
+import com.ddang.ddang.user.domain.User;
+import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MessageService {
+
+    private final JpaMessageRepository messageRepository;
+    private final JpaChatRoomRepository chatRoomRepository;
+    private final JpaUserRepository userRepository;
+
+    @Transactional
+    public Long create(final CreateMessageDto dto) {
+        final ChatRoom chatRoom = getChatRoom(dto);
+        final User writer = getUser(dto.writerId(), "지정한 아이디에 대한 발신자를 찾을 수 없습니다.");
+        final User receiver = getUser(dto.receiverId(), "지정한 아이디에 대한 수신자를 찾을 수 없습니다.");
+        final Message message = dto.toEntity(chatRoom, writer, receiver);
+
+        return messageRepository.save(message)
+                .getId();
+    }
+
+    private User getUser(final Long dto, final String message) {
+        return userRepository.findById(dto)
+                .orElseThrow(() -> new UserNotFoundException(message));
+    }
+
+    private ChatRoom getChatRoom(final CreateMessageDto dto) {
+        return chatRoomRepository.findById(dto.chatRoomId())
+                .orElseThrow(() -> new ChatRoomNotFoundException(
+                        "지정한 아이디에 대한 채팅방을 찾을 수 없습니다."
+                ));
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/application/MessageService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/application/MessageService.java
@@ -30,18 +30,18 @@ public class MessageService {
         final Message message = dto.toEntity(chatRoom, writer, receiver);
 
         return messageRepository.save(message)
-                .getId();
+                                .getId();
     }
 
     private User getUser(final Long dto, final String message) {
         return userRepository.findById(dto)
-                .orElseThrow(() -> new UserNotFoundException(message));
+                             .orElseThrow(() -> new UserNotFoundException(message));
     }
 
     private ChatRoom getChatRoom(final CreateMessageDto dto) {
         return chatRoomRepository.findById(dto.chatRoomId())
-                .orElseThrow(() -> new ChatRoomNotFoundException(
-                        "지정한 아이디에 대한 채팅방을 찾을 수 없습니다."
-                ));
+                                 .orElseThrow(() -> new ChatRoomNotFoundException(
+                                         "지정한 아이디에 대한 채팅방을 찾을 수 없습니다."
+                                 ));
     }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/application/MessageService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/application/MessageService.java
@@ -33,15 +33,15 @@ public class MessageService {
                                 .getId();
     }
 
-    private User getUser(final Long dto, final String message) {
-        return userRepository.findById(dto)
-                             .orElseThrow(() -> new UserNotFoundException(message));
-    }
-
     private ChatRoom getChatRoom(final CreateMessageDto dto) {
         return chatRoomRepository.findById(dto.chatRoomId())
                                  .orElseThrow(() -> new ChatRoomNotFoundException(
                                          "지정한 아이디에 대한 채팅방을 찾을 수 없습니다."
                                  ));
+    }
+
+    private User getUser(final Long dto, final String message) {
+        return userRepository.findById(dto)
+                             .orElseThrow(() -> new UserNotFoundException(message));
     }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/application/dto/CreateMessageDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/application/dto/CreateMessageDto.java
@@ -12,7 +12,7 @@ public record CreateMessageDto(
         String contents
 ) {
 
-    public CreateMessageDto from(final CreateMessageRequest request) {
+    public static CreateMessageDto from(final CreateMessageRequest request) {
         return new CreateMessageDto(
                 request.chatRoomId(),
                 request.writerId(),

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/application/dto/CreateMessageDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/application/dto/CreateMessageDto.java
@@ -1,0 +1,36 @@
+package com.ddang.ddang.chat.application.dto;
+
+import com.ddang.ddang.chat.domain.ChatRoom;
+import com.ddang.ddang.chat.domain.Message;
+import com.ddang.ddang.chat.presentation.dto.CreateMessageRequest;
+import com.ddang.ddang.user.domain.User;
+
+public record CreateMessageDto(
+        Long chatRoomId,
+        Long writerId,
+        Long receiverId,
+        String contents
+) {
+
+    public CreateMessageDto from(final CreateMessageRequest request) {
+        return new CreateMessageDto(
+                request.chatRoomId(),
+                request.writerId(),
+                request.receiverId(),
+                request.contents()
+        );
+    }
+
+    public Message toEntity(
+            final ChatRoom chatRoom,
+            final User writer,
+            final User receiver
+    ) {
+        return Message.builder()
+                .chatRoom(chatRoom)
+                .writer(writer)
+                .receiver(receiver)
+                .contents(contents)
+                .build();
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/application/dto/CreateMessageDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/application/dto/CreateMessageDto.java
@@ -27,10 +27,10 @@ public record CreateMessageDto(
             final User receiver
     ) {
         return Message.builder()
-                .chatRoom(chatRoom)
-                .writer(writer)
-                .receiver(receiver)
-                .contents(contents)
-                .build();
+                      .chatRoom(chatRoom)
+                      .writer(writer)
+                      .receiver(receiver)
+                      .contents(contents)
+                      .build();
     }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/application/dto/CreateMessageDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/application/dto/CreateMessageDto.java
@@ -12,9 +12,9 @@ public record CreateMessageDto(
         String contents
 ) {
 
-    public static CreateMessageDto from(final CreateMessageRequest request) {
+    public static CreateMessageDto from(final Long chatRoomId, final CreateMessageRequest request) {
         return new CreateMessageDto(
-                request.chatRoomId(),
+                chatRoomId,
                 request.writerId(),
                 request.receiverId(),
                 request.contents()

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/application/exception/ChatRoomNotFoundException.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/application/exception/ChatRoomNotFoundException.java
@@ -1,0 +1,7 @@
+package com.ddang.ddang.chat.application.exception;
+
+public class ChatRoomNotFoundException extends IllegalArgumentException {
+    public ChatRoomNotFoundException(final String message) {
+        super(message);
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/application/exception/ChatRoomNotFoundException.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/application/exception/ChatRoomNotFoundException.java
@@ -1,6 +1,7 @@
 package com.ddang.ddang.chat.application.exception;
 
 public class ChatRoomNotFoundException extends IllegalArgumentException {
+
     public ChatRoomNotFoundException(final String message) {
         super(message);
     }

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/application/exception/UserNotFoundException.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/application/exception/UserNotFoundException.java
@@ -1,0 +1,8 @@
+package com.ddang.ddang.chat.application.exception;
+
+public class UserNotFoundException extends IllegalArgumentException {
+
+    public UserNotFoundException(final String message) {
+        super(message);
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/presentation/ChatRoomController.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/presentation/ChatRoomController.java
@@ -1,0 +1,36 @@
+package com.ddang.ddang.chat.presentation;
+
+import com.ddang.ddang.chat.application.MessageService;
+import com.ddang.ddang.chat.application.dto.CreateMessageDto;
+import com.ddang.ddang.chat.presentation.dto.CreateMessageRequest;
+import com.ddang.ddang.chat.presentation.dto.CreateMessageResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/chattings")
+@RequiredArgsConstructor
+public class ChatRoomController {
+
+    private final MessageService messageService;
+
+    @PostMapping("/{chatRoomId}/messages")
+    public ResponseEntity<CreateMessageResponse> create(
+            @PathVariable final Long chatRoomId,
+            @RequestBody @Valid final CreateMessageRequest request
+    ) {
+        final Long messageId = messageService.create(CreateMessageDto.from(request));
+        final CreateMessageResponse response = new CreateMessageResponse(messageId);
+
+        return ResponseEntity.created(URI.create("/chattings/" + chatRoomId + "/messages/" + messageId))
+                             .body(response);
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/presentation/ChatRoomController.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/presentation/ChatRoomController.java
@@ -27,7 +27,7 @@ public class ChatRoomController {
             @PathVariable final Long chatRoomId,
             @RequestBody @Valid final CreateMessageRequest request
     ) {
-        final Long messageId = messageService.create(CreateMessageDto.from(request));
+        final Long messageId = messageService.create(CreateMessageDto.from(chatRoomId, request));
         final CreateMessageResponse response = new CreateMessageResponse(messageId);
 
         return ResponseEntity.created(URI.create("/chattings/" + chatRoomId + "/messages/" + messageId))

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/presentation/dto/CreateMessageRequest.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/presentation/dto/CreateMessageRequest.java
@@ -5,8 +5,10 @@ import jakarta.validation.constraints.NotNull;
 public record CreateMessageRequest(
         @NotNull(message = "메시지 발신자 아이디가 입력되지 않았습니다.")
         Long writerId,
+
         @NotNull(message = "메시지 수신자 아이디가 입력되지 않았습니다.")
         Long receiverId,
+
         @NotNull(message = "메시지 내용이 입력되지 않았습니다.")
         String contents
 ) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/presentation/dto/CreateMessageRequest.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/presentation/dto/CreateMessageRequest.java
@@ -3,8 +3,6 @@ package com.ddang.ddang.chat.presentation.dto;
 import jakarta.validation.constraints.NotNull;
 
 public record CreateMessageRequest(
-        @NotNull(message = "채팅방 아이디가 입력되지 않았습니다.")
-        Long chatRoomId,
         @NotNull(message = "메시지 발신자 아이디가 입력되지 않았습니다.")
         Long writerId,
         @NotNull(message = "메시지 수신자 아이디가 입력되지 않았습니다.")

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/presentation/dto/CreateMessageRequest.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/presentation/dto/CreateMessageRequest.java
@@ -1,0 +1,17 @@
+package com.ddang.ddang.chat.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CreateMessageRequest(
+        @NotNull(message = "경매 아이디가 입력되지 않았습니다.")
+        Long auctionId,
+        @NotNull(message = "채팅방 아이디가 입력되지 않았습니다.")
+        Long chatRoomId,
+        @NotNull(message = "메시지 발신자 아이디가 입력되지 않았습니다.")
+        Long writerId,
+        @NotNull(message = "메시지 수신자 아이디가 입력되지 않았습니다.")
+        Long receiverId,
+        @NotNull(message = "메시지 내용이 입력되지 않았습니다.")
+        String contents
+) {
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/presentation/dto/CreateMessageRequest.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/presentation/dto/CreateMessageRequest.java
@@ -3,8 +3,6 @@ package com.ddang.ddang.chat.presentation.dto;
 import jakarta.validation.constraints.NotNull;
 
 public record CreateMessageRequest(
-        @NotNull(message = "경매 아이디가 입력되지 않았습니다.")
-        Long auctionId,
         @NotNull(message = "채팅방 아이디가 입력되지 않았습니다.")
         Long chatRoomId,
         @NotNull(message = "메시지 발신자 아이디가 입력되지 않았습니다.")

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/presentation/dto/CreateMessageResponse.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/presentation/dto/CreateMessageResponse.java
@@ -1,0 +1,4 @@
+package com.ddang.ddang.chat.presentation.dto;
+
+public record CreateMessageResponse(Long id) {
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/configuration/ImageConfiguration.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/configuration/ImageConfiguration.java
@@ -14,7 +14,6 @@ public class ImageConfiguration {
     private static final long MAXIMUM_FILE_SIZE = 10L;
     private static final long MAXIMUM_REQUEST_SIZE = 110L;
 
-    @Bean
     public MultipartConfigElement multipartConfigElement() {
         MultipartConfigFactory factory = new MultipartConfigFactory();
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/exception/GlobalExceptionHandler.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/exception/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.ddang.ddang.exception;
 
 import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
-import com.ddang.ddang.bid.application.exception.InvalidBidException;
 import com.ddang.ddang.category.application.exception.CategoryNotFoundException;
 import com.ddang.ddang.chat.application.exception.ChatRoomNotFoundException;
 import com.ddang.ddang.chat.application.exception.UserNotFoundException;
@@ -66,9 +65,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ExceptionResponse> handleUserNotFoundException(final UserNotFoundException ex) {
         logger.warn(String.format(EXCEPTION_FORMAT, UserNotFoundException.class), ex);
-      
-         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                         .body(new ExceptionResponse(ex.getMessage()));
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                             .body(new ExceptionResponse(ex.getMessage()));
     }
 
     @ExceptionHandler(AuctionNotFoundException.class)
@@ -95,13 +94,5 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(message));
-    }
-
-    @ExceptionHandler(InvalidBidException.class)
-    public ResponseEntity<ExceptionResponse> handleInvalidBidException(final InvalidBidException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, InvalidBidException.class), ex);
-
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                             .body(new ExceptionResponse(ex.getMessage()));
     }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/exception/GlobalExceptionHandler.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.ddang.ddang.exception;
 
 import com.ddang.ddang.category.application.exception.CategoryNotFoundException;
+import com.ddang.ddang.chat.application.exception.ChatRoomNotFoundException;
+import com.ddang.ddang.chat.application.exception.UserNotFoundException;
 import com.ddang.ddang.exception.dto.ExceptionResponse;
 import com.ddang.ddang.region.application.exception.RegionNotFoundException;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
@@ -46,6 +48,22 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(RegionNotFoundException.class)
     public ResponseEntity<ExceptionResponse> handleRegionNotFoundException(final RegionNotFoundException ex) {
         logger.warn(String.format(EXCEPTION_FORMAT, RegionNotFoundException.class), ex);
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                             .body(new ExceptionResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(ChatRoomNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleChatRoomNotFoundException(final ChatRoomNotFoundException ex) {
+        logger.warn(String.format(EXCEPTION_FORMAT, ChatRoomNotFoundException.class), ex);
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                             .body(new ExceptionResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleUserNotFoundException(final UserNotFoundException ex) {
+        logger.warn(String.format(EXCEPTION_FORMAT, UserNotFoundException.class), ex);
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                              .body(new ExceptionResponse(ex.getMessage()));

--- a/backend/ddang/src/main/java/com/ddang/ddang/exception/GlobalExceptionHandler.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.ddang.ddang.exception;
 
 import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
+import com.ddang.ddang.bid.application.exception.InvalidBidException;
 import com.ddang.ddang.category.application.exception.CategoryNotFoundException;
 import com.ddang.ddang.chat.application.exception.ChatRoomNotFoundException;
 import com.ddang.ddang.chat.application.exception.UserNotFoundException;
@@ -75,6 +76,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         logger.warn(String.format(EXCEPTION_FORMAT, AuctionNotFoundException.class), ex);
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                             .body(new ExceptionResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidBidException.class)
+    public ResponseEntity<ExceptionResponse> handleInvalidBidException(final InvalidBidException ex) {
+        logger.warn(String.format(EXCEPTION_FORMAT, InvalidBidException.class), ex);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(ex.getMessage()));
     }
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/bid/application/BidServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/bid/application/BidServiceTest.java
@@ -7,12 +7,14 @@ import com.ddang.ddang.auction.domain.Price;
 import com.ddang.ddang.auction.infrastructure.persistence.JpaAuctionRepository;
 import com.ddang.ddang.bid.application.dto.CreateBidDto;
 import com.ddang.ddang.bid.application.dto.LoginUserDto;
+import com.ddang.ddang.bid.application.dto.ReadBidDto;
 import com.ddang.ddang.bid.application.exception.InvalidAuctionToBidException;
 import com.ddang.ddang.bid.application.exception.InvalidBidPriceException;
 import com.ddang.ddang.bid.application.exception.InvalidBidderException;
 import com.ddang.ddang.bid.application.exception.UserNotFoundException;
 import com.ddang.ddang.user.domain.User;
 import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import org.assertj.core.api.*;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -23,6 +25,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -126,7 +129,7 @@ class BidServiceTest {
     @Test
     void 존재하지_않는_경매에_입찰하는_경우_예외가_발생한다() {
         // given
-        final long invaliAuctionId = -9999L;
+        final Long invaliAuctionId = -9999L;
 
         final User user = new User("사용자1", "이미지1", 4.9);
         userRepository.save(user);
@@ -143,7 +146,7 @@ class BidServiceTest {
     @Test
     void 존재하지_않는_사용자가_경매에_입찰하는_경우_예외가_발생한다() {
         // given
-        final long invalidUserId = -9999L;
+        final Long invalidUserId = -9999L;
 
         final Auction auction = Auction.builder()
                                        .title("경매 상품 1")
@@ -378,5 +381,85 @@ class BidServiceTest {
         assertThatThrownBy(() -> bidService.create(loginUserDto, createBidDto))
                 .isInstanceOf(InvalidBidPriceException.class)
                 .hasMessage("입찰 금액이 잘못되었습니다");
+    }
+
+    @Test
+    void 특정_경매에_대한_입찰_목록을_조회한다() {
+        // given
+        final Auction auction1 = Auction.builder()
+                                        .title("경매 상품 1")
+                                        .description("이것은 경매 상품 1 입니다.")
+                                        .bidUnit(new BidUnit(1_000))
+                                        .startPrice(new Price(1_000))
+                                        .closingTime(LocalDateTime.now().plusDays(7))
+                                        .build();
+        final Auction auction2 = Auction.builder()
+                                        .title("경매 상품 2")
+                                        .description("이것은 경매 상품 2 입니다.")
+                                        .bidUnit(new BidUnit(1_000))
+                                        .startPrice(new Price(1_000))
+                                        .closingTime(LocalDateTime.now().plusDays(7))
+                                        .build();
+        final User user1 = new User("사용자1", "이미지1", 4.9);
+        final User user2 = new User("사용자2", "이미지2", 4.9);
+
+        auctionRepository.save(auction1);
+        auctionRepository.save(auction2);
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        final LoginUserDto loginUserDto1 = new LoginUserDto(user1.getId());
+        final CreateBidDto createBidDto1 = new CreateBidDto(auction1.getId(), 1_000);
+        bidService.create(loginUserDto1, createBidDto1);
+
+        final LoginUserDto loginUserDto2 = new LoginUserDto(user1.getId());
+        final CreateBidDto createBidDto2 = new CreateBidDto(auction2.getId(), 1_000);
+        bidService.create(loginUserDto2, createBidDto2);
+
+        final LoginUserDto loginUserDto3 = new LoginUserDto(user2.getId());
+        final CreateBidDto createBidDto3 = new CreateBidDto(auction1.getId(), 10_000);
+        bidService.create(loginUserDto3, createBidDto3);
+
+        // when
+        final List<ReadBidDto> actual = bidService.readAllByAuctionId(auction1.getId());
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual.get(0).name()).isEqualTo(user1.getName());
+            softAssertions.assertThat(actual.get(1).name()).isEqualTo(user2.getName());
+        });
+    }
+
+    @Test
+    void 특정_경매에_대한_입찰_내역이_없다면_빈배열을_반환한다() {
+        // given
+        final Auction auction1 = Auction.builder()
+                                        .title("경매 상품 1")
+                                        .description("이것은 경매 상품 1 입니다.")
+                                        .bidUnit(new BidUnit(1_000))
+                                        .startPrice(new Price(1_000))
+                                        .closingTime(LocalDateTime.now().plusDays(7))
+                                        .build();
+        final User user1 = new User("사용자1", "이미지1", 4.9);
+
+        auctionRepository.save(auction1);
+        userRepository.save(user1);
+
+        // when
+        final List<ReadBidDto> actual = bidService.readAllByAuctionId(auction1.getId());
+
+        // then
+        assertThat(actual).hasSize(0);
+    }
+
+    @Test
+    void 입찰을_조회하려는_경매가_존재하지_않는_경우_예외를_반환한다() {
+        // given
+        final Long invalidAuctionId = -999L;
+
+        // when & then
+        assertThatThrownBy(() -> bidService.readAllByAuctionId(invalidAuctionId))
+                .isInstanceOf(AuctionNotFoundException.class)
+                .hasMessage("해당 경매를 찾을 수 없습니다.");
     }
 }

--- a/backend/ddang/src/test/java/com/ddang/ddang/bid/infrastructure/persistence/JpaBidRepositoryTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/bid/infrastructure/persistence/JpaBidRepositoryTest.java
@@ -68,6 +68,33 @@ class JpaBidRepositoryTest {
     }
 
     @Test
+    void 특정_경매가_존재하는지_확인한다() {
+        // given
+        final Auction auction = Auction.builder()
+                                       .title("경매 상품 1")
+                                       .description("이것은 경매 상품 1 입니다.")
+                                       .bidUnit(new BidUnit(1_000))
+                                       .startPrice(new Price(1_000))
+                                       .closingTime(LocalDateTime.now())
+                                       .build();
+        final User user = new User("사용자", "이미지", 4.9);
+        final Bid bid = new Bid(auction, user, new Price(10_000));
+
+        auctionRepository.save(auction);
+        userRepository.save(user);
+        bidRepository.save(bid);
+
+        em.flush();
+        em.clear();
+
+        // when
+        final boolean actual = bidRepository.existsById(bid.getId());
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
     void 특정_경매의_입찰을_모두_조회한다() {
         // given
         final Auction auction1 = Auction.builder()

--- a/backend/ddang/src/test/java/com/ddang/ddang/bid/presentation/BidControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/bid/presentation/BidControllerTest.java
@@ -4,8 +4,9 @@ import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
 import com.ddang.ddang.bid.application.BidService;
 import com.ddang.ddang.bid.application.dto.CreateBidDto;
 import com.ddang.ddang.bid.application.dto.LoginUserDto;
+import com.ddang.ddang.bid.application.dto.ReadBidDto;
 import com.ddang.ddang.bid.application.exception.InvalidAuctionToBidException;
-import com.ddang.ddang.bid.presentation.dto.CreateBidRequest;
+import com.ddang.ddang.bid.presentation.dto.request.CreateBidRequest;
 import com.ddang.ddang.bid.presentation.resolver.LoginUserArgumentResolver;
 import com.ddang.ddang.exception.GlobalExceptionHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,9 +22,14 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -76,7 +82,7 @@ class BidControllerTest {
     @Test
     void 해당_경매가_없는_경우_입찰시_404를_반환한다() throws Exception {
         // given
-        final long invalidAuctionId = 9999L;
+        final Long invalidAuctionId = 9999L;
 
         final CreateBidRequest bidRequest = new CreateBidRequest(invalidAuctionId, 10_000);
         final AuctionNotFoundException auctionNotFoundException = new AuctionNotFoundException("해당 경매를 찾을 수 없습니다.");
@@ -108,6 +114,45 @@ class BidControllerTest {
                .andExpectAll(
                        status().isBadRequest(),
                        jsonPath("$.message", is(invalidAuctionToBidException.getMessage()))
+               );
+    }
+
+    @Test
+    void 특정_경매에_대한_입찰_목록을_조회한다() throws Exception {
+        // given
+        final ReadBidDto bid1 = new ReadBidDto("사용자1", "이미지1", 10_000, LocalDateTime.now());
+        final ReadBidDto bid2 = new ReadBidDto("사용자2", "이미지2", 12_000, LocalDateTime.now());
+
+        given(bidService.readAllByAuctionId(anyLong())).willReturn(List.of(bid1, bid2));
+
+        // when & then
+        mockMvc.perform(get("/bids/{auctionId}", 1L).contentType(MediaType.APPLICATION_JSON))
+               .andExpectAll(
+                       status().isOk(),
+                       jsonPath("$.bids.[0].name", is(bid1.name())),
+                       jsonPath("$.bids.[0].profileImage", is(bid1.profileImage())),
+                       jsonPath("$.bids.[0].price", is(bid1.price())),
+                       jsonPath("$.bids.[0].bidTime").exists(),
+                       jsonPath("$.bids.[1].name", is(bid2.name())),
+                       jsonPath("$.bids.[1].profileImage", is(bid2.profileImage())),
+                       jsonPath("$.bids.[1].price", is(bid2.price())),
+                       jsonPath("$.bids.[1].bidTime").exists()
+               );
+    }
+
+    @Test
+    void 존재하지_않는_경매에_대한_입찰_목록을_조회하는_경우_404를_반환한다() throws Exception {
+        // given
+        final AuctionNotFoundException auctionNotFoundException = new AuctionNotFoundException("해당 경매를 찾을 수 없습니다.");
+        given(bidService.readAllByAuctionId(anyLong()))
+                .willThrow(auctionNotFoundException);
+
+        // when & then
+        final Long invalidAuctionId = -999L;
+        mockMvc.perform(get("/bids/{auctionId}", invalidAuctionId).contentType(MediaType.APPLICATION_JSON))
+               .andExpectAll(
+                       status().isNotFound(),
+                       jsonPath("$.message", is(auctionNotFoundException.getMessage()))
                );
     }
 }

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/application/MessageServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/application/MessageServiceTest.java
@@ -51,12 +51,7 @@ class MessageServiceTest {
         final ChatRoom chatRoom = createChatRoom(auction, receiver);
         final String contents = "메시지 내용";
 
-        final CreateMessageDto createMessageDto = new CreateMessageDto(
-                chatRoom.getId(),
-                writer.getId(),
-                receiver.getId(),
-                contents
-        );
+        final CreateMessageDto createMessageDto = new CreateMessageDto(chatRoom.getId(), writer.getId(), receiver.getId(), contents);
 
         // when
         final Long messageId = messageService.create(createMessageDto);
@@ -72,11 +67,7 @@ class MessageServiceTest {
     }
 
     private User createUser(final String userName) {
-        final User user = new User(
-                userName,
-                "https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/7r5X/image/9djEiPBPMLu_IvCYyvRPwmZkM1g.jpg",
-                0.8
-        );
+        final User user = new User(userName, "https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/7r5X/image/9djEiPBPMLu_IvCYyvRPwmZkM1g.jpg", 0.8);
 
         return userRepository.save(user);
     }
@@ -85,15 +76,15 @@ class MessageServiceTest {
         final BidUnit bidUnit = new BidUnit(1_000);
         final Price startPrice = new Price(10_000);
         final Auction auction = Auction.builder()
-                .title("title")
-                .description("description")
-                .bidUnit(bidUnit)
-                .startPrice(startPrice)
-                .closingTime(LocalDateTime.now().plusDays(3L))
-                .image("image")
-                .mainCategory("mainCategory")
-                .subCategory("subCategory")
-                .build();
+                                       .title("title")
+                                       .description("description")
+                                       .bidUnit(bidUnit)
+                                       .startPrice(startPrice)
+                                       .closingTime(LocalDateTime.now().plusDays(3L))
+                                       .image("image")
+                                       .mainCategory("mainCategory")
+                                       .subCategory("subCategory")
+                                       .build();
 
         return auctionRepository.save(auction);
     }

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/application/MessageServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/application/MessageServiceTest.java
@@ -4,6 +4,8 @@ import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.domain.BidUnit;
 import com.ddang.ddang.auction.domain.Price;
 import com.ddang.ddang.auction.infrastructure.persistence.JpaAuctionRepository;
+import com.ddang.ddang.category.domain.Category;
+import com.ddang.ddang.category.infrastructure.persistence.JpaCategoryRepository;
 import com.ddang.ddang.chat.application.dto.CreateMessageDto;
 import com.ddang.ddang.chat.application.exception.ChatRoomNotFoundException;
 import com.ddang.ddang.chat.application.exception.UserNotFoundException;
@@ -45,20 +47,27 @@ class MessageServiceTest {
     @Autowired
     JpaChatRoomRepository chatRoomRepository;
 
+    @Autowired
+    JpaCategoryRepository categoryRepository;
+
     @Test
     void 메시지를_생성한다() {
         // given
         final BidUnit bidUnit = new BidUnit(1_000);
         final Price startPrice = new Price(10_000);
+        final Category main = new Category("전자기기");
+        final Category sub = new Category("노트북");
+
+        main.addSubCategory(sub);
+
+        categoryRepository.save(main);
         final Auction auction = Auction.builder()
                                        .title("title")
                                        .description("description")
                                        .bidUnit(bidUnit)
                                        .startPrice(startPrice)
                                        .closingTime(LocalDateTime.now().plusDays(3L))
-                                       .image("image")
-                                       .mainCategory("mainCategory")
-                                       .subCategory("subCategory")
+                                       .subCategory(sub)
                                        .build();
 
         auctionRepository.save(auction);
@@ -104,13 +113,19 @@ class MessageServiceTest {
         // given
         final BidUnit bidUnit = new BidUnit(1_000);
         final Price startPrice = new Price(10_000);
+        final Category main = new Category("전자기기");
+        final Category sub = new Category("노트북");
+
+        main.addSubCategory(sub);
+
+        categoryRepository.save(main);
         final Auction auction = Auction.builder()
                                        .title("title")
                                        .description("description")
                                        .bidUnit(bidUnit)
                                        .startPrice(startPrice)
                                        .closingTime(LocalDateTime.now().plusDays(3L))
-                                       .subCategory("subCategory")
+                                       .subCategory(sub)
                                        .build();
 
         auctionRepository.save(auction);
@@ -152,13 +167,20 @@ class MessageServiceTest {
         // given
         final BidUnit bidUnit = new BidUnit(1_000);
         final Price startPrice = new Price(10_000);
+        final Category main = new Category("전자기기");
+        final Category sub = new Category("노트북");
+
+        main.addSubCategory(sub);
+
+        categoryRepository.save(main);
+
         final Auction auction = Auction.builder()
                                        .title("title")
                                        .description("description")
                                        .bidUnit(bidUnit)
                                        .startPrice(startPrice)
                                        .closingTime(LocalDateTime.now().plusDays(3L))
-                                       .subCategory("subCategory")
+                                       .subCategory(sub)
                                        .build();
 
         auctionRepository.save(auction);
@@ -196,13 +218,20 @@ class MessageServiceTest {
         // given
         final BidUnit bidUnit = new BidUnit(1_000);
         final Price startPrice = new Price(10_000);
+        final Category main = new Category("전자기기");
+        final Category sub = new Category("노트북");
+
+        main.addSubCategory(sub);
+
+        categoryRepository.save(main);
+
         final Auction auction = Auction.builder()
                                        .title("title")
                                        .description("description")
                                        .bidUnit(bidUnit)
                                        .startPrice(startPrice)
                                        .closingTime(LocalDateTime.now().plusDays(3L))
-                                       .subCategory("subCategory")
+                                       .subCategory(sub)
                                        .build();
 
         auctionRepository.save(auction);

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/application/MessageServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/application/MessageServiceTest.java
@@ -1,0 +1,100 @@
+package com.ddang.ddang.chat.application;
+
+import com.ddang.ddang.auction.domain.Auction;
+import com.ddang.ddang.auction.domain.BidUnit;
+import com.ddang.ddang.auction.domain.Price;
+import com.ddang.ddang.auction.infrastructure.persistence.JpaAuctionRepository;
+import com.ddang.ddang.chat.application.dto.CreateMessageDto;
+import com.ddang.ddang.chat.domain.ChatRoom;
+import com.ddang.ddang.chat.infrastructure.persistence.JpaChatRoomRepository;
+import com.ddang.ddang.chat.infrastructure.persistence.JpaMessageRepository;
+import com.ddang.ddang.user.domain.User;
+import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class MessageServiceTest {
+
+    @Autowired
+    MessageService messageService;
+
+    @Autowired
+    JpaMessageRepository messageRepository;
+
+    @Autowired
+    JpaAuctionRepository auctionRepository;
+
+    @Autowired
+    JpaUserRepository userRepository;
+
+    @Autowired
+    JpaChatRoomRepository chatRoomRepository;
+
+    @Test
+    void 메시지를_생성한다() {
+        // given
+        final Auction auction = createAuction();
+        final User writer = createUser("발신자");
+        final User receiver = createUser("수신자");
+        final ChatRoom chatRoom = createChatRoom(auction, receiver);
+        final String contents = "메시지 내용";
+
+        final CreateMessageDto createMessageDto = new CreateMessageDto(
+                chatRoom.getId(),
+                writer.getId(),
+                receiver.getId(),
+                contents
+        );
+
+        // when
+        final Long messageId = messageService.create(createMessageDto);
+
+        // then
+        assertThat(messageId).isPositive();
+    }
+
+    private ChatRoom createChatRoom(final Auction auction, final User buyer) {
+        final ChatRoom chatRoom = new ChatRoom(auction, buyer);
+
+        return chatRoomRepository.save(chatRoom);
+    }
+
+    private User createUser(final String userName) {
+        final User user = new User(
+                userName,
+                "https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/7r5X/image/9djEiPBPMLu_IvCYyvRPwmZkM1g.jpg",
+                0.8
+        );
+
+        return userRepository.save(user);
+    }
+
+    private Auction createAuction() {
+        final BidUnit bidUnit = new BidUnit(1_000);
+        final Price startPrice = new Price(10_000);
+        final Auction auction = Auction.builder()
+                .title("title")
+                .description("description")
+                .bidUnit(bidUnit)
+                .startPrice(startPrice)
+                .closingTime(LocalDateTime.now().plusDays(3L))
+                .image("image")
+                .mainCategory("mainCategory")
+                .subCategory("subCategory")
+                .build();
+
+        return auctionRepository.save(auction);
+    }
+}

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/application/MessageServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/application/MessageServiceTest.java
@@ -51,7 +51,12 @@ class MessageServiceTest {
         final ChatRoom chatRoom = createChatRoom(auction, receiver);
         final String contents = "메시지 내용";
 
-        final CreateMessageDto createMessageDto = new CreateMessageDto(chatRoom.getId(), writer.getId(), receiver.getId(), contents);
+        final CreateMessageDto createMessageDto = new CreateMessageDto(
+                chatRoom.getId(),
+                writer.getId(),
+                receiver.getId(),
+                contents
+        );
 
         // when
         final Long messageId = messageService.create(createMessageDto);

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/application/MessageServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/application/MessageServiceTest.java
@@ -214,7 +214,7 @@ class MessageServiceTest {
     }
 
     @Test
-    void 수신자가_없는_경우_메시지를_생성하면제_예외가_발생한다() {
+    void 수신자가_없는_경우_메시지를_생성하면_예외가_발생한다() {
         // given
         final BidUnit bidUnit = new BidUnit(1_000);
         final Price startPrice = new Price(10_000);

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/application/MessageServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/application/MessageServiceTest.java
@@ -110,8 +110,6 @@ class MessageServiceTest {
                                        .bidUnit(bidUnit)
                                        .startPrice(startPrice)
                                        .closingTime(LocalDateTime.now().plusDays(3L))
-                                       .image("image")
-                                       .mainCategory("mainCategory")
                                        .subCategory("subCategory")
                                        .build();
 
@@ -160,8 +158,6 @@ class MessageServiceTest {
                                        .bidUnit(bidUnit)
                                        .startPrice(startPrice)
                                        .closingTime(LocalDateTime.now().plusDays(3L))
-                                       .image("image")
-                                       .mainCategory("mainCategory")
                                        .subCategory("subCategory")
                                        .build();
 
@@ -206,8 +202,6 @@ class MessageServiceTest {
                                        .bidUnit(bidUnit)
                                        .startPrice(startPrice)
                                        .closingTime(LocalDateTime.now().plusDays(3L))
-                                       .image("image")
-                                       .mainCategory("mainCategory")
                                        .subCategory("subCategory")
                                        .build();
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/application/MessageServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/application/MessageServiceTest.java
@@ -48,10 +48,41 @@ class MessageServiceTest {
     @Test
     void 메시지를_생성한다() {
         // given
-        final Auction auction = createAuction();
-        final User writer = createUser("발신자");
-        final User receiver = createUser("수신자");
-        final ChatRoom chatRoom = createChatRoom(auction, receiver);
+        final BidUnit bidUnit = new BidUnit(1_000);
+        final Price startPrice = new Price(10_000);
+        final Auction auction = Auction.builder()
+                                       .title("title")
+                                       .description("description")
+                                       .bidUnit(bidUnit)
+                                       .startPrice(startPrice)
+                                       .closingTime(LocalDateTime.now().plusDays(3L))
+                                       .image("image")
+                                       .mainCategory("mainCategory")
+                                       .subCategory("subCategory")
+                                       .build();
+
+        auctionRepository.save(auction);
+
+        final User writer = new User(
+                "발신자",
+                "https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/7r5X/image/9djEiPBPMLu_IvCYyvRPwmZkM1g.jpg",
+                0.8
+        );
+
+        userRepository.save(writer);
+
+        final User receiver = new User(
+                "수신자",
+                "https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/7r5X/image/9djEiPBPMLu_IvCYyvRPwmZkM1g.jpg",
+                0.8
+        );
+
+        userRepository.save(receiver);
+
+        final ChatRoom chatRoom = new ChatRoom(auction, writer);
+
+        chatRoomRepository.save(chatRoom);
+
         final String contents = "메시지 내용";
 
         final CreateMessageDto createMessageDto = new CreateMessageDto(
@@ -71,8 +102,37 @@ class MessageServiceTest {
     @Test
     void 채팅방이_없는_경우_메시지를_생성하면_예외가_발생한다() {
         // given
-        final User writer = createUser("발신자");
-        final User receiver = createUser("수신자");
+        final BidUnit bidUnit = new BidUnit(1_000);
+        final Price startPrice = new Price(10_000);
+        final Auction auction = Auction.builder()
+                                       .title("title")
+                                       .description("description")
+                                       .bidUnit(bidUnit)
+                                       .startPrice(startPrice)
+                                       .closingTime(LocalDateTime.now().plusDays(3L))
+                                       .image("image")
+                                       .mainCategory("mainCategory")
+                                       .subCategory("subCategory")
+                                       .build();
+
+        auctionRepository.save(auction);
+
+        final User writer = new User(
+                "발신자",
+                "https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/7r5X/image/9djEiPBPMLu_IvCYyvRPwmZkM1g.jpg",
+                0.8
+        );
+
+        userRepository.save(writer);
+
+        final User receiver = new User(
+                "수신자",
+                "https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/7r5X/image/9djEiPBPMLu_IvCYyvRPwmZkM1g.jpg",
+                0.8
+        );
+
+        userRepository.save(receiver);
+
         final Long invalidChatRoomId = -999L;
         final String contents = "메시지 내용";
 
@@ -92,11 +152,36 @@ class MessageServiceTest {
     @Test
     void 발신자가_없는_경우_메시지를_생성하면_예외가_발생한다() {
         // given
-        final Auction auction = createAuction();
-        final Long invalidWriterId = -999L;
-        final User receiver = createUser("수신자");
-        final ChatRoom chatRoom = createChatRoom(auction, receiver);
+        final BidUnit bidUnit = new BidUnit(1_000);
+        final Price startPrice = new Price(10_000);
+        final Auction auction = Auction.builder()
+                                       .title("title")
+                                       .description("description")
+                                       .bidUnit(bidUnit)
+                                       .startPrice(startPrice)
+                                       .closingTime(LocalDateTime.now().plusDays(3L))
+                                       .image("image")
+                                       .mainCategory("mainCategory")
+                                       .subCategory("subCategory")
+                                       .build();
+
+        auctionRepository.save(auction);
+
+        final User receiver = new User(
+                "수신자",
+                "https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/7r5X/image/9djEiPBPMLu_IvCYyvRPwmZkM1g.jpg",
+                0.8
+        );
+
+        userRepository.save(receiver);
+
+
+        final ChatRoom chatRoom = new ChatRoom(auction, receiver);
+
+        chatRoomRepository.save(chatRoom);
+
         final String contents = "메시지 내용";
+        final Long invalidWriterId = -999L;
 
         final CreateMessageDto createMessageDto = new CreateMessageDto(
                 chatRoom.getId(),
@@ -111,39 +196,8 @@ class MessageServiceTest {
     }
 
     @Test
-    void 수신자가_없는_경우_메시지를_생성하면_예외가_발생한다() {
+    void 수신자가_없는_경우_메시지를_생성하면제_예외가_발생한다() {
         // given
-        final Auction auction = createAuction();
-        final User writer = createUser("발신자");
-        final Long invalidReceiverId = -999L;
-        final ChatRoom chatRoom = createChatRoom(auction, writer);
-        final String contents = "메시지 내용";
-
-        final CreateMessageDto createMessageDto = new CreateMessageDto(
-                chatRoom.getId(),
-                writer.getId(),
-                invalidReceiverId,
-                contents
-        );
-
-        assertThatThrownBy(() -> messageService.create(createMessageDto))
-                .isInstanceOf(UserNotFoundException.class)
-                .hasMessageContaining("지정한 아이디에 대한 수신자를 찾을 수 없습니다.");
-    }
-
-    private ChatRoom createChatRoom(final Auction auction, final User buyer) {
-        final ChatRoom chatRoom = new ChatRoom(auction, buyer);
-
-        return chatRoomRepository.save(chatRoom);
-    }
-
-    private User createUser(final String userName) {
-        final User user = new User(userName, "https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/7r5X/image/9djEiPBPMLu_IvCYyvRPwmZkM1g.jpg", 0.8);
-
-        return userRepository.save(user);
-    }
-
-    private Auction createAuction() {
         final BidUnit bidUnit = new BidUnit(1_000);
         final Price startPrice = new Price(10_000);
         final Auction auction = Auction.builder()
@@ -157,6 +211,33 @@ class MessageServiceTest {
                                        .subCategory("subCategory")
                                        .build();
 
-        return auctionRepository.save(auction);
+        auctionRepository.save(auction);
+
+        final User writer = new User(
+                "발신자",
+                "https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/7r5X/image/9djEiPBPMLu_IvCYyvRPwmZkM1g.jpg",
+                0.8
+        );
+
+        userRepository.save(writer);
+
+
+        final ChatRoom chatRoom = new ChatRoom(auction, writer);
+
+        chatRoomRepository.save(chatRoom);
+
+        final Long invalidReceiverId = -999L;
+        final String contents = "메시지 내용";
+
+        final CreateMessageDto createMessageDto = new CreateMessageDto(
+                chatRoom.getId(),
+                writer.getId(),
+                invalidReceiverId,
+                contents
+        );
+
+        assertThatThrownBy(() -> messageService.create(createMessageDto))
+                .isInstanceOf(UserNotFoundException.class)
+                .hasMessageContaining("지정한 아이디에 대한 수신자를 찾을 수 없습니다.");
     }
 }

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/presentation/ChatRoomControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/presentation/ChatRoomControllerTest.java
@@ -24,9 +24,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = {ChatRoomController.class})
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -48,14 +46,20 @@ class ChatRoomControllerTest {
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(chatRoomController)
                                  .setControllerAdvice(new GlobalExceptionHandler())
-                                 .alwaysDo(print()).build();
+                                 .alwaysDo(print())
+                                 .build();
     }
 
     @Test
     void 메시지를_생성한다() throws Exception {
         // given
         final String contents = "메시지 내용";
-        final CreateMessageRequest request = new CreateMessageRequest(1L, 1L, contents);
+        final CreateMessageRequest request = new CreateMessageRequest(
+                1L,
+                1L,
+                1L,
+                contents
+        );
 
         given(messageService.create(any(CreateMessageDto.class))).willReturn(1L);
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/presentation/ChatRoomControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/presentation/ChatRoomControllerTest.java
@@ -46,7 +46,8 @@ class ChatRoomControllerTest {
 
     @BeforeEach
     void setUp() {
-        mockMvc = MockMvcBuilders.standaloneSetup(chatRoomController).setControllerAdvice(new GlobalExceptionHandler())
+        mockMvc = MockMvcBuilders.standaloneSetup(chatRoomController)
+                                 .setControllerAdvice(new GlobalExceptionHandler())
                                  .alwaysDo(print()).build();
     }
 
@@ -59,9 +60,14 @@ class ChatRoomControllerTest {
         given(messageService.create(any(CreateMessageDto.class))).willReturn(1L);
 
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.post("/chattings/1/messages").contentType(MediaType.APPLICATION_JSON)
+        mockMvc.perform(MockMvcRequestBuilders.post("/chattings/1/messages")
+                                              .contentType(MediaType.APPLICATION_JSON)
                                               .content(objectMapper.writeValueAsString(request)))
-               .andExpectAll(status().isCreated(), header().string(HttpHeaders.LOCATION, is("/chattings/1/messages/1")), jsonPath("$.id", is(1L), Long.class));
+               .andExpectAll(
+                       status().isCreated(),
+                       header().string(HttpHeaders.LOCATION, is("/chattings/1/messages/1")),
+                       jsonPath("$.id", is(1L), Long.class)
+               );
     }
 
     @Test
@@ -79,7 +85,10 @@ class ChatRoomControllerTest {
         mockMvc.perform(MockMvcRequestBuilders.post("/chattings/{chatRoomId}/messages", invalidChatRoomId)
                                               .content(objectMapper.writeValueAsString(request))
                                               .contentType(MediaType.APPLICATION_JSON))
-               .andExpectAll(status().isNotFound(), jsonPath("$.message", is(chatRoomNotFoundException.getMessage())));
+               .andExpectAll(
+                       status().isNotFound(),
+                       jsonPath("$.message", is(chatRoomNotFoundException.getMessage()))
+               );
     }
 
     @Test
@@ -98,6 +107,9 @@ class ChatRoomControllerTest {
         mockMvc.perform(MockMvcRequestBuilders.post("/chattings/{chatRoomId}/messages", chatRoomId)
                                               .content(objectMapper.writeValueAsString(request))
                                               .contentType(MediaType.APPLICATION_JSON))
-               .andExpectAll(status().isNotFound(), jsonPath("$.message", is(userNotFoundException.getMessage())));
+               .andExpectAll(
+                       status().isNotFound(),
+                       jsonPath("$.message", is(userNotFoundException.getMessage()))
+               );
     }
 }

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/presentation/ChatRoomControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/presentation/ChatRoomControllerTest.java
@@ -24,7 +24,9 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = {ChatRoomController.class})
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/presentation/ChatRoomControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/presentation/ChatRoomControllerTest.java
@@ -57,7 +57,6 @@ class ChatRoomControllerTest {
         final CreateMessageRequest request = new CreateMessageRequest(
                 1L,
                 1L,
-                1L,
                 contents
         );
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/presentation/ChatRoomControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/presentation/ChatRoomControllerTest.java
@@ -1,0 +1,75 @@
+package com.ddang.ddang.chat.presentation;
+
+import com.ddang.ddang.chat.application.MessageService;
+import com.ddang.ddang.chat.application.dto.CreateMessageDto;
+import com.ddang.ddang.chat.presentation.dto.CreateMessageRequest;
+import com.ddang.ddang.exception.GlobalExceptionHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = {ChatRoomController.class})
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ChatRoomControllerTest {
+
+    @MockBean
+    MessageService messageService;
+
+    @Autowired
+    ChatRoomController chatRoomController;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(chatRoomController)
+                                 .setControllerAdvice(new GlobalExceptionHandler())
+                                 .alwaysDo(print())
+                                 .build();
+    }
+
+    @Test
+    void 메시지를_생성한다() throws Exception {
+        // given
+        final String contents = "메시지 내용";
+        final CreateMessageRequest request = new CreateMessageRequest(
+                1L,
+                1L,
+                1L,
+                contents
+        );
+
+        given(messageService.create(any(CreateMessageDto.class))).willReturn(1L);
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders.post("/chattings/1/messages")
+                                              .contentType(MediaType.APPLICATION_JSON)
+                                              .content(objectMapper.writeValueAsString(request))
+               )
+               .andExpectAll(
+                       status().isCreated(),
+                       header().string(HttpHeaders.LOCATION, is("/chattings/1/messages/1")),
+                       jsonPath("$.id", is(1L), Long.class)
+               );
+    }
+}


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->
채팅 전송 API 추가

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

- `userNotFoundException` 생성
    - 메시지 전송 시 메시지 수신자와 발신자 id를 함께 전달받습니다. 잘못된 user id가 전달된 경우 예외를 발생시키게 하기 위해 `UserNotFound`를 추가해두었습니다.
    
- POST `/chattings/{chatRoomId}/messages`
    - 채팅방 아이디를 request DTO에 포함시켜 전달받는 형태로 구현했다가 구현 예정인 채팅 메시지 조회 API 명세와 동일하게 path variable로 전달받도록 구현했습니다.

## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

- closed #151

<!-- closed #번호 --> 
