### PR TITLE
경매 목록 조회 시 인가 기능 추가

### DIFF
--- a/backend/ddang/src/docs/asciidoc/docs.adoc
+++ b/backend/ddang/src/docs/asciidoc/docs.adoc
@@ -157,6 +157,7 @@ include::{snippets}/auction-controller-test/경매를_등록한다/response-fiel
 
 include::{snippets}/auction-controller-test/첫번째_페이지의_경매_목록을_조회한다/http-request.adoc[]
 include::{snippets}/auction-controller-test/첫번째_페이지의_경매_목록을_조회한다/query-parameters.adoc[]
+include::{snippets}/auction-controller-test/첫번째_페이지의_경매_목록을_조회한다/request-headers.adoc[]
 
 ==== 응답
 
@@ -169,6 +170,7 @@ include::{snippets}/auction-controller-test/첫번째_페이지의_경매_목록
 
 include::{snippets}/auction-controller-test/지정한_아이디에_해당하는_경매를_조회한다/http-request.adoc[]
 include::{snippets}/auction-controller-test/지정한_아이디에_해당하는_경매를_조회한다/path-parameters.adoc[]
+include::{snippets}/auction-controller-test/지정한_아이디에_해당하는_경매를_조회한다/request-headers.adoc[]
 
 ==== 응답
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
@@ -71,6 +71,7 @@ public class AuctionController {
 
     @GetMapping
     public ResponseEntity<ReadAuctionsResponse> readAllByLastAuctionId(
+            @AuthenticateUser AuthenticationUserInfo ignored,
             @RequestParam(required = false) final Long lastAuctionId,
             @RequestParam(required = false, defaultValue = "10") final int size
     ) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
@@ -39,7 +39,7 @@ public class AuctionController {
 
     @PostMapping
     public ResponseEntity<CreateAuctionResponse> create(
-            @AuthenticateUser AuthenticationUserInfo userInfo,
+            @AuthenticateUser final AuthenticationUserInfo userInfo,
             @RequestPart final List<MultipartFile> images,
             @RequestPart @Valid final CreateAuctionRequest request
     ) {
@@ -71,7 +71,7 @@ public class AuctionController {
 
     @GetMapping
     public ResponseEntity<ReadAuctionsResponse> readAllByLastAuctionId(
-            @AuthenticateUser AuthenticationUserInfo ignored,
+            @AuthenticateUser final AuthenticationUserInfo ignored,
             @RequestParam(required = false) final Long lastAuctionId,
             @RequestParam(required = false, defaultValue = "10") final int size
     ) {
@@ -83,7 +83,7 @@ public class AuctionController {
 
     @DeleteMapping("/{auctionId}")
     public ResponseEntity<Void> delete(
-            @AuthenticateUser AuthenticationUserInfo userInfo,
+            @AuthenticateUser final AuthenticationUserInfo userInfo,
             @PathVariable final Long auctionId
     ) {
         auctionService.deleteByAuctionId(auctionId, userInfo.userId());

--- a/backend/ddang/src/main/resources/static/docs/docs.html
+++ b/backend/ddang/src/main/resources/static/docs/docs.html
@@ -1217,7 +1217,7 @@ Content-Type: image/png
 Content-Disposition: form-data; name=request; filename=request
 Content-Type: application/json
 
-{"title":"경매 상품 1","description":"이것은 경매 상품 1 입니다.","bidUnit":1000,"startPrice":1000,"closingTime":"2023-08-19T16:30:53.364176","subCategoryId":2,"thirdRegionIds":[3]}
+{"title":"경매 상품 1","description":"이것은 경매 상품 1 입니다.","bidUnit":1000,"startPrice":1000,"closingTime":"2023-08-20T09:59:53.172963","subCategoryId":2,"thirdRegionIds":[3]}
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
 </div>
 </div>
@@ -1335,7 +1335,8 @@ Content-Type: application/json
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /auctions?size=10 HTTP/1.1
-Content-Type: application/json</code></pre>
+Content-Type: application/json
+Authorization: Bearer accessToken</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -1357,6 +1358,24 @@ Content-Type: application/json</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">페이지 크기</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 Bearer 인증 정보</p></td>
 </tr>
 </tbody>
 </table>
@@ -1481,6 +1500,24 @@ Authorization: Bearer accessToken</code></pre>
 </tr>
 </tbody>
 </table>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 Bearer 인증 정보</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="sect3">
 <h4 id="_응답_12"><a class="link" href="#_응답_12">응답</a></h4>
@@ -1503,8 +1540,8 @@ Content-Type: application/json
     "lastBidPrice" : null,
     "status" : "FAILURE",
     "bidUnit" : 1000,
-    "registerTime" : "2023-08-16T16:30:53",
-    "closingTime" : "2023-08-16T16:30:53",
+    "registerTime" : "2023-08-17T09:59:53",
+    "closingTime" : "2023-08-17T09:59:53",
     "directRegions" : [ {
       "first" : "서울특별시",
       "second" : "강서구",
@@ -1836,12 +1873,12 @@ Content-Type: application/json
     "name" : "사용자1",
     "profileImage" : "이미지1",
     "price" : 10000,
-    "bidTime" : "2023-08-16T16:30:54"
+    "bidTime" : "2023-08-17T09:59:54"
   }, {
     "name" : "사용자2",
     "profileImage" : "이미지2",
     "price" : 12000,
-    "bidTime" : "2023-08-16T16:30:54"
+    "bidTime" : "2023-08-17T09:59:54"
   } ]
 }</code></pre>
 </div>
@@ -2036,7 +2073,7 @@ Content-Type: application/json
     "price" : 10000
   },
   "lastMessage" : {
-    "createdAt" : "2023-08-16T16:30:55",
+    "createdAt" : "2023-08-17T09:59:55",
     "contents" : "메시지1"
   },
   "isChatAvailable" : true
@@ -2054,7 +2091,7 @@ Content-Type: application/json
     "price" : 20000
   },
   "lastMessage" : {
-    "createdAt" : "2023-08-16T16:30:55",
+    "createdAt" : "2023-08-17T09:59:55",
     "contents" : "메시지2"
   },
   "isChatAvailable" : true
@@ -2492,7 +2529,7 @@ Content-Type: application/json
 
 [ {
   "id" : 1,
-  "createdAt" : "2023-08-16T16:30:55",
+  "createdAt" : "2023-08-17T09:59:55",
   "isMyMessage" : true,
   "contents" : "메시지내용"
 } ]</code></pre>
@@ -2642,7 +2679,7 @@ Content-Type: application/json
       "id" : 1,
       "name" : "회원1"
     },
-    "createdTime" : "2023-08-16T16:30:57",
+    "createdTime" : "2023-08-17T09:59:57",
     "auction" : {
       "id" : 1,
       "title" : "제목"
@@ -2654,7 +2691,7 @@ Content-Type: application/json
       "id" : 2,
       "name" : "회원2"
     },
-    "createdTime" : "2023-08-16T16:30:57",
+    "createdTime" : "2023-08-17T09:59:57",
     "auction" : {
       "id" : 1,
       "title" : "제목"
@@ -2666,7 +2703,7 @@ Content-Type: application/json
       "id" : 3,
       "name" : "회원3"
     },
-    "createdTime" : "2023-08-16T16:30:57",
+    "createdTime" : "2023-08-17T09:59:57",
     "auction" : {
       "id" : 1,
       "title" : "제목"
@@ -2830,7 +2867,7 @@ Content-Type: application/json
       "id" : 1,
       "name" : "회원1"
     },
-    "createdTime" : "2023-08-16T16:30:57",
+    "createdTime" : "2023-08-17T09:59:57",
     "chatRoom" : {
       "id" : 1
     },
@@ -2841,7 +2878,7 @@ Content-Type: application/json
       "id" : 1,
       "name" : "회원1"
     },
-    "createdTime" : "2023-08-16T16:30:57",
+    "createdTime" : "2023-08-17T09:59:57",
     "chatRoom" : {
       "id" : 1
     },
@@ -2852,7 +2889,7 @@ Content-Type: application/json
       "id" : 1,
       "name" : "회원1"
     },
-    "createdTime" : "2023-08-16T16:30:57",
+    "createdTime" : "2023-08-17T09:59:57",
     "chatRoom" : {
       "id" : 1
     },
@@ -2920,7 +2957,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-08-16 16:29:20 +0900
+Last updated 2023-08-17 09:59:27 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
@@ -501,7 +501,6 @@ class AuctionControllerTest {
 
         final ReadAuctionWithChatRoomIdDto auctionWithChatRoomIdDto =
                 new ReadAuctionWithChatRoomIdDto(auction, chatRoomDto);
-
         final PrivateClaims privateClaims = new PrivateClaims(1L);
 
         given(mockTokenDecoder.decode(eq(TokenType.ACCESS), anyString())).willReturn(Optional.of(privateClaims));
@@ -526,6 +525,9 @@ class AuctionControllerTest {
                )
                .andDo(
                        restDocs.document(
+                               requestHeaders(
+                                       headerWithName("Authorization").description("회원 Bearer 인증 정보")
+                               ),
                                pathParameters(
                                        parameterWithName("auctionId").description("조회하고자 하는 경매 ID")
                                ),
@@ -630,14 +632,17 @@ class AuctionControllerTest {
                 "판매자",
                 3.5d
         );
-
+        final PrivateClaims privateClaims = new PrivateClaims(1L);
         final ReadAuctionsDto readAuctionsDto = new ReadAuctionsDto(List.of(auction2, auction1), true);
+
+        given(mockTokenDecoder.decode(eq(TokenType.ACCESS), anyString())).willReturn(Optional.of(privateClaims));
         given(auctionService.readAllByLastAuctionId(any(), anyInt())).willReturn(readAuctionsDto);
 
         // when & then
         mockMvc.perform(get("/auctions")
                        .contentType(MediaType.APPLICATION_JSON)
                        .queryParam("size", "10")
+                       .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
                )
                .andExpectAll(
                        status().isOk(),
@@ -656,6 +661,9 @@ class AuctionControllerTest {
                )
                .andDo(
                        restDocs.document(
+                               requestHeaders(
+                                       headerWithName("Authorization").description("회원 Bearer 인증 정보")
+                               ),
                                queryParameters(
                                        parameterWithName("lastAuctionId").description("마지막으로 조회한 경매 ID").optional(),
                                        parameterWithName("size").description("페이지 크기").optional()


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->
- 경매 목록 조회 시 인가 기능 추가
  - 안드로이드에게 문의한 결과 인증/인가(로그인 같은)를 제외한 서비스의 모든 api는 인가가 필수가 되었습니다
  - 앱도 키자마자 카카오톡 로그인을 해야 하더라고요..
## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
- AuctionController.readAllByLastAuctionId()에서 인가를 위해 `@AuthenticateUser AuthenticationUserInfo ignored`를 인자로 받습니다
  - 그런데 인가를 받고 난 정보는 현재 사용되지 않아서 ignored라는 변수명을 붙여주었습니다
  - 나중에 특정 경매 글을 감춘다거나 신고한 경매 글을 보이지 않게 한다거나 하는 식으로 확장할 예정이라고 합니다
## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
- closed #323 
<!-- closed #번호 --> 
