### PR TITLE
경매 목록 새로고침 기능 추가

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 
     // lifecycle
     implementation 'androidx.activity:activity-ktx:1.7.2'   // by viewModels()

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
@@ -42,6 +42,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
         if (viewModel.lastAuctionId.value == null) {
             viewModel.loadAuctions()
         }
+        setupReloadAuctions()
     }
 
     private fun setupViewModel() {
@@ -76,6 +77,13 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
             adapter = auctionAdapter
             addItemDecoration(AuctionSpaceItemDecoration(spanCount = 2, space = 20))
             addOnScrollListener(auctionScrollListener)
+        }
+    }
+
+    private fun setupReloadAuctions() {
+        binding.srlReloadAuctions.setOnRefreshListener {
+            viewModel.reloadAuctions()
+            binding.srlReloadAuctions.isRefreshing = false
         }
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
@@ -60,6 +60,27 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
         _event.value = HomeEvent.NavigateToRegisterAuction
     }
 
+    fun reloadAuctions() {
+        if (loadingAuctionInProgress.not()) {
+            _loadingAuctionsInProgress = true
+            viewModelScope.launch {
+                when (
+                    val response =
+                        repository.reloadAuctionPreviews(SIZE_AUCTION_LOAD)
+                ) {
+                    is ApiResponse.Success -> {
+                        _isLast = response.body.isLast
+                    }
+
+                    is ApiResponse.Failure -> {}
+                    is ApiResponse.NetworkError -> {}
+                    is ApiResponse.Unexpected -> {}
+                }
+                _loadingAuctionsInProgress = false
+            }
+        }
+    }
+
     sealed class HomeEvent {
         data class NavigateToAuctionDetail(val auctionId: Long) : HomeEvent()
         object NavigateToRegisterAuction : HomeEvent()

--- a/android/app/src/main/res/layout/fragment_home.xml
+++ b/android/app/src/main/res/layout/fragment_home.xml
@@ -82,16 +82,22 @@
             </com.google.android.material.chip.ChipGroup>
         </HorizontalScrollView>
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rv_auction"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/srl_reload_auctions"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/sv_filter"
-            app:spanCount="2" />
+            app:layout_constraintTop_toBottomOf="@id/sv_filter">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_auction"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                app:spanCount="2" />
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:layout_width="wrap_content"

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionLocalDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionLocalDataSource.kt
@@ -34,4 +34,8 @@ class AuctionLocalDataSource {
         }
         auctionPreviews.value = updatedList
     }
+
+    fun resetAuctionPreviews(auctions: List<AuctionPreviewResponse>) {
+        auctionPreviews.value = auctions
+    }
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
@@ -26,4 +26,6 @@ interface AuctionRepository {
         auctionId: Long,
         bidPrice: Int,
     ): ApiResponse<Unit>
+
+    suspend fun reloadAuctionPreviews(size: Int): ApiResponse<AuctionPreviewsResponse>
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
@@ -58,6 +58,14 @@ class AuctionRepositoryImpl private constructor(
         return remoteDataSource.submitAuctionBid(AuctionBidRequest(auctionId, bidPrice))
     }
 
+    override suspend fun reloadAuctionPreviews(size: Int): ApiResponse<AuctionPreviewsResponse> {
+        val response = remoteDataSource.getAuctionPreviews(null, size)
+        if (response is ApiResponse.Success) {
+            localDataSource.resetAuctionPreviews(response.body.auctions)
+        }
+        return response
+    }
+
     companion object {
         @Volatile
         private var instance: AuctionRepositoryImpl? = null


### PR DESCRIPTION
## 📄 작업 내용 요약
경매 목록을 새로고침하는 기능을 추가했습니다.

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
- 경매 목록을 추가로 불러오는 함수와 경매 목록을 새로고침하는 코드는 약간 차이가 있어서 함수를 분리하게 되었습니다!
분리하면서 함수명이 애매해져서 (reget은 아닌 것 같아서^-^) `reload`와 `reset`이라는 이름으로 지어봤는데 괜찮은지 확인 부탁드려요!
- 경매 목록이 무한스크롤이다 보니 눈으로 새로고침이 확인이 어려워 auctions 데이터를 observe하는 부분에서 로그를 찍어 경매 사이즈를 확인해본 결과, 잘 동작하는 것을 확인할 수 있었습니다! 동일한 방법으로 확인 부탁드려요! 
- 새로고침과 무한스크롤 서버 통신이 동시에 이루어지면 경매 목록이라는 같은 데이터를 수정하기 때문에 문제가 발생할 수 있다고 생각하여 기존의 `loadingAuctionInProgress` 프로퍼티를 활용하여 lock을 걸어 한 번에 하나의 통신만 주고받을 수 있도록 하였습니다. (두 기능이 같은 api 통신을 하고 있기도 합니다)

## 📎 Issue 번호
- Close : #263 
