### PR TITLE
이미지 Uri를 MultipartBody로 변환

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionViewModel.kt
@@ -12,6 +12,7 @@ import com.ddangddangddang.data.model.request.RegisterAuctionRequest
 import com.ddangddangddang.data.remote.ApiResponse
 import com.ddangddangddang.data.repository.AuctionRepository
 import kotlinx.coroutines.launch
+import java.io.File
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -67,7 +68,8 @@ class RegisterAuctionViewModel(private val repository: AuctionRepository) : View
         if (!isValidInputs) return
 
         viewModelScope.launch {
-            when (val response = repository.registerAuction(createRequestModel())) {
+            val files = images.value?.map { File(it.uri.path ?: "") } ?: emptyList()
+            when (val response = repository.registerAuction(files, createRequestModel())) {
                 is ApiResponse.Success -> {
                     _event.value = RegisterAuctionEvent.SubmitResult(response.body.id)
                 }

--- a/android/app/src/main/res/layout/activity_register_auction.xml
+++ b/android/app/src/main/res/layout/activity_register_auction.xml
@@ -315,7 +315,7 @@
                     android:layout_width="0dp"
                     android:layout_height="48dp"
                     android:layout_marginVertical="22dp"
-                    android:onClick="@{() -> viewModel.submitAuction()}"
+                    android:onClick="@{() -> viewModel.submitAuction(context)}"
                     android:padding="0dp"
                     android:text="@string/register_auction"
                     android:textSize="18sp"

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
@@ -6,14 +6,29 @@ import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
 import com.ddangddangddang.data.model.response.RegisterAuctionResponse
 import com.ddangddangddang.data.remote.ApiResponse
 import com.ddangddangddang.data.remote.Service
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import java.io.File
 
 class AuctionRemoteDataSource(private val service: Service) {
-    suspend fun getAuctionPreviews(lastAuctionId: Long?, size: Int): ApiResponse<AuctionPreviewsResponse> =
+    suspend fun getAuctionPreviews(
+        lastAuctionId: Long?,
+        size: Int,
+    ): ApiResponse<AuctionPreviewsResponse> =
         service.fetchAuctionPreviews(lastAuctionId, size)
 
     suspend fun getAuctionDetail(id: Long): ApiResponse<AuctionDetailResponse> =
         service.fetchAuctionDetail(id)
 
-    suspend fun registerAuction(auction: RegisterAuctionRequest): ApiResponse<RegisterAuctionResponse> =
-        service.registerAuction(auction)
+    suspend fun registerAuction(
+        images: List<File>,
+        auction: RegisterAuctionRequest,
+    ): ApiResponse<RegisterAuctionResponse> {
+        val files = images.map {
+            val fileBody = it.asRequestBody("image/*".toMediaTypeOrNull())
+            MultipartBody.Part.createFormData("image", it.name, fileBody)
+        }
+        return service.registerAuction(auction)
+    }
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
@@ -7,11 +7,12 @@ import com.ddangddangddang.data.model.response.AuctionPreviewResponse
 import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
 import com.ddangddangddang.data.model.response.RegisterAuctionResponse
 import com.ddangddangddang.data.remote.ApiResponse
+import java.io.File
 
 interface AuctionRepository {
     fun observeAuctionPreviews(): LiveData<List<AuctionPreviewResponse>>
 
     suspend fun getAuctionPreviews(lastAuctionId: Long?, size: Int): ApiResponse<AuctionPreviewsResponse>
     suspend fun getAuctionDetail(id: Long): ApiResponse<AuctionDetailResponse>
-    suspend fun registerAuction(auction: RegisterAuctionRequest): ApiResponse<RegisterAuctionResponse>
+    suspend fun registerAuction(images: List<File>, auction: RegisterAuctionRequest): ApiResponse<RegisterAuctionResponse>
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
 import com.ddangddangddang.data.model.response.RegisterAuctionResponse
 import com.ddangddangddang.data.remote.ApiResponse
 import com.ddangddangddang.data.remote.Service
+import java.io.File
 
 class AuctionRepositoryImpl private constructor(
     private val localDataSource: AuctionLocalDataSource,
@@ -32,8 +33,8 @@ class AuctionRepositoryImpl private constructor(
         return remoteDataSource.getAuctionDetail(id)
     }
 
-    override suspend fun registerAuction(auction: RegisterAuctionRequest): ApiResponse<RegisterAuctionResponse> {
-        val response = remoteDataSource.registerAuction(auction)
+    override suspend fun registerAuction(images: List<File>, auction: RegisterAuctionRequest): ApiResponse<RegisterAuctionResponse> {
+        val response = remoteDataSource.registerAuction(images, auction)
         if (response is ApiResponse.Success) {
             val auctionPreviewResponse = AuctionPreviewResponse(
                 response.body.id,


### PR DESCRIPTION
## 📄 작업 내용 요약
갤러리에서 가져온 이미지 Uri를 File로 변환 후 서버에 전송 가능한 MultipartBody로 변환하는 작업을 진행했습니다.

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
Uri를 File로 변환하고 이후에 DataSource에서 File을 MultipartBody로 변환하는 부분을 확인해주시면 좋을 것 같습니다!
Uri로부터 절대 경로를 가져오는 로직도 확인 부탁드려요!
버전 분기처리를 하지 않았는데도 API 28과 API 33에서 잘 동작하여 일단은 버전 분기처리를 하지 않았습니다!

## 📎 Issue 번호
- closed : #159 
