### PR TITLE
삭제된 경매 상세 조회 시 데이터를 삭제하고 경매 목록으로 돌아오는 기능 추가

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
@@ -12,6 +12,7 @@ import com.ddangddangddang.android.feature.common.viewModelFactory
 import com.ddangddangddang.android.feature.detail.bid.AuctionBidDialog
 import com.ddangddangddang.android.model.RegionModel
 import com.ddangddangddang.android.util.binding.BindingActivity
+import com.ddangddangddang.android.util.view.showDialog
 import com.google.android.material.tabs.TabLayoutMediator
 
 class AuctionDetailActivity :
@@ -42,11 +43,20 @@ class AuctionDetailActivity :
             is AuctionDetailViewModel.AuctionDetailEvent.Exit -> finish()
             is AuctionDetailViewModel.AuctionDetailEvent.PopupAuctionBid -> showAuctionBidDialog()
             is AuctionDetailViewModel.AuctionDetailEvent.EnterChatRoom -> {}
+            is AuctionDetailViewModel.AuctionDetailEvent.NotifyAuctionDoesNotExist -> notifyAuctionDoesNotExist()
         }
     }
 
     private fun showAuctionBidDialog() {
         AuctionBidDialog().show(supportFragmentManager, BID_DIALOG_TAG)
+    }
+
+    private fun notifyAuctionDoesNotExist() {
+        showDialog(
+            messageId = R.string.detail_auction_dialog_auction_does_not_exist_message,
+            actionPositive = { finish() },
+            isCancelable = false,
+        )
     }
 
     private fun setupAuctionImages(images: List<String>) {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailViewModel.kt
@@ -43,7 +43,6 @@ class AuctionDetailViewModel(
                 is ApiResponse.Success -> _auctionDetailModel.value = response.body.toPresentation()
                 is ApiResponse.Failure -> {
                     if (response.responseCode == 404) {
-                        auctionRepository.removeAuction(auctionId)
                         _event.value = AuctionDetailEvent.NotifyAuctionDoesNotExist
                     }
                 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailViewModel.kt
@@ -41,7 +41,13 @@ class AuctionDetailViewModel(
         viewModelScope.launch {
             when (val response = auctionRepository.getAuctionDetail(auctionId)) {
                 is ApiResponse.Success -> _auctionDetailModel.value = response.body.toPresentation()
-                is ApiResponse.Failure -> {}
+                is ApiResponse.Failure -> {
+                    if (response.responseCode == 404) {
+                        auctionRepository.removeAuction(auctionId)
+                        _event.value = AuctionDetailEvent.NotifyAuctionDoesNotExist
+                    }
+                }
+
                 is ApiResponse.NetworkError -> {}
                 is ApiResponse.Unexpected -> {}
             }
@@ -89,5 +95,6 @@ class AuctionDetailViewModel(
         object Exit : AuctionDetailEvent()
         object PopupAuctionBid : AuctionDetailEvent()
         data class EnterChatRoom(val chatId: Long) : AuctionDetailEvent()
+        object NotifyAuctionDoesNotExist : AuctionDetailEvent()
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionActivity.kt
@@ -15,10 +15,10 @@ import com.ddangddangddang.android.feature.common.viewModelFactory
 import com.ddangddangddang.android.feature.detail.AuctionDetailActivity
 import com.ddangddangddang.android.feature.register.category.SelectCategoryActivity
 import com.ddangddangddang.android.feature.register.region.SelectRegionsActivity
-import com.ddangddangddang.android.model.CategoryModel
-import com.ddangddangddang.android.model.RegionSelectionModel
 import com.ddangddangddang.android.global.AnalyticsDelegate
 import com.ddangddangddang.android.global.AnalyticsDelegateImpl
+import com.ddangddangddang.android.model.CategoryModel
+import com.ddangddangddang.android.model.RegionSelectionModel
 import com.ddangddangddang.android.model.RegisterImageModel
 import com.ddangddangddang.android.util.binding.BindingActivity
 import com.ddangddangddang.android.util.compat.getParcelableCompat
@@ -199,6 +199,7 @@ class RegisterAuctionActivity :
     private fun showDeleteImageDialog(image: RegisterImageModel) {
         showDialog(
             messageId = R.string.register_auction_dialog_delete_image_message,
+            negativeStringId = R.string.all_dialog_default_negative_button,
             positiveStringId = R.string.register_auction_dialog_delete_image_positive_button,
             actionPositive = { viewModel.deleteImage(image) },
         )

--- a/android/app/src/main/java/com/ddangddangddang/android/util/view/DialogFactory.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/util/view/DialogFactory.kt
@@ -8,26 +8,30 @@ import com.ddangddangddang.android.R
 
 fun Activity.showDialog(
     @StringRes
-    titleId: Int = R.string.all_dialog_default_title,
+    titleId: Int? = null,
     @StringRes
     messageId: Int,
     @StringRes
-    negativeStringId: Int = R.string.all_dialog_default_negative_button,
+    negativeStringId: Int? = null,
     @StringRes
     positiveStringId: Int = R.string.all_dialog_default_positive_button,
     actionNegative: () -> Unit = {},
     actionPositive: () -> Unit = {},
+    isCancelable: Boolean = true,
 ) {
-    AlertDialog.Builder(this)
-        .setTitle(getString(titleId))
-        .setMessage(getString(messageId))
-        .setNegativeButton(negativeStringId) { _, _ ->
-            actionNegative()
+    AlertDialog.Builder(this).apply {
+        titleId?.let { setTitle(getString(it)) }
+        setMessage(getString(messageId))
+        negativeStringId?.let {
+            setNegativeButton(negativeStringId) { _, _ ->
+                actionNegative()
+            }
         }
-        .setPositiveButton(positiveStringId) { _, _ ->
+        setPositiveButton(positiveStringId) { _, _ ->
             actionPositive()
         }
-        .show()
+        setCancelable(isCancelable)
+    }.show()
 }
 
 fun Fragment.showDialog(

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -14,7 +14,6 @@
     <string name="all_auction_success">낙찰 완료</string>
     <string name="all_auction_failure">경매 유찰</string>
     <string name="all_app_bar_back_key_description">뒤로가기 버튼</string>
-    <string name="all_dialog_default_title"></string>
     <string name="all_dialog_default_negative_button">취소</string>
     <string name="all_dialog_default_positive_button">확인</string>
     <string name="all_snackbar_default_action">확인</string>
@@ -51,6 +50,8 @@
     <string name="detail_auction_remain_time">마감까지 %s</string>
     <string name="detail_auction_remain_time_finish">마감</string>
     <string name="detail_auction_auctioneer_count">%d명 경매 참여중</string>
+    <string name="detail_auction_dialog_auction_does_not_exist_message">존재하지 않는 경매입니다.</string>
+
 
     <!-- detail_auction_bid_dialog -->
     <string name="detail_auction_bid_dialog_title">입찰하기</string>

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionLocalDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionLocalDataSource.kt
@@ -34,4 +34,8 @@ class AuctionLocalDataSource {
         }
         auctionPreviews.value = updatedList
     }
+
+    fun removeAuctionPreview(auctionId: Long) {
+        auctionPreviews.value = auctionPreviews.value?.filter { it.id != auctionId }
+    }
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
@@ -26,6 +26,4 @@ interface AuctionRepository {
         auctionId: Long,
         bidPrice: Int,
     ): ApiResponse<Unit>
-
-    fun removeAuction(auctionId: Long)
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
@@ -26,4 +26,6 @@ interface AuctionRepository {
         auctionId: Long,
         bidPrice: Int,
     ): ApiResponse<Unit>
+
+    fun removeAuction(auctionId: Long)
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
@@ -37,6 +37,9 @@ class AuctionRepositoryImpl private constructor(
         if (response is ApiResponse.Success) {
             localDataSource.updateAuctionPreview(response.body)
         }
+        if (response is ApiResponse.Failure && response.responseCode == 404) {
+            localDataSource.removeAuctionPreview(id)
+        }
         return response
     }
 
@@ -56,10 +59,6 @@ class AuctionRepositoryImpl private constructor(
         bidPrice: Int,
     ): ApiResponse<Unit> {
         return remoteDataSource.submitAuctionBid(AuctionBidRequest(auctionId, bidPrice))
-    }
-
-    override fun removeAuction(auctionId: Long) {
-        localDataSource.removeAuctionPreview(auctionId)
     }
 
     companion object {

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
@@ -58,6 +58,10 @@ class AuctionRepositoryImpl private constructor(
         return remoteDataSource.submitAuctionBid(AuctionBidRequest(auctionId, bidPrice))
     }
 
+    override fun removeAuction(auctionId: Long) {
+        localDataSource.removeAuctionPreview(auctionId)
+    }
+
     companion object {
         @Volatile
         private var instance: AuctionRepositoryImpl? = null


### PR DESCRIPTION
## 📄 작업 내용 요약
삭제된 경매 상세 조회 시 로컬에 저장된 경매 목록에서 삭제 후 사용자에게 다이얼로그를 보여줘서 존재하지 않는 경매임을 알려줍니다.
사용자가 확인하면 경매 목록으로 돌아옵니다.

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
- 사용자가 다이얼로그를 확인한 후 페이지를 나가도록 하기 위해서 `cancelable`을 `false`로 설정하여 다이얼로그를 취소할 수 없도록 하였습니다.
- dialog negative 버튼이 필요 없다고 판단하여 아예 넣지 않도록 하기 위해서 util에 있는 DialogFactory 코드를 수정하였습니다.
- 경매가 이미 삭제되어 로컬에서 데이터를 제거해야하는 경우는 `remove`, 경매를 서버에서 삭제하려는 경우는 `delete`로 나누면 어떨까 생각했고, 그래서 함수명을 `remove`로 지었습니다.

## 📎 Issue 번호
- Closed: #266 
