### PR TITLE
운영 서버 관련 script 변경

### DIFF
--- a/backend/ddang/script/prod-deploy-script.sh
+++ b/backend/ddang/script/prod-deploy-script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ABSPATH=$(readlink -f $0) # /home/ubuntu/dev-deploy-script.sh
+ABSPATH=$(readlink -f $0) # /home/ubuntu/prod-deploy-script.sh
 ABSDIR=$(dirname $ABSPATH) # /home/ubuntu
 APPNAME="ddang-0.0.1-SNAPSHOT"
 APPDIR=${ABSDIR}/${APPNAME} # /home/ubuntu/ddang-0.0.1-SNAPSHOT

--- a/backend/ddang/script/prod-pipeline.jenkinsfile
+++ b/backend/ddang/script/prod-pipeline.jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
         stage('github clone') {
             steps {
                 checkout scmGit(
-                    branches: [[name: '*/develop-be']],
+                    branches: [[name: '*/develop']],
                     extensions: [submodule(parentCredentials: true, reference: '', trackingSubmodules: true)],
                     userRemoteConfigs: [[credentialsId: 'ddang-dev-token', url: 'https://github.com/woowacourse-teams/2023-3-ddang']])
             }

--- a/backend/ddang/src/main/resources/db/migration/V5__alter_user_tables.sql
+++ b/backend/ddang/src/main/resources/db/migration/V5__alter_user_tables.sql
@@ -1,6 +1,12 @@
 alter table users add oauth_id varchar(50);
-alter table users add created_time datetime(6) not null;
-alter table users add last_modified_time datetime(6) not null;
+alter table users add created_time datetime(6);
+alter table users add last_modified_time datetime(6);
+
+update users set created_time = now() where created_time is null;
+update users set last_modified_time = now() where last_modified_time is null;
+
+alter table users modify created_time datetime(6) not null;
+alter table users modify last_modified_time datetime(6) not null;
 
 alter table users add constraint uq_oauth_id unique(oauth_id);
 alter table users add constraint uq_name unique(name);


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->
운영 서버 관련 script 변경
## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
- 운영 서버가 잘못된 설정으로 인해 현재 동작하지 않는 상황입니다 (502 발생)
  - 운영 서버 jenkins pipeline에서 develop-be로 checkout 하는 것을 develop으로 변경했습니다
    - 사실상 현재까지는 develop-be 브랜치가 개발 서버와 운영 서버 모두에 배포가 되고 있던 상황이었습니다
  - 배포 스크립트는 주석만 잘못되어 있어서 이것만 수정했습니다
- flyway
  - 운영서버는 V4까지 적용된 상태인데 V5를 적용하면서 script의 문제로 인해 실행에 실패한 상황입니다
  - users에 없던 created_time, last_modified_time을 추가하는 내용인데 기존에 레코드가 있는 상태에서 컬럼을 추가하면 값이 null이 되는데 not null로 설정해서 이러한 문제가 발생했습니다 
    - 개발 서버에서는 다른 더 큰 부분(까먹음)에 문제가 있었는데 그거 해결하다가 얼떨결에 V5도 묻힌 채로 해결이 된 것 같습니다 
    - null을 허용한 상태로 created_time / last_modified_time 컬럼 추가 -> null인 컬럼에 now()를 통해 현재 시간으로 값 초기화 -> not null 제약조건 추가의 단계로 변경해주었습니다 
## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
- closed #301 
<!-- closed #번호 --> 
