### PR TITLE
로그인 안 한 경우 경매 상세 조회 불가한 오류 수정

### DIFF
--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
@@ -103,19 +103,23 @@ public class AuctionService {
                                                      .orElseThrow(() -> new AuctionNotFoundException(
                                                              "지정한 아이디에 대한 경매를 찾을 수 없습니다."
                                                      ));
-        final User findUser = userRepository.findById(userInfo.userId())
-                                            .orElseThrow(() -> new UserNotFoundException("회원 정보를 찾을 수 없습니다."));
         final Long nullableChatRoomId = chatRoomRepository.findByAuctionId(findAuction.getId())
                                                           .map(ChatRoom::getId)
                                                           .orElse(DEFAULT_CHAT_ROOM_ID);
 
         return new ReadAuctionWithChatRoomIdDto(
                 ReadAuctionDto.from(findAuction),
-                new ReadChatRoomDto(nullableChatRoomId, isChatParticipant(findAuction, findUser))
+                new ReadChatRoomDto(nullableChatRoomId, isChatParticipant(findAuction, userInfo))
         );
     }
 
-    private boolean isChatParticipant(final Auction findAuction, final User findUser) {
+    private boolean isChatParticipant(final Auction findAuction, final AuthenticationUserInfo userInfo) {
+        if (userInfo.userId() == null) {
+            return false;
+        }
+        final User findUser = userRepository.findById(userInfo.userId())
+                                            .orElseThrow(() -> new UserNotFoundException("회원 정보를 찾을 수 없습니다."));
+
         return findAuction.isClosed(LocalDateTime.now()) && findAuction.isSellerOrWinner(findUser, LocalDateTime.now());
     }
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
@@ -56,7 +56,7 @@ public class AuctionController {
 
     @GetMapping("/{auctionId}")
     public ResponseEntity<ReadAuctionDetailResponse> read(
-            @AuthenticateUser final AuthenticationUserInfo userInfo,
+            @AuthenticateUser(required = false) final AuthenticationUserInfo userInfo,
             @PathVariable final Long auctionId
     ) {
         final ReadAuctionWithChatRoomIdDto readAuctionDto = auctionService.readByAuctionId(auctionId, userInfo);

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/response/ReadAuctionDetailResponse.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/response/ReadAuctionDetailResponse.java
@@ -33,6 +33,9 @@ public record ReadAuctionDetailResponse(
     }
 
     private static boolean isOwner(final ReadAuctionWithChatRoomIdDto dto, final AuthenticationUserInfo userInfo) {
+        if (userInfo == null || userInfo.userId() == null) {
+            return false;
+        }
         return dto.auctionDto().sellerId().equals(userInfo.userId());
     }
 }


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->
로그인 안 한 경우 경매 상세 조회 불가한 오류 수정
## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
- 경매 상세 조회 api `@AuthenticateUser` -> `@AuthenticateUser(required = false)` 변경
  - 해당 옵션 때문에 로그인이 필수였습니다
- AuctionService.readByAuctionId()에서 호출하는 isChatParticipant() 변경
  - 로그인 하지 않은 경우도 존재하기 때문에 null 체크하는 로직을 하나 추가했습니다 
- ReadAuctionDetailResponse.of()에서 호출하는 isOwner() 변경
  - 로그인 하지 않은 경우도 존재하기 때문에 null 체크하는 로직을 하나 추가했습니다
## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
- closed #319 
<!-- closed #번호 --> 
