### PR TITLE
토큰 자동 갱신 로직에서 첫 번째 응답 안 닫아서 발생하던 버그 수정

### DIFF
--- a/android/data/src/main/java/com/ddangddangddang/data/remote/AuctionRetrofit.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/remote/AuctionRetrofit.kt
@@ -61,6 +61,7 @@ class AuctionRetrofit private constructor(retrofit: Retrofit) {
                 val response = chain.proceed(tokenAddedRequest)
 
                 if (response.code == 401) {
+                    response.close()
                     refreshTokenRequest(authRepository)
 
                     val refreshedTokenAddedRequest =


### PR DESCRIPTION
## 📄 작업 내용 요약
토큰 자동 갱신 로직에서 첫 번째 응답 안 닫아서 발생하던 버그 수정

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
없음

## 📎 Issue 번호
- #327 

<!-- closed #번호 --> 
