### PR TITLE
자동로그인 기능 서버 연동

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/splash/SplashViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/splash/SplashViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ddangddangddang.android.util.livedata.SingleLiveEvent
+import com.ddangddangddang.data.remote.ApiResponse
 import com.ddangddangddang.data.repository.AuthRepository
 import kotlinx.coroutines.launch
 
@@ -24,8 +25,15 @@ class SplashViewModel(
 
     private fun verifyToken() {
         viewModelScope.launch {
-            // 액세스 토큰 유효성 검증 받아서, 만약 401 에러 나오면, 토큰 리프레시 요청 다시 보내고 또 401 에러면, RefreshTokenExpired
-            // 성공하면, AutoLoginSuccess
+            when (val response = repository.verifyToken()) {
+                is ApiResponse.Success -> _event.value = SplashEvent.AutoLoginSuccess
+                is ApiResponse.Failure -> {
+                    if (response.responseCode == 401) _event.value = SplashEvent.RefreshTokenExpired
+                }
+
+                is ApiResponse.NetworkError -> {}
+                is ApiResponse.Unexpected -> {}
+            }
         }
     }
 

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionLocalDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionLocalDataSource.kt
@@ -37,7 +37,8 @@ class AuctionLocalDataSource {
 
     fun removeAuctionPreview(auctionId: Long) {
         auctionPreviews.value = auctionPreviews.value?.filter { it.id != auctionId }
-        
+    }
+
     fun resetAuctionPreviews(auctions: List<AuctionPreviewResponse>) {
         auctionPreviews.value = auctions
     }

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuthRemoteDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuthRemoteDataSource.kt
@@ -4,6 +4,7 @@ import com.ddangddangddang.data.model.request.KakaoLoginRequest
 import com.ddangddangddang.data.model.request.LogoutRequest
 import com.ddangddangddang.data.model.request.RefreshTokenRequest
 import com.ddangddangddang.data.model.response.TokenResponse
+import com.ddangddangddang.data.model.response.ValidateTokenResponse
 import com.ddangddangddang.data.remote.ApiResponse
 import com.ddangddangddang.data.remote.AuthService
 
@@ -11,9 +12,21 @@ class AuthRemoteDataSource(private val service: AuthService) {
     suspend fun loginByKakao(kakaoToken: KakaoLoginRequest): ApiResponse<TokenResponse> =
         service.loginByKakao(kakaoToken)
 
-    suspend fun refreshToken(refreshTokenRequest: RefreshTokenRequest): ApiResponse<TokenResponse> =
-        service.refreshToken(refreshTokenRequest)
+    suspend fun refreshToken(refreshToken: String): ApiResponse<TokenResponse> =
+        service.refreshToken(RefreshTokenRequest(formatToken(refreshToken)))
 
-    suspend fun logout(accessToken: String, logoutRequest: LogoutRequest): ApiResponse<Unit> =
-        service.logout(accessToken, logoutRequest)
+    suspend fun logout(accessToken: String, refreshToken: String): ApiResponse<Unit> {
+        val response =
+            service.logout(formatToken(accessToken), LogoutRequest(formatToken(refreshToken)))
+        return response
+    }
+
+    suspend fun verifyToken(token: String): ApiResponse<ValidateTokenResponse> =
+        service.verifyToken(formatToken(token))
+
+    private fun formatToken(token: String): String = "$TOKEN_PREFIX $token"
+
+    companion object {
+        private const val TOKEN_PREFIX = "Bearer"
+    }
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/model/response/ValidateTokenResponse.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/model/response/ValidateTokenResponse.kt
@@ -1,0 +1,8 @@
+package com.ddangddangddang.data.model.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ValidateTokenResponse(
+    val validated: Boolean,
+)

--- a/android/data/src/main/java/com/ddangddangddang/data/remote/AuctionCallAdapter.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/remote/AuctionCallAdapter.kt
@@ -7,5 +7,5 @@ import java.lang.reflect.Type
 class AuctionCallAdapter<T : Any>(private val responseType: Type) : CallAdapter<T, Call<ApiResponse<T>>> {
     override fun responseType(): Type = responseType
 
-    override fun adapt(call: Call<T>): Call<ApiResponse<T>> = AuctionCall(call)
+    override fun adapt(call: Call<T>): Call<ApiResponse<T>> = AuctionCall(call, responseType)
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/remote/AuthService.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/remote/AuthService.kt
@@ -4,7 +4,9 @@ import com.ddangddangddang.data.model.request.KakaoLoginRequest
 import com.ddangddangddang.data.model.request.LogoutRequest
 import com.ddangddangddang.data.model.request.RefreshTokenRequest
 import com.ddangddangddang.data.model.response.TokenResponse
+import com.ddangddangddang.data.model.response.ValidateTokenResponse
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.POST
 
@@ -24,4 +26,9 @@ interface AuthService {
         @Header("Authorization") authorization: String,
         @Body logoutRequest: LogoutRequest,
     ): ApiResponse<Unit>
+
+    @GET("/oauth2/validate-token")
+    suspend fun verifyToken(
+        @Header("Authorization") authorization: String,
+    ): ApiResponse<ValidateTokenResponse>
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
@@ -62,11 +62,10 @@ class AuctionRepositoryImpl private constructor(
         return remoteDataSource.submitAuctionBid(AuctionBidRequest(auctionId, bidPrice))
     }
 
-
     override suspend fun reportAuction(auctionId: Long, description: String): ApiResponse<Unit> {
         return remoteDataSource.reportAuction(ReportRequest(auctionId, description))
     }
-    
+
     override suspend fun reloadAuctionPreviews(size: Int): ApiResponse<AuctionPreviewsResponse> {
         val response = remoteDataSource.getAuctionPreviews(null, size)
         if (response is ApiResponse.Success) {

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuthRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuthRepository.kt
@@ -2,6 +2,7 @@ package com.ddangddangddang.data.repository
 
 import com.ddangddangddang.data.model.request.KakaoLoginRequest
 import com.ddangddangddang.data.model.response.TokenResponse
+import com.ddangddangddang.data.model.response.ValidateTokenResponse
 import com.ddangddangddang.data.remote.ApiResponse
 
 interface AuthRepository {
@@ -14,4 +15,6 @@ interface AuthRepository {
     fun getRefreshToken(): String
 
     suspend fun logout(): ApiResponse<Unit>
+
+    suspend fun verifyToken(): ApiResponse<ValidateTokenResponse>
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
자동로그인 기능 서버 연동

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
 - response body가 없을 때(`null`일 때) let 뒤의 함수 블록이 실행되지 않던 문제를 해결
 - response body가 없더라도 응답타입이 Unit이면 Success를 반환하도록 수정

## 📎 Issue 번호
- #278