### PR TITLE
카카오 소셜로그인 서버 연동

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/common/ViewModelFactory.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/common/ViewModelFactory.kt
@@ -13,12 +13,14 @@ import com.ddangddangddang.android.feature.register.category.SelectCategoryViewM
 import com.ddangddangddang.android.feature.register.region.SelectRegionsViewModel
 import com.ddangddangddang.data.remote.AuctionRetrofit
 import com.ddangddangddang.data.repository.AuctionRepositoryImpl
+import com.ddangddangddang.data.repository.AuthRepositoryImpl
 import com.ddangddangddang.data.repository.CategoryRepositoryImpl
 import com.ddangddangddang.data.repository.RegionRepositoryImpl
 
-val repository = AuctionRepositoryImpl.getInstance(AuctionRetrofit.getInstance().service)
+val auctionRepository = AuctionRepositoryImpl.getInstance(AuctionRetrofit.getInstance().service)
 val categoryRepository = CategoryRepositoryImpl.getInstance(AuctionRetrofit.getInstance().service)
 val regionRepository = RegionRepositoryImpl.getInstance(AuctionRetrofit.getInstance().service)
+val authRepository = AuthRepositoryImpl.getInstance(AuctionRetrofit.getInstance().service)
 
 @Suppress("UNCHECKED_CAST")
 val viewModelFactory = object : ViewModelProvider.Factory {
@@ -27,13 +29,28 @@ val viewModelFactory = object : ViewModelProvider.Factory {
             // 레포지토리 싱글톤 객체 얻어옴
             when {
                 isAssignableFrom(MainViewModel::class.java) -> MainViewModel()
-                isAssignableFrom(HomeViewModel::class.java) -> HomeViewModel(repository)
-                isAssignableFrom(AuctionDetailViewModel::class.java) -> AuctionDetailViewModel(repository)
-                isAssignableFrom(RegisterAuctionViewModel::class.java) -> RegisterAuctionViewModel(repository)
-                isAssignableFrom(AuctionBidViewModel::class.java) -> AuctionBidViewModel(repository)
-                isAssignableFrom(SelectCategoryViewModel::class.java) -> SelectCategoryViewModel(categoryRepository)
-                isAssignableFrom(SelectRegionsViewModel::class.java) -> SelectRegionsViewModel(regionRepository)
-                isAssignableFrom(LoginViewModel::class.java) -> LoginViewModel()
+                isAssignableFrom(HomeViewModel::class.java) -> HomeViewModel(auctionRepository)
+                isAssignableFrom(AuctionDetailViewModel::class.java) -> AuctionDetailViewModel(
+                    auctionRepository,
+                )
+
+                isAssignableFrom(RegisterAuctionViewModel::class.java) -> RegisterAuctionViewModel(
+                    auctionRepository,
+                )
+
+                isAssignableFrom(AuctionBidViewModel::class.java) -> AuctionBidViewModel(
+                    auctionRepository,
+                )
+
+                isAssignableFrom(SelectCategoryViewModel::class.java) -> SelectCategoryViewModel(
+                    categoryRepository,
+                )
+
+                isAssignableFrom(SelectRegionsViewModel::class.java) -> SelectRegionsViewModel(
+                    regionRepository,
+                )
+
+                isAssignableFrom(LoginViewModel::class.java) -> LoginViewModel(authRepository)
                 else -> throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
             }
         } as T

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/common/ViewModelFactory.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/common/ViewModelFactory.kt
@@ -11,16 +11,15 @@ import com.ddangddangddang.android.feature.main.MainViewModel
 import com.ddangddangddang.android.feature.register.RegisterAuctionViewModel
 import com.ddangddangddang.android.feature.register.category.SelectCategoryViewModel
 import com.ddangddangddang.android.feature.register.region.SelectRegionsViewModel
+import com.ddangddangddang.android.global.DdangDdangDdang
 import com.ddangddangddang.data.remote.AuctionRetrofit
 import com.ddangddangddang.data.repository.AuctionRepositoryImpl
-import com.ddangddangddang.data.repository.AuthRepositoryImpl
 import com.ddangddangddang.data.repository.CategoryRepositoryImpl
 import com.ddangddangddang.data.repository.RegionRepositoryImpl
 
 val auctionRepository = AuctionRepositoryImpl.getInstance(AuctionRetrofit.getInstance().service)
 val categoryRepository = CategoryRepositoryImpl.getInstance(AuctionRetrofit.getInstance().service)
 val regionRepository = RegionRepositoryImpl.getInstance(AuctionRetrofit.getInstance().service)
-val authRepository = AuthRepositoryImpl.getInstance(AuctionRetrofit.getInstance().service)
 
 @Suppress("UNCHECKED_CAST")
 val viewModelFactory = object : ViewModelProvider.Factory {
@@ -50,7 +49,7 @@ val viewModelFactory = object : ViewModelProvider.Factory {
                     regionRepository,
                 )
 
-                isAssignableFrom(LoginViewModel::class.java) -> LoginViewModel(authRepository)
+                isAssignableFrom(LoginViewModel::class.java) -> LoginViewModel(DdangDdangDdang.authRepository)
                 else -> throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
             }
         } as T

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/login/LoginActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/login/LoginActivity.kt
@@ -50,7 +50,7 @@ class LoginActivity :
                 }
                 loginByKakaoAccount()
             } else if (token != null) {
-                completeLogin(token)
+                completeLoginByKakao(token)
             }
         }
     }
@@ -63,7 +63,7 @@ class LoginActivity :
             if (error != null) {
                 logLoginError(error)
             } else if (token != null) {
-                completeLogin(token)
+                completeLoginByKakao(token)
             }
         }
     }
@@ -72,7 +72,7 @@ class LoginActivity :
         Log.d("test", "로그인 실패 $error")
     }
 
-    private fun completeLogin(token: OAuthToken) {
-        Log.d("test", "로그인 성공 ${token.accessToken}")
+    private fun completeLoginByKakao(token: OAuthToken) {
+        viewModel.completeLoginByKakao(token.accessToken)
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/login/LoginViewModel.kt
@@ -2,15 +2,34 @@ package com.ddangddangddang.android.feature.login
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.ddangddangddang.android.util.livedata.SingleLiveEvent
+import com.ddangddangddang.data.model.request.KakaoLoginRequest
+import com.ddangddangddang.data.remote.ApiResponse
+import com.ddangddangddang.data.repository.AuthRepositoryImpl
+import kotlinx.coroutines.launch
 
-class LoginViewModel : ViewModel() {
+class LoginViewModel(
+    private val repository: AuthRepositoryImpl,
+) : ViewModel() {
     private val _event: SingleLiveEvent<LoginEvent> = SingleLiveEvent()
     val event: LiveData<LoginEvent>
         get() = _event
 
     fun loginByKakao() {
         _event.value = LoginEvent.KakaoLoginEvent
+    }
+
+    fun completeLoginByKakao(accessToken: String) {
+        viewModelScope.launch {
+            val kakaoToken = KakaoLoginRequest(accessToken)
+            when (repository.loginByKakao(kakaoToken)) {
+                is ApiResponse.Success -> {}
+                is ApiResponse.Failure -> {}
+                is ApiResponse.NetworkError -> {}
+                is ApiResponse.Unexpected -> {}
+            }
+        }
     }
 
     sealed class LoginEvent {

--- a/android/app/src/main/java/com/ddangddangddang/android/global/DdangDdangDdang.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/global/DdangDdangDdang.kt
@@ -2,13 +2,18 @@ package com.ddangddangddang.android.global
 
 import android.app.Application
 import com.ddangddangddang.android.BuildConfig
+import com.ddangddangddang.data.remote.AuctionRetrofit
+import com.ddangddangddang.data.repository.AuthRepositoryImpl
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.kakao.sdk.common.KakaoSdk
+import kotlin.NullPointerException
 
 class DdangDdangDdang : Application() {
     override fun onCreate() {
         super.onCreate()
         _firebaseAnalytics = FirebaseAnalytics.getInstance(this)
+        _authRepository =
+            AuthRepositoryImpl.getInstance(this, AuctionRetrofit.getInstance().service)
 
         KakaoSdk.init(this, BuildConfig.KEY_KAKAO)
     }
@@ -17,5 +22,8 @@ class DdangDdangDdang : Application() {
         private var _firebaseAnalytics: FirebaseAnalytics? = null
         val firebaseAnalytics: FirebaseAnalytics?
             get() = _firebaseAnalytics
+        private var _authRepository: AuthRepositoryImpl? = null
+        val authRepository: AuthRepositoryImpl
+            get() = _authRepository ?: throw NullPointerException("AuthRepository가 존재하지 않습니다.")
     }
 }

--- a/android/data/build.gradle
+++ b/android/data/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     implementation 'com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1'
 
+    // EncryptedSharedPreferences
+    implementation 'androidx.security:security-crypto:1.0.0'
+
     // 테스트
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuthLocalDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuthLocalDataSource.kt
@@ -1,3 +1,15 @@
 package com.ddangddangddang.data.datasource
 
-class AuthLocalDataSource
+import com.ddangddangddang.data.local.AuthSharedPreference
+import com.ddangddangddang.data.model.response.TokenResponse
+
+class AuthLocalDataSource(private val sharedPreferences: AuthSharedPreference) {
+    fun saveToken(token: TokenResponse) {
+        sharedPreferences.accessToken = token.accessToken
+        sharedPreferences.refreshToken = token.refreshToken
+    }
+
+    fun getAccessToken(): String = sharedPreferences.accessToken
+
+    fun getRefreshToken(): String = sharedPreferences.refreshToken
+}

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuthLocalDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuthLocalDataSource.kt
@@ -1,0 +1,3 @@
+package com.ddangddangddang.data.datasource
+
+class AuthLocalDataSource

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuthRemoteDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuthRemoteDataSource.kt
@@ -1,0 +1,11 @@
+package com.ddangddangddang.data.datasource
+
+import com.ddangddangddang.data.model.request.KakaoLoginRequest
+import com.ddangddangddang.data.model.response.TokenResponse
+import com.ddangddangddang.data.remote.ApiResponse
+import com.ddangddangddang.data.remote.Service
+
+class AuthRemoteDataSource(private val service: Service) {
+    suspend fun loginByKakao(kakaoToken: KakaoLoginRequest): ApiResponse<TokenResponse> =
+        service.loginByKakao(kakaoToken)
+}

--- a/android/data/src/main/java/com/ddangddangddang/data/local/AuthSharedPreference.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/local/AuthSharedPreference.kt
@@ -1,0 +1,43 @@
+package com.ddangddangddang.data.local
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+
+class AuthSharedPreference(context: Context) {
+    private val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+    private val sharedPreferences: SharedPreferences
+    var accessToken: String
+        get() = sharedPreferences.getString(KEY_ACCESS_TOKEN, "") ?: ""
+        set(value) {
+            sharedPreferences
+                .edit()
+                .putString(KEY_ACCESS_TOKEN, value)
+                .apply()
+        }
+    var refreshToken: String
+        get() = sharedPreferences.getString(KEY_REFRESH_TOKEN, "") ?: ""
+        set(value) {
+            sharedPreferences
+                .edit()
+                .putString(KEY_REFRESH_TOKEN, value)
+                .apply()
+        }
+
+    init {
+        sharedPreferences = EncryptedSharedPreferences.create(
+            FILE_NAME,
+            masterKeyAlias,
+            context.applicationContext,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+    }
+
+    companion object {
+        private const val FILE_NAME = "auth"
+        private const val KEY_ACCESS_TOKEN = "access_token"
+        private const val KEY_REFRESH_TOKEN = "refresh_token"
+    }
+}

--- a/android/data/src/main/java/com/ddangddangddang/data/model/request/KakaoLoginRequest.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/model/request/KakaoLoginRequest.kt
@@ -1,5 +1,8 @@
 package com.ddangddangddang.data.model.request
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class KakaoLoginRequest(
     val accessToken: String,
 )

--- a/android/data/src/main/java/com/ddangddangddang/data/model/request/KakaoLoginRequest.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/model/request/KakaoLoginRequest.kt
@@ -1,0 +1,5 @@
+package com.ddangddangddang.data.model.request
+
+data class KakaoLoginRequest(
+    val accessToken: String,
+)

--- a/android/data/src/main/java/com/ddangddangddang/data/model/response/TokenResponse.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/model/response/TokenResponse.kt
@@ -1,5 +1,8 @@
 package com.ddangddangddang.data.model.response
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class TokenResponse(
     val accessToken: String,
     val refreshToken: String,

--- a/android/data/src/main/java/com/ddangddangddang/data/model/response/TokenResponse.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/model/response/TokenResponse.kt
@@ -1,0 +1,6 @@
+package com.ddangddangddang.data.model.response
+
+data class TokenResponse(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/android/data/src/main/java/com/ddangddangddang/data/remote/Service.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/remote/Service.kt
@@ -1,11 +1,13 @@
 package com.ddangddangddang.data.remote
 
 import com.ddangddangddang.data.model.request.AuctionBidRequest
+import com.ddangddangddang.data.model.request.KakaoLoginRequest
 import com.ddangddangddang.data.model.response.AuctionDetailResponse
 import com.ddangddangddang.data.model.response.AuctionPreviewResponse
 import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
-import com.ddangddangddang.data.model.response.RegionDetailResponse
 import com.ddangddangddang.data.model.response.EachCategoryResponse
+import com.ddangddangddang.data.model.response.RegionDetailResponse
+import com.ddangddangddang.data.model.response.TokenResponse
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.http.Body
@@ -39,7 +41,7 @@ interface Service {
         @Header("Authorization") authorization: String,
         @Body auctionBidRequest: AuctionBidRequest,
     ): ApiResponse<Unit>
-  
+
     @GET("/regions")
     suspend fun fetchFirstRegions(): ApiResponse<List<RegionDetailResponse>>
 
@@ -57,4 +59,9 @@ interface Service {
 
     @GET("/categories/{id}")
     suspend fun fetchSubCategories(@Path("id") mainId: Long): ApiResponse<List<EachCategoryResponse>>
+
+    @POST("/oauth2/login/kakao")
+    suspend fun loginByKakao(
+        @Body kakaoLoginRequest: KakaoLoginRequest,
+    ): ApiResponse<TokenResponse>
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuthRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuthRepository.kt
@@ -6,4 +6,8 @@ import com.ddangddangddang.data.remote.ApiResponse
 
 interface AuthRepository {
     suspend fun loginByKakao(kakaoToken: KakaoLoginRequest): ApiResponse<TokenResponse>
+
+    fun getAccessToken(): String
+
+    fun getRefreshToken(): String
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuthRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuthRepository.kt
@@ -1,0 +1,9 @@
+package com.ddangddangddang.data.repository
+
+import com.ddangddangddang.data.model.request.KakaoLoginRequest
+import com.ddangddangddang.data.model.response.TokenResponse
+import com.ddangddangddang.data.remote.ApiResponse
+
+interface AuthRepository {
+    suspend fun loginByKakao(kakaoToken: KakaoLoginRequest): ApiResponse<TokenResponse>
+}

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuthRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuthRepositoryImpl.kt
@@ -1,0 +1,36 @@
+package com.ddangddangddang.data.repository
+
+import com.ddangddangddang.data.datasource.AuthLocalDataSource
+import com.ddangddangddang.data.datasource.AuthRemoteDataSource
+import com.ddangddangddang.data.model.request.KakaoLoginRequest
+import com.ddangddangddang.data.model.response.TokenResponse
+import com.ddangddangddang.data.remote.ApiResponse
+import com.ddangddangddang.data.remote.Service
+
+class AuthRepositoryImpl private constructor(
+    private val localDataSource: AuthLocalDataSource,
+    private val remoteDataSource: AuthRemoteDataSource,
+) : AuthRepository {
+    override suspend fun loginByKakao(kakaoToken: KakaoLoginRequest): ApiResponse<TokenResponse> {
+        val response = remoteDataSource.loginByKakao(kakaoToken)
+        return response
+    }
+
+    companion object {
+        @Volatile
+        private var instance: AuthRepositoryImpl? = null
+
+        fun getInstance(service: Service): AuthRepositoryImpl {
+            return instance ?: synchronized(this) {
+                instance ?: createInstance(service)
+            }
+        }
+
+        private fun createInstance(service: Service): AuthRepositoryImpl {
+            val localDataSource = AuthLocalDataSource()
+            val remoteDataSource = AuthRemoteDataSource(service)
+            return AuthRepositoryImpl(localDataSource, remoteDataSource)
+                .also { instance = it }
+        }
+    }
+}

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuthRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuthRepositoryImpl.kt
@@ -1,7 +1,9 @@
 package com.ddangddangddang.data.repository
 
+import android.content.Context
 import com.ddangddangddang.data.datasource.AuthLocalDataSource
 import com.ddangddangddang.data.datasource.AuthRemoteDataSource
+import com.ddangddangddang.data.local.AuthSharedPreference
 import com.ddangddangddang.data.model.request.KakaoLoginRequest
 import com.ddangddangddang.data.model.response.TokenResponse
 import com.ddangddangddang.data.remote.ApiResponse
@@ -13,21 +15,29 @@ class AuthRepositoryImpl private constructor(
 ) : AuthRepository {
     override suspend fun loginByKakao(kakaoToken: KakaoLoginRequest): ApiResponse<TokenResponse> {
         val response = remoteDataSource.loginByKakao(kakaoToken)
+        if (response is ApiResponse.Success) {
+            localDataSource.saveToken(response.body)
+        }
         return response
     }
+
+    override fun getAccessToken(): String = localDataSource.getAccessToken()
+
+    override fun getRefreshToken(): String = localDataSource.getRefreshToken()
 
     companion object {
         @Volatile
         private var instance: AuthRepositoryImpl? = null
 
-        fun getInstance(service: Service): AuthRepositoryImpl {
+        fun getInstance(context: Context, service: Service): AuthRepositoryImpl {
             return instance ?: synchronized(this) {
-                instance ?: createInstance(service)
+                instance ?: createInstance(context, service)
             }
         }
 
-        private fun createInstance(service: Service): AuthRepositoryImpl {
-            val localDataSource = AuthLocalDataSource()
+        private fun createInstance(context: Context, service: Service): AuthRepositoryImpl {
+            val sharedPreferences = AuthSharedPreference(context)
+            val localDataSource = AuthLocalDataSource(sharedPreferences)
             val remoteDataSource = AuthRemoteDataSource(service)
             return AuthRepositoryImpl(localDataSource, remoteDataSource)
                 .also { instance = it }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/RegionRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/RegionRepositoryImpl.kt
@@ -5,8 +5,9 @@ import com.ddangddangddang.data.model.response.RegionDetailResponse
 import com.ddangddangddang.data.remote.ApiResponse
 import com.ddangddangddang.data.remote.Service
 
-class RegionRepositoryImpl(private val remoteDataSource: RegionRemoteDataSource) :
-    RegionRepository {
+class RegionRepositoryImpl private constructor(
+    private val remoteDataSource: RegionRemoteDataSource,
+) : RegionRepository {
 
     override suspend fun getFirstRegions(): ApiResponse<List<RegionDetailResponse>> {
         return remoteDataSource.getFirstRegions()


### PR DESCRIPTION
## 📄 작업 내용 요약
카카오로부터 받아온 토큰 정보를 서버에 전송하여 서버 자체 토큰을 받아오는 기능을 구현하였습니다.
서버로부터 받아온 자체 토큰을 EncryptedSharedPreferences에 암호화된 상태로 저장하고 decrypt하여 가져올 수 있도록 하였습니다.

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
AuthSharedPreferences는 토큰만을 관리합니다.
AuthSharedPreferences는 앱 전체에서 한 번만 생성하여 AuthRepository 생성 시 생성자로 넘겨주도록 하였습니다.
AuthRepository를 통해서만 토큰 정보를 수정하고 가져올 수 있도록 할 예정입니다.
AuthSharedPreferences 생성을 위해서는 context가 필요한데 앱 전체에서 하나의 인스턴스만 생성하고 싶기 때문에 application class에서 AuthSharedPreferences와 AuthRepository를 생성하고 있습니다.

## 📎 Issue 번호
- closed : #230 
