### PR TITLE
경매 엔티티에 판매자 필드 추가

### DIFF
--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
@@ -41,12 +41,8 @@ public class AuctionService {
     @Transactional
     public CreateInfoAuctionDto create(final CreateAuctionDto dto) {
         final Auction auction = dto.toEntity();
-        final User seller = userRepository.findById(dto.sellerId())
-                                        .orElseThrow(() -> new UserNotFoundException("지정한 판매자를 찾을 수 없습니다."));
-        final Category subCategory = categoryRepository.findSubCategoryById(dto.subCategoryId())
-                                                       .orElseThrow(() -> new CategoryNotFoundException(
-                                                               "지정한 하위 카테고리가 없거나 하위 카테고리가 아닙니다."
-                                                       ));
+        final User seller = findSeller(dto);
+        final Category subCategory = findSubCategory(dto);
         final List<AuctionRegion> auctionRegions = convertAuctionRegions(dto);
         final List<AuctionImage> auctionImages = convertAuctionImages(dto);
 
@@ -58,6 +54,18 @@ public class AuctionService {
         final Auction persistAuction = auctionRepository.save(auction);
 
         return CreateInfoAuctionDto.from(persistAuction);
+    }
+
+    private User findSeller(final CreateAuctionDto dto) {
+        return userRepository.findById(dto.sellerId())
+                             .orElseThrow(() -> new UserNotFoundException("지정한 판매자를 찾을 수 없습니다."));
+    }
+
+    private Category findSubCategory(final CreateAuctionDto dto) {
+        return categoryRepository.findSubCategoryById(dto.subCategoryId())
+                                 .orElseThrow(() -> new CategoryNotFoundException(
+                                         "지정한 하위 카테고리가 없거나 하위 카테고리가 아닙니다."
+                                 ));
     }
 
     private List<AuctionRegion> convertAuctionRegions(final CreateAuctionDto dto) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
@@ -40,28 +40,24 @@ public class AuctionService {
 
     @Transactional
     public CreateInfoAuctionDto create(final CreateAuctionDto dto) {
-        final Auction auction = convertAuction(dto);
+        final Auction auction = dto.toEntity();
         final User seller = userRepository.findById(dto.sellerId())
                                         .orElseThrow(() -> new UserNotFoundException("지정한 판매자를 찾을 수 없습니다."));
+        final Category subCategory = categoryRepository.findSubCategoryById(dto.subCategoryId())
+                                                       .orElseThrow(() -> new CategoryNotFoundException(
+                                                               "지정한 하위 카테고리가 없거나 하위 카테고리가 아닙니다."
+                                                       ));
         final List<AuctionRegion> auctionRegions = convertAuctionRegions(dto);
         final List<AuctionImage> auctionImages = convertAuctionImages(dto);
 
         auction.addAuctionRegions(auctionRegions);
         auction.addAuctionImages(auctionImages);
         auction.addSeller(seller);
+        auction.addSubCategory(subCategory);
 
         final Auction persistAuction = auctionRepository.save(auction);
 
         return CreateInfoAuctionDto.from(persistAuction);
-    }
-
-    private Auction convertAuction(final CreateAuctionDto dto) {
-        final Category subCategory = categoryRepository.findSubCategoryById(dto.subCategoryId())
-                                                       .orElseThrow(() -> new CategoryNotFoundException(
-                                                               "지정한 하위 카테고리가 없거나 하위 카테고리가 아닙니다."
-                                                       ));
-
-        return dto.toEntity(subCategory);
     }
 
     private List<AuctionRegion> convertAuctionRegions(final CreateAuctionDto dto) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
@@ -7,6 +7,7 @@ import com.ddang.ddang.auction.application.dto.ReadAuctionsDto;
 import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
 import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.infrastructure.persistence.JpaAuctionRepository;
+import com.ddang.ddang.bid.application.exception.UserNotFoundException;
 import com.ddang.ddang.category.application.exception.CategoryNotFoundException;
 import com.ddang.ddang.category.domain.Category;
 import com.ddang.ddang.category.infrastructure.persistence.JpaCategoryRepository;
@@ -17,6 +18,8 @@ import com.ddang.ddang.region.application.exception.RegionNotFoundException;
 import com.ddang.ddang.region.domain.AuctionRegion;
 import com.ddang.ddang.region.domain.Region;
 import com.ddang.ddang.region.infrastructure.persistence.JpaRegionRepository;
+import com.ddang.ddang.user.domain.User;
+import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AuctionService {
 
+    private final JpaUserRepository userRepository;
     private final JpaAuctionRepository auctionRepository;
     private final JpaRegionRepository regionRepository;
     private final JpaCategoryRepository categoryRepository;
@@ -37,11 +41,14 @@ public class AuctionService {
     @Transactional
     public CreateInfoAuctionDto create(final CreateAuctionDto dto) {
         final Auction auction = convertAuction(dto);
+        final User seller = userRepository.findById(dto.sellerId())
+                                        .orElseThrow(() -> new UserNotFoundException("지정한 판매자를 찾을 수 없습니다."));
         final List<AuctionRegion> auctionRegions = convertAuctionRegions(dto);
         final List<AuctionImage> auctionImages = convertAuctionImages(dto);
 
         auction.addAuctionRegions(auctionRegions);
         auction.addAuctionImages(auctionImages);
+        auction.addSeller(seller);
 
         final Auction persistAuction = auctionRepository.save(auction);
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/CreateAuctionDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/CreateAuctionDto.java
@@ -18,10 +18,16 @@ public record CreateAuctionDto(
         LocalDateTime closingTime,
         List<Long> thirdRegionIds,
         Long subCategoryId,
-        List<MultipartFile> auctionImages
+        List<MultipartFile> auctionImages,
+        Long sellerId
 ) {
 
-    public static CreateAuctionDto from(final CreateAuctionRequest request, final List<MultipartFile> images) {
+    public static CreateAuctionDto from(
+            final CreateAuctionRequest request,
+            final List<MultipartFile> images,
+            // TODO 3차 데모데이 이후 리펙토링 예정
+            final Long sellerId
+    ) {
         return new CreateAuctionDto(
                 request.title(),
                 request.description(),
@@ -30,7 +36,8 @@ public record CreateAuctionDto(
                 request.closingTime(),
                 calculateThirdRegionIds(request),
                 request.subCategoryId(),
-                images
+                images,
+                sellerId
         );
     }
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/CreateAuctionDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/CreateAuctionDto.java
@@ -4,7 +4,6 @@ import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.domain.BidUnit;
 import com.ddang.ddang.auction.domain.Price;
 import com.ddang.ddang.auction.presentation.dto.request.CreateAuctionRequest;
-import com.ddang.ddang.category.domain.Category;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -49,14 +48,13 @@ public record CreateAuctionDto(
         return request.thirdRegionIds();
     }
 
-    public Auction toEntity(final Category subCategory) {
+    public Auction toEntity() {
         return Auction.builder()
                       .title(title)
                       .description(description)
                       .bidUnit(new BidUnit(bidUnit))
                       .startPrice(new Price(startPrice))
                       .closingTime(closingTime)
-                      .subCategory(subCategory)
                       .build();
     }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/ReadAuctionDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/ReadAuctionDto.java
@@ -20,7 +20,11 @@ public record ReadAuctionDto(
         List<ReadRegionsDto> auctionRegions,
         List<Long> auctionImageIds,
         String mainCategory,
-        String subCategory
+        String subCategory,
+        Long sellerId,
+        String sellerProfile,
+        String sellerName,
+        double sellerReliability
 ) {
 
     public static ReadAuctionDto from(final Auction auction) {
@@ -37,7 +41,11 @@ public record ReadAuctionDto(
                 convertReadRegionsDto(auction),
                 convertImageUrls(auction),
                 auction.getSubCategory().getMainCategory().getName(),
-                auction.getSubCategory().getName()
+                auction.getSubCategory().getName(),
+                auction.getSeller().getId(),
+                auction.getSeller().getProfileImage(),
+                auction.getSeller().getName(),
+                auction.getSeller().getReliability()
         );
     }
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/exception/UserNotAuthorizationException.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/exception/UserNotAuthorizationException.java
@@ -1,0 +1,8 @@
+package com.ddang.ddang.auction.application.exception;
+
+public class UserNotAuthorizationException extends IllegalArgumentException {
+
+    public UserNotAuthorizationException(final String message) {
+        super(message);
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
@@ -87,15 +87,13 @@ public class Auction extends BaseTimeEntity {
             final String description,
             final BidUnit bidUnit,
             final Price startPrice,
-            final LocalDateTime closingTime,
-            final Category subCategory
+            final LocalDateTime closingTime
     ) {
         this.title = title;
         this.description = description;
         this.bidUnit = bidUnit;
         this.startPrice = startPrice;
         this.closingTime = closingTime;
-        this.subCategory = subCategory;
     }
 
     public void delete() {

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
@@ -120,6 +120,10 @@ public class Auction extends BaseTimeEntity {
         this.seller = seller;
     }
 
+    public void addSubCategory(final Category subCategory) {
+        this.subCategory = subCategory;
+    }
+
     public boolean isClosed(final LocalDateTime targetTime) {
         return targetTime.isAfter(closingTime);
     }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
@@ -5,6 +5,7 @@ import com.ddang.ddang.category.domain.Category;
 import com.ddang.ddang.common.entity.BaseTimeEntity;
 import com.ddang.ddang.image.domain.AuctionImage;
 import com.ddang.ddang.region.domain.AuctionRegion;
+import com.ddang.ddang.user.domain.User;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -42,6 +43,10 @@ public class Auction extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seller_id", foreignKey = @ForeignKey(name = "fk_auction_seller"))
+    private User seller;
 
     @Column(length = 30)
     private String title;
@@ -104,6 +109,17 @@ public class Auction extends BaseTimeEntity {
         }
     }
 
+    public void addAuctionImages(final List<AuctionImage> auctionImages) {
+        for (final AuctionImage auctionImage : auctionImages) {
+            this.auctionImages.add(auctionImage);
+            auctionImage.initAuction(this);
+        }
+    }
+
+    public void addSeller(final User seller) {
+        this.seller = seller;
+    }
+
     public boolean isClosed(final LocalDateTime targetTime) {
         return targetTime.isAfter(closingTime);
     }
@@ -123,12 +139,5 @@ public class Auction extends BaseTimeEntity {
     private Price calculateNextMinimumBidPrice() {
         final int nextMinimumBidPrice = this.lastBid.getPrice().getValue() + this.bidUnit.getValue();
         return new Price(nextMinimumBidPrice);
-    }
-
-    public void addAuctionImages(final List<AuctionImage> auctionImages) {
-        for (final AuctionImage auctionImage : auctionImages) {
-            this.auctionImages.add(auctionImage);
-            auctionImage.initAuction(this);
-        }
     }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
@@ -122,6 +122,10 @@ public class Auction extends BaseTimeEntity {
         this.subCategory = subCategory;
     }
 
+    public boolean isOwner(final User seller) {
+        return this.seller.equals(seller);
+    }
+
     public boolean isClosed(final LocalDateTime targetTime) {
         return targetTime.isAfter(closingTime);
     }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImpl.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImpl.java
@@ -31,6 +31,7 @@ public class QuerydslAuctionRepositoryImpl implements QuerydslAuctionRepository 
                 .leftJoin(region.secondRegion).fetchJoin()
                 .leftJoin(auction.subCategory, category).fetchJoin()
                 .leftJoin(category.mainCategory).fetchJoin()
+                .leftJoin(auction.seller).fetchJoin()
                 .where(auction.deleted.isFalse(), lessThanLastAuctionId(lastAuctionId))
                 .orderBy(auction.id.desc())
                 .limit(size + 1L)
@@ -57,6 +58,7 @@ public class QuerydslAuctionRepositoryImpl implements QuerydslAuctionRepository 
                 .leftJoin(region.secondRegion).fetchJoin()
                 .leftJoin(auction.subCategory, category).fetchJoin()
                 .leftJoin(category.mainCategory).fetchJoin()
+                .leftJoin(auction.seller).fetchJoin()
                 .where(auction.deleted.isFalse(), auction.id.eq(auctionId))
                 .fetchOne();
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
@@ -39,7 +39,12 @@ public class AuctionController {
             @RequestPart final List<MultipartFile> images,
             @RequestPart @Valid final CreateAuctionRequest request
     ) {
-        final CreateInfoAuctionDto createInfoAuctionDto = auctionService.create(CreateAuctionDto.from(request, images));
+        final CreateInfoAuctionDto createInfoAuctionDto = auctionService.create(CreateAuctionDto.from(
+                request,
+                images,
+                // TODO 3차 데모데이 이후 리펙토링 예정
+                1L
+        ));
         final CreateAuctionResponse response = CreateAuctionResponse.of(createInfoAuctionDto, calculateBaseImageUrl());
 
         return ResponseEntity.created(URI.create("/auctions/" + createInfoAuctionDto.id()))

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
@@ -75,7 +75,8 @@ public class AuctionController {
 
     @DeleteMapping("/{auctionId}")
     public ResponseEntity<Void> delete(@PathVariable final Long auctionId) {
-        auctionService.deleteByAuctionId(auctionId);
+        // TODO 3차 데모데이 이후 리펙토링 예정
+        auctionService.deleteByAuctionId(auctionId, 1L);
 
         return ResponseEntity.noContent()
                              .build();

--- a/backend/ddang/src/main/java/com/ddang/ddang/configuration/InitializationAuctionConfiguration.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/configuration/InitializationAuctionConfiguration.java
@@ -53,7 +53,6 @@ public class InitializationAuctionConfiguration implements ApplicationRunner {
                                         .bidUnit(new BidUnit(1_000))
                                         .startPrice(new Price(1_000_000))
                                         .closingTime(LocalDateTime.now())
-                                        .subCategory(sub)
                                         .build();
         auction1.addAuctionRegions(List.of(auctionRegion1));
 
@@ -64,7 +63,6 @@ public class InitializationAuctionConfiguration implements ApplicationRunner {
                                         .startPrice(new Price(900_000))
                                         .closingTime(LocalDateTime.now()
                                                                   .plusDays(5L))
-                                        .subCategory(sub)
                                         .build();
         auction2.addAuctionRegions(List.of(auctionRegion2));
 

--- a/backend/ddang/src/main/resources/db/migration/V3__alter_auction_tables.sql
+++ b/backend/ddang/src/main/resources/db/migration/V3__alter_auction_tables.sql
@@ -1,0 +1,3 @@
+alter table auction add seller_id bigint;
+
+alter table auction add constraint fk_auction_seller foreign key (seller_id) references users (id);

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
@@ -1,5 +1,10 @@
 package com.ddang.ddang.auction.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
 import com.ddang.ddang.auction.application.dto.CreateAuctionDto;
 import com.ddang.ddang.auction.application.dto.CreateInfoAuctionDto;
 import com.ddang.ddang.auction.application.dto.ReadAuctionDto;
@@ -15,7 +20,10 @@ import com.ddang.ddang.image.domain.dto.StoreImageDto;
 import com.ddang.ddang.region.application.exception.RegionNotFoundException;
 import com.ddang.ddang.region.domain.Region;
 import com.ddang.ddang.region.infrastructure.persistence.JpaRegionRepository;
-import org.assertj.core.api.*;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -26,15 +34,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Transactional
@@ -92,7 +91,8 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(thirdRegion.getId()),
                 sub.getId(),
-                List.of(auctionImage)
+                List.of(auctionImage),
+                1L
         );
 
         // when
@@ -124,7 +124,8 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(3L),
                 sub.getId(),
-                List.of(auctionImage)
+                List.of(auctionImage),
+                1L
         );
 
         // when & then
@@ -164,7 +165,8 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(secondRegion.getId()),
                 sub.getId(),
-                List.of(auctionImage)
+                List.of(auctionImage),
+                1L
         );
 
         // when & then
@@ -198,7 +200,8 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(thirdRegion.getId()),
                 1L,
-                List.of(auctionImage)
+                List.of(auctionImage),
+                1L
         );
 
         // when & then
@@ -238,7 +241,8 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(thirdRegion.getId()),
                 main.getId(),
-                List.of(auctionImage)
+                List.of(auctionImage),
+                1L
         );
 
         // when & then
@@ -282,7 +286,8 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(thirdRegion.getId()),
                 sub.getId(),
-                List.of(auctionImage)
+                List.of(auctionImage),
+                1L
         );
 
         final CreateInfoAuctionDto createInfoAuctionDto = auctionService.create(createAuctionDto);
@@ -349,7 +354,8 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(thirdRegion.getId()),
                 sub.getId(),
-                List.of(auctionImage)
+                List.of(auctionImage),
+                1L
         );
         final CreateAuctionDto createAuctionDto2 = new CreateAuctionDto(
                 "경매 상품 2",
@@ -359,7 +365,8 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(thirdRegion.getId()),
                 sub.getId(),
-                List.of(auctionImage)
+                List.of(auctionImage),
+                1L
         );
 
         auctionService.create(createAuctionDto1);
@@ -411,7 +418,8 @@ class AuctionServiceTest {
                 LocalDateTime.now(),
                 List.of(thirdRegion.getId()),
                 sub.getId(),
-                List.of(auctionImage)
+                List.of(auctionImage),
+                1L
         );
 
         final CreateInfoAuctionDto createInfoAuctionDto = auctionService.create(createAuctionDto);

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/domain/AuctionTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/domain/AuctionTest.java
@@ -1,19 +1,18 @@
 package com.ddang.ddang.auction.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.ddang.ddang.bid.domain.Bid;
 import com.ddang.ddang.image.domain.AuctionImage;
 import com.ddang.ddang.region.domain.AuctionRegion;
 import com.ddang.ddang.region.domain.Region;
 import com.ddang.ddang.user.domain.User;
-import org.assertj.core.api.*;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -90,6 +89,21 @@ class AuctionTest {
             softAssertions.assertThat(auction.getAuctionImages()).isNotEmpty();
             softAssertions.assertThat(auctionImage.getAuction()).isNotNull();
         });
+    }
+
+    @Test
+    void 경매_판매자_연관_관계를_세팅한다() {
+        // given
+        final Auction auction = Auction.builder()
+                                       .title("title")
+                                       .build();
+        final User seller = new User("seller", "https://profile.com", 3.5d);
+
+        // when
+        auction.addSeller(seller);
+
+        // then
+        assertThat(auction.getSeller()).isNotNull();
     }
 
     @Test

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/domain/AuctionTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/domain/AuctionTest.java
@@ -14,6 +14,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -186,5 +187,43 @@ class AuctionTest {
 
         // then
         assertThat(actual).isTrue();
+    }
+
+    @Test
+    void 특정_회원이_경매_판매자와_일치하면_참을_반환한다() {
+        // given
+        final Auction auction = Auction.builder()
+                                       .title("title")
+                                       .bidUnit(new BidUnit(1_000))
+                                       .build();
+        final User seller = new User("사용자1", "이미지1", 4.9);
+
+        auction.addSeller(seller);
+
+        // when
+        final boolean actual = auction.isOwner(seller);
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void 특정_회원이_경매_판매자와_일치하지_않으면_거짓을_반환한다() {
+        // given
+        final Auction auction = Auction.builder()
+                                       .title("title")
+                                       .bidUnit(new BidUnit(1_000))
+                                       .build();
+        final User seller = new User("사용자1", "이미지1", 4.9);
+        final User user = new User("사용자2", "이미지2", 4.9);
+
+        ReflectionTestUtils.setField(user, "id", 1L);
+        auction.addSeller(seller);
+
+        // when
+        final boolean actual = auction.isOwner(user);
+
+        // then
+        assertThat(actual).isFalse();
     }
 }

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/domain/AuctionTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/domain/AuctionTest.java
@@ -3,6 +3,7 @@ package com.ddang.ddang.auction.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.ddang.ddang.bid.domain.Bid;
+import com.ddang.ddang.category.domain.Category;
 import com.ddang.ddang.image.domain.AuctionImage;
 import com.ddang.ddang.region.domain.AuctionRegion;
 import com.ddang.ddang.region.domain.Region;
@@ -89,6 +90,21 @@ class AuctionTest {
             softAssertions.assertThat(auction.getAuctionImages()).isNotEmpty();
             softAssertions.assertThat(auctionImage.getAuction()).isNotNull();
         });
+    }
+
+    @Test
+    void 하위_카테고리_연관_관계를_세팅한다() {
+        // given
+        final Auction auction = Auction.builder()
+                                       .title("title")
+                                       .build();
+        final Category subCategory = new Category("sub");
+
+        // when
+        auction.addSubCategory(subCategory);
+
+        // then
+        assertThat(auction.getSubCategory()).isNotNull();
     }
 
     @Test

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImplTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImplTest.java
@@ -77,7 +77,6 @@ class QuerydslAuctionRepositoryImplTest {
                                        .bidUnit(new BidUnit(1_000))
                                        .startPrice(new Price(1_000))
                                        .closingTime(LocalDateTime.now())
-                                       .subCategory(sub)
                                        .build();
 
         final Region firstRegion = new Region("서울특별시");
@@ -92,6 +91,7 @@ class QuerydslAuctionRepositoryImplTest {
 
         auction.addAuctionRegions(List.of(auctionRegion));
         auction.addSeller(seller);
+        auction.addSubCategory(sub);
 
         auctionRepository.save(auction);
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImplTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImplTest.java
@@ -7,7 +7,6 @@ import com.ddang.ddang.auction.domain.BidUnit;
 import com.ddang.ddang.auction.domain.Price;
 import com.ddang.ddang.category.domain.Category;
 import com.ddang.ddang.category.infrastructure.persistence.JpaCategoryRepository;
-import com.ddang.ddang.configuration.IsolateDatabase;
 import com.ddang.ddang.configuration.JpaConfiguration;
 import com.ddang.ddang.configuration.QuerydslConfiguration;
 import com.ddang.ddang.region.domain.AuctionRegion;
@@ -27,10 +26,11 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Slice;
 
-@IsolateDatabase
+@DataJpaTest
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 @Import({JpaConfiguration.class, QuerydslConfiguration.class})

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
@@ -128,8 +128,12 @@ class AuctionControllerTest {
                 LocalDateTime.now(),
                 List.of(readRegionsDto),
                 List.of(1L),
-                "",
-                ""
+                "main",
+                "sub",
+                1L,
+                "https://profile.com",
+                "판매자",
+                3.5d
         );
 
         given(auctionService.readByAuctionId(anyLong())).willReturn(auction);
@@ -169,7 +173,11 @@ class AuctionControllerTest {
                 List.of(readRegionsDto),
                 List.of(1L),
                 "main1",
-                "sub1"
+                "sub1",
+                1L,
+                "https://profile.com",
+                "판매자",
+                3.5d
         );
         final ReadAuctionDto auction2 = new ReadAuctionDto(
                 2L,
@@ -184,7 +192,11 @@ class AuctionControllerTest {
                 List.of(readRegionsDto),
                 List.of(1L),
                 "main2",
-                "sub2"
+                "sub2",
+                1L,
+                "https://profile.com",
+                "판매자",
+                3.5d
         );
 
         final ReadAuctionsDto readAuctionsDto = new ReadAuctionsDto(List.of(auction2, auction1), true);

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
@@ -224,7 +224,7 @@ class AuctionControllerTest {
     @Test
     void 지정한_아이디에_해당하는_경매를_삭제한다() throws Exception {
         // given
-        willDoNothing().given(auctionService).deleteByAuctionId(anyLong());
+        willDoNothing().given(auctionService).deleteByAuctionId(anyLong(), anyLong());
 
         // when & then
         mockMvc.perform(delete("/auctions/{auctionId}", 1L).contentType(MediaType.APPLICATION_JSON))

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/application/MessageServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/application/MessageServiceTest.java
@@ -67,7 +67,6 @@ class MessageServiceTest {
                                        .bidUnit(bidUnit)
                                        .startPrice(startPrice)
                                        .closingTime(LocalDateTime.now().plusDays(3L))
-                                       .subCategory(sub)
                                        .build();
 
         auctionRepository.save(auction);
@@ -125,7 +124,6 @@ class MessageServiceTest {
                                        .bidUnit(bidUnit)
                                        .startPrice(startPrice)
                                        .closingTime(LocalDateTime.now().plusDays(3L))
-                                       .subCategory(sub)
                                        .build();
 
         auctionRepository.save(auction);
@@ -180,7 +178,6 @@ class MessageServiceTest {
                                        .bidUnit(bidUnit)
                                        .startPrice(startPrice)
                                        .closingTime(LocalDateTime.now().plusDays(3L))
-                                       .subCategory(sub)
                                        .build();
 
         auctionRepository.save(auction);
@@ -231,7 +228,6 @@ class MessageServiceTest {
                                        .bidUnit(bidUnit)
                                        .startPrice(startPrice)
                                        .closingTime(LocalDateTime.now().plusDays(3L))
-                                       .subCategory(sub)
                                        .build();
 
         auctionRepository.save(auction);


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->
- 경매 엔티티에 판매자 필드 추가
- DTO 일부 수정
- 테스트 일부 수정
- flyway V3 스크립트 작성
- AuctionApplication 일부 수정
  - sellter 주입 로직 추가
  - category 초기화 방식 변경 (생성자 초기화 -> 연관관계 세팅 메서드를 활용한 초기화)
- 경매 삭제 시 판매자인지 검증하는 로직 추가
## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
AuctionController.create에서 고정된 회원 1번(판매자)를 입력하도록 한 상태입니다
추후 로그인 기능이 추가되면 컨트롤러나 CreateAuctionDto등이 전반적으로 변경될 예정입니다

추가로 이전에 변경 사항이 너무 많았던 것은 제가 이상한 코드를 수정하고 있었기 때문이었습니다
처음부터 하니 비교적 금방 끝나네요 
## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
- closed #185 
<!-- closed #번호 --> 
