### PR TITLE
경매 등록 시 갤러리에 있는 이미지를 서버로 전송하는 기능 구현

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
@@ -18,7 +18,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
         override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
             super.onScrolled(recyclerView, dx, dy)
 
-            // 다음 페이지가 존재하는지 뷰 모델 데이터 확인하는 코드 추가 필요
+            if (viewModel.isLast) return
 
             if (!viewModel.loadingAuctionInProgress) {
                 val lastVisibleItemPosition =

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
@@ -25,6 +25,10 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
     val loadingAuctionInProgress: Boolean
         get() = _loadingAuctionsInProgress
 
+    private var _isLast = false
+    val isLast: Boolean
+        get() = _isLast
+
     private val _event: SingleLiveEvent<HomeEvent> = SingleLiveEvent()
     val event: LiveData<HomeEvent>
         get() = _event
@@ -36,7 +40,10 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
                 val response =
                     repository.getAuctionPreviews(lastAuctionId.value, SIZE_AUCTION_LOAD)
             ) {
-                is ApiResponse.Success -> {}
+                is ApiResponse.Success -> {
+                    _isLast = response.body.isLast
+                }
+
                 is ApiResponse.Failure -> {}
                 is ApiResponse.NetworkError -> {}
                 is ApiResponse.Unexpected -> {}

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionViewModel.kt
@@ -9,8 +9,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ddangddangddang.android.model.RegisterImageModel
 import com.ddangddangddang.android.util.livedata.SingleLiveEvent
-import com.ddangddangddang.data.model.request.CategoryRequest
-import com.ddangddangddang.data.model.request.DirectRegionRequest
 import com.ddangddangddang.data.model.request.RegisterAuctionRequest
 import com.ddangddangddang.data.remote.ApiResponse
 import com.ddangddangddang.data.repository.AuctionRepository
@@ -98,24 +96,21 @@ class RegisterAuctionViewModel(private val repository: AuctionRepository) : View
     }
 
     private fun createRequestModel(): RegisterAuctionRequest {
-        val images = images.value ?: emptyList()
         val title = title.value ?: ""
-        val category = category.value ?: ""
         val description = description.value ?: ""
         val startPrice = startPrice.value?.toInt() ?: 0
         val bidUnit = bidUnit.value?.toInt() ?: 0
         val closingTime = closingTime.value.toString() + ":00" // seconds
-        val directRegion = directRegion.value ?: ""
 
+        // 카테고리와 지역 선택 기능 구현 후 수정 필요!
         return RegisterAuctionRequest(
-            listOf("https://item.kakaocdn.net/do/58119590d6204ebd70e97763ca933baf113e2bd2b7407c8202a97d2241a96625"),
             title,
-            CategoryRequest(category.split(" > ")[0], category.split(" > ")[1]),
+            102,
             description,
             startPrice,
             bidUnit,
             closingTime,
-            listOf(DirectRegionRequest("경기도", "부천시", "원미구")),
+            listOf(3),
         )
     }
 

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
@@ -2,13 +2,16 @@ package com.ddangddangddang.data.datasource
 
 import com.ddangddangddang.data.model.request.RegisterAuctionRequest
 import com.ddangddangddang.data.model.response.AuctionDetailResponse
+import com.ddangddangddang.data.model.response.AuctionPreviewResponse
 import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
-import com.ddangddangddang.data.model.response.RegisterAuctionResponse
 import com.ddangddangddang.data.remote.ApiResponse
 import com.ddangddangddang.data.remote.Service
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.File
 
 class AuctionRemoteDataSource(private val service: Service) {
@@ -24,11 +27,13 @@ class AuctionRemoteDataSource(private val service: Service) {
     suspend fun registerAuction(
         images: List<File>,
         auction: RegisterAuctionRequest,
-    ): ApiResponse<RegisterAuctionResponse> {
+    ): ApiResponse<AuctionPreviewResponse> {
         val files = images.map {
             val fileBody = it.asRequestBody("image/*".toMediaTypeOrNull())
-            MultipartBody.Part.createFormData("image", it.name, fileBody)
+            MultipartBody.Part.createFormData("images", it.name, fileBody)
         }
-        return service.registerAuction(auction)
+        val body = Json.encodeToString(RegisterAuctionRequest.serializer(), auction)
+            .toRequestBody("application/json".toMediaType())
+        return service.registerAuction(files, body)
     }
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/model/request/CategoryRequest.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/model/request/CategoryRequest.kt
@@ -1,6 +1,0 @@
-package com.ddangddangddang.data.model.request
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class CategoryRequest(val main: String, val sub: String)

--- a/android/data/src/main/java/com/ddangddangddang/data/model/request/DirectRegionRequest.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/model/request/DirectRegionRequest.kt
@@ -1,6 +1,0 @@
-package com.ddangddangddang.data.model.request
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class DirectRegionRequest(val first: String, val second: String, val third: String)

--- a/android/data/src/main/java/com/ddangddangddang/data/model/request/RegisterAuctionRequest.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/model/request/RegisterAuctionRequest.kt
@@ -4,12 +4,11 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class RegisterAuctionRequest(
-    val images: List<String>,
     val title: String,
-    val category: CategoryRequest,
+    val subCategoryId: Long,
     val description: String,
     val startPrice: Int,
     val bidUnit: Int,
     val closingTime: String,
-    val directRegions: List<DirectRegionRequest>,
+    val thirdRegionIds: List<Long>,
 )

--- a/android/data/src/main/java/com/ddangddangddang/data/model/response/AuctionPreviewsResponse.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/model/response/AuctionPreviewsResponse.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AuctionPreviewsResponse(
     val auctions: List<AuctionPreviewResponse>,
-    val lastAuctionId: Long? = null,
+    val isLast: Boolean,
 )

--- a/android/data/src/main/java/com/ddangddangddang/data/model/response/RegisterAuctionResponse.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/model/response/RegisterAuctionResponse.kt
@@ -1,6 +1,0 @@
-package com.ddangddangddang.data.model.response
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class RegisterAuctionResponse(val id: Long)

--- a/android/data/src/main/java/com/ddangddangddang/data/remote/Service.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/remote/Service.kt
@@ -1,12 +1,14 @@
 package com.ddangddangddang.data.remote
 
-import com.ddangddangddang.data.model.request.RegisterAuctionRequest
 import com.ddangddangddang.data.model.response.AuctionDetailResponse
+import com.ddangddangddang.data.model.response.AuctionPreviewResponse
 import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
-import com.ddangddangddang.data.model.response.RegisterAuctionResponse
-import retrofit2.http.Body
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import retrofit2.http.GET
+import retrofit2.http.Multipart
 import retrofit2.http.POST
+import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -20,6 +22,10 @@ interface Service {
     @GET("/auctions/{id}")
     suspend fun fetchAuctionDetail(@Path("id") id: Long): ApiResponse<AuctionDetailResponse>
 
+    @Multipart
     @POST("/auctions")
-    suspend fun registerAuction(@Body body: RegisterAuctionRequest): ApiResponse<RegisterAuctionResponse>
+    suspend fun registerAuction(
+        @Part images: List<MultipartBody.Part>,
+        @Part("request") body: RequestBody,
+    ): ApiResponse<AuctionPreviewResponse>
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
@@ -5,14 +5,20 @@ import com.ddangddangddang.data.model.request.RegisterAuctionRequest
 import com.ddangddangddang.data.model.response.AuctionDetailResponse
 import com.ddangddangddang.data.model.response.AuctionPreviewResponse
 import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
-import com.ddangddangddang.data.model.response.RegisterAuctionResponse
 import com.ddangddangddang.data.remote.ApiResponse
 import java.io.File
 
 interface AuctionRepository {
     fun observeAuctionPreviews(): LiveData<List<AuctionPreviewResponse>>
 
-    suspend fun getAuctionPreviews(lastAuctionId: Long?, size: Int): ApiResponse<AuctionPreviewsResponse>
+    suspend fun getAuctionPreviews(
+        lastAuctionId: Long?,
+        size: Int,
+    ): ApiResponse<AuctionPreviewsResponse>
+
     suspend fun getAuctionDetail(id: Long): ApiResponse<AuctionDetailResponse>
-    suspend fun registerAuction(images: List<File>, auction: RegisterAuctionRequest): ApiResponse<RegisterAuctionResponse>
+    suspend fun registerAuction(
+        images: List<File>,
+        auction: RegisterAuctionRequest,
+    ): ApiResponse<AuctionPreviewResponse>
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
@@ -7,7 +7,6 @@ import com.ddangddangddang.data.model.request.RegisterAuctionRequest
 import com.ddangddangddang.data.model.response.AuctionDetailResponse
 import com.ddangddangddang.data.model.response.AuctionPreviewResponse
 import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
-import com.ddangddangddang.data.model.response.RegisterAuctionResponse
 import com.ddangddangddang.data.remote.ApiResponse
 import com.ddangddangddang.data.remote.Service
 import java.io.File
@@ -21,7 +20,10 @@ class AuctionRepositoryImpl private constructor(
         return localDataSource.observeAuctionPreviews()
     }
 
-    override suspend fun getAuctionPreviews(lastAuctionId: Long?, size: Int): ApiResponse<AuctionPreviewsResponse> {
+    override suspend fun getAuctionPreviews(
+        lastAuctionId: Long?,
+        size: Int,
+    ): ApiResponse<AuctionPreviewsResponse> {
         val response = remoteDataSource.getAuctionPreviews(lastAuctionId, size)
         if (response is ApiResponse.Success) {
             localDataSource.addAuctionPreviews(response.body.auctions)
@@ -33,18 +35,13 @@ class AuctionRepositoryImpl private constructor(
         return remoteDataSource.getAuctionDetail(id)
     }
 
-    override suspend fun registerAuction(images: List<File>, auction: RegisterAuctionRequest): ApiResponse<RegisterAuctionResponse> {
+    override suspend fun registerAuction(
+        images: List<File>,
+        auction: RegisterAuctionRequest,
+    ): ApiResponse<AuctionPreviewResponse> {
         val response = remoteDataSource.registerAuction(images, auction)
         if (response is ApiResponse.Success) {
-            val auctionPreviewResponse = AuctionPreviewResponse(
-                response.body.id,
-                auction.title,
-                auction.images.firstOrNull() ?: "",
-                auction.startPrice,
-                "UNBIDDEN",
-                0,
-            )
-            localDataSource.addAuctionPreview(auctionPreviewResponse)
+            localDataSource.addAuctionPreview(response.body)
         }
         return response
     }

--- a/android/data/src/test/java/com/ddangddangddang/data/Fixtures.kt
+++ b/android/data/src/test/java/com/ddangddangddang/data/Fixtures.kt
@@ -1,7 +1,5 @@
 package com.ddangddangddang.data
 
-import com.ddangddangddang.data.model.request.CategoryRequest
-import com.ddangddangddang.data.model.request.DirectRegionRequest
 import com.ddangddangddang.data.model.request.RegisterAuctionRequest
 import com.ddangddangddang.data.model.response.AuctionDetailResponse
 import com.ddangddangddang.data.model.response.AuctionPreviewResponse
@@ -9,7 +7,6 @@ import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
 import com.ddangddangddang.data.model.response.AuctionResponse
 import com.ddangddangddang.data.model.response.CategoryResponse
 import com.ddangddangddang.data.model.response.DirectRegionResponse
-import com.ddangddangddang.data.model.response.RegisterAuctionResponse
 import com.ddangddangddang.data.model.response.SellerResponse
 
 private fun createAuctionPreviewResponse(
@@ -23,30 +20,27 @@ private fun createAuctionPreviewResponse(
 
 fun createAuctionPreviewsResponse(
     auctions: List<AuctionPreviewResponse> = listOf(createAuctionPreviewResponse()),
-    lastAuctionId: Long = 1,
-) = AuctionPreviewsResponse(auctions, lastAuctionId)
+    isLast: Boolean = false,
+) = AuctionPreviewsResponse(auctions, isLast)
 
 fun createRegisterAuctionRequest(
-    images: List<String> = listOf("https://i0.wp.com/opensea.kr/wp-content/uploads/2021/01/2169FF1C-8A4A-46CE-A55A-7ED291EEA033_1_105_c-1.jpeg?w=1051&ssl=1"),
     title: String = "맥북 에어 13인치",
-    category: CategoryRequest = CategoryRequest("전자기기", "노트북"),
+    subCategoryId: Long = 1,
     description: String = "얼마 안쓴 맥북 팝니다",
     startPrice: Int = 100000,
     bidUnit: Int = 1000,
     closingTime: String = "2100-07-31T12:00:00",
-    directRegions: List<DirectRegionRequest> = listOf(DirectRegionRequest("경기도", "부천시", "원미구")),
+    thirdRegionIds: List<Long> = listOf(1),
 ) = RegisterAuctionRequest(
-    images,
     title,
-    category,
+    subCategoryId,
     description,
     startPrice,
     bidUnit,
     closingTime,
-    directRegions,
+    thirdRegionIds,
 )
 
-fun createRegisterAuctionResponse(id: Long = 2) = RegisterAuctionResponse(id)
 fun createAuctionDetailResponse(
     auction: AuctionResponse = createAuctionResponse(),
     seller: SellerResponse = createSellerResponse(),


### PR DESCRIPTION
## 📄 작업 내용 요약
경매 등록 시 갤러리 이미지를 서버로 전송할 수 있는 기능을 구현했습니다.

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
service를 보시면 images 파트와 json body 파트 둘로 나눠서 서버로 전송하고 있고 api 명세도 이에 따라 수정된 상태입니다!
### 문제점
1. 버전 호환성 문제
현재 API 33에서는 잘 동작하는데 이전 버전에서는 잘 동작하지 않는 것 같습니다.
API 30에서는 절대 경로를 가져올 때 cursor의 column 정보를 읽어오는 곳에서 정보를 읽어오지 못하는 문제가 있고,
API 28에서는 절대 경로가 storage로 시작하는데 이 경로의 경우 사용자에게 권한을 얻어와야 하는데 아직 권한을 물어보는 코드는 작성하지 않은 상태입니다.
2. 파일 업로드 시 용량 제한 문제
서버에서 전체 파일이 110MB를 넘지 않도록 설정해 두었는데 현재는 이미지를 압축하는 코드를 작성하지 않아서 이미지를 업로드하는데 문제가 존재합니다.
추후에 이미지를 압축하여 서버로 전송하는 코드를 추가할 예정입니다!

## 📎 Issue 번호
- closed: #175 
