### PR TITLE
경매 목록 검색 시 제목 기반의 검색 기능 추가

### DIFF
--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
@@ -10,7 +10,7 @@ import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
 import com.ddang.ddang.auction.application.exception.UserForbiddenException;
 import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.infrastructure.persistence.JpaAuctionRepository;
-import com.ddang.ddang.auction.presentation.dto.request.SearchCondition;
+import com.ddang.ddang.auction.presentation.dto.request.ReadAuctionSearchCondition;
 import com.ddang.ddang.authentication.domain.dto.AuthenticationUserInfo;
 import com.ddang.ddang.category.application.exception.CategoryNotFoundException;
 import com.ddang.ddang.category.domain.Category;
@@ -124,11 +124,11 @@ public class AuctionService {
     public ReadAuctionsDto readAllByLastAuctionId(
             final Long lastAuctionId,
             final Pageable pageable,
-            final SearchCondition searchCondition) {
+            final ReadAuctionSearchCondition readAuctionSearchCondition) {
         final Slice<Auction> auctions = auctionRepository.findAuctionsAllByLastAuctionId(
                 lastAuctionId,
                 pageable,
-                searchCondition
+                readAuctionSearchCondition
         );
 
         return ReadAuctionsDto.from(auctions);

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
@@ -10,6 +10,7 @@ import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
 import com.ddang.ddang.auction.application.exception.UserForbiddenException;
 import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.infrastructure.persistence.JpaAuctionRepository;
+import com.ddang.ddang.auction.presentation.dto.request.SearchCondition;
 import com.ddang.ddang.authentication.domain.dto.AuthenticationUserInfo;
 import com.ddang.ddang.category.application.exception.CategoryNotFoundException;
 import com.ddang.ddang.category.domain.Category;
@@ -120,8 +121,15 @@ public class AuctionService {
         return findAuction.isClosed(LocalDateTime.now()) && findAuction.isSellerOrWinner(findUser, LocalDateTime.now());
     }
 
-    public ReadAuctionsDto readAllByLastAuctionId(final Long lastAuctionId, final Pageable pageable) {
-        final Slice<Auction> auctions = auctionRepository.findAuctionsAllByLastAuctionId(lastAuctionId, pageable);
+    public ReadAuctionsDto readAllByLastAuctionId(
+            final Long lastAuctionId,
+            final Pageable pageable,
+            final SearchCondition searchCondition) {
+        final Slice<Auction> auctions = auctionRepository.findAuctionsAllByLastAuctionId(
+                lastAuctionId,
+                pageable,
+                searchCondition
+        );
 
         return ReadAuctionsDto.from(auctions);
     }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/configuration/AuctionSearchConditionArgumentResolver.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/configuration/AuctionSearchConditionArgumentResolver.java
@@ -1,0 +1,49 @@
+package com.ddang.ddang.auction.configuration;
+
+import com.ddang.ddang.auction.configuration.exception.InvalidSearchConditionException;
+import com.ddang.ddang.auction.presentation.dto.request.ReadAuctionSearchCondition;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class AuctionSearchConditionArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final int MINIMUM_TITLE_SEARCH_CONDITION_LENGTH = 2;
+    private static final int MAXIMUM_TITLE_SEARCH_CONDITION_LENGTH = 30;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.getParameterType().equals(ReadAuctionSearchCondition.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            final MethodParameter ignoredParameter,
+            final ModelAndViewContainer ignoredMavContainer,
+            final NativeWebRequest webRequest,
+            final WebDataBinderFactory ignoredBinderFactory)
+    {
+        final String titleSearchCondition = webRequest.getParameter("title");
+
+        if (titleSearchCondition == null) {
+            return new ReadAuctionSearchCondition(null);
+        }
+
+        validateSearchCondition(titleSearchCondition);
+
+        return new ReadAuctionSearchCondition(titleSearchCondition);
+    }
+
+    private void validateSearchCondition(final String titleSearchCondition) {
+        final int length = titleSearchCondition.length();
+
+        if (length < MINIMUM_TITLE_SEARCH_CONDITION_LENGTH || length > MAXIMUM_TITLE_SEARCH_CONDITION_LENGTH) {
+
+            throw new InvalidSearchConditionException("경매 목록 제목 검색의 길이가 유효하지 않습니다.");
+        }
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/configuration/exception/InvalidSearchConditionException.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/configuration/exception/InvalidSearchConditionException.java
@@ -1,0 +1,8 @@
+package com.ddang.ddang.auction.configuration.exception;
+
+public class InvalidSearchConditionException extends IllegalArgumentException {
+
+    public InvalidSearchConditionException(final String s) {
+        super(s);
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepository.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepository.java
@@ -1,7 +1,7 @@
 package com.ddang.ddang.auction.infrastructure.persistence;
 
 import com.ddang.ddang.auction.domain.Auction;
-import com.ddang.ddang.auction.presentation.dto.request.SearchCondition;
+import com.ddang.ddang.auction.presentation.dto.request.ReadAuctionSearchCondition;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -11,7 +11,7 @@ public interface QuerydslAuctionRepository {
     Slice<Auction> findAuctionsAllByLastAuctionId(
             final Long lastAuctionId,
             final Pageable pageable,
-            final SearchCondition searchCondition
+            final ReadAuctionSearchCondition readAuctionSearchCondition
     );
 
     Optional<Auction> findAuctionById(final Long auctionId);

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepository.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepository.java
@@ -1,13 +1,18 @@
 package com.ddang.ddang.auction.infrastructure.persistence;
 
 import com.ddang.ddang.auction.domain.Auction;
+import com.ddang.ddang.auction.presentation.dto.request.SearchCondition;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface QuerydslAuctionRepository {
 
-    Slice<Auction> findAuctionsAllByLastAuctionId(final Long lastAuctionId, final Pageable pageable);
+    Slice<Auction> findAuctionsAllByLastAuctionId(
+            final Long lastAuctionId,
+            final Pageable pageable,
+            final SearchCondition searchCondition
+    );
 
     Optional<Auction> findAuctionById(final Long auctionId);
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImpl.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImpl.java
@@ -8,7 +8,7 @@ import static com.ddang.ddang.region.domain.QRegion.region;
 import com.ddang.ddang.auction.configuration.util.AuctionSortConditionConsts;
 import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.infrastructure.persistence.util.AuctionSortCondition;
-import com.ddang.ddang.auction.presentation.dto.request.SearchCondition;
+import com.ddang.ddang.auction.presentation.dto.request.ReadAuctionSearchCondition;
 import com.ddang.ddang.common.helper.QuerydslSliceHelper;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -36,7 +36,7 @@ public class QuerydslAuctionRepositoryImpl implements QuerydslAuctionRepository 
     public Slice<Auction> findAuctionsAllByLastAuctionId(
             final Long lastAuctionId,
             final Pageable pageable,
-            final SearchCondition searchCondition
+            final ReadAuctionSearchCondition readAuctionSearchCondition
     ) {
         final List<OrderSpecifier<?>> orderSpecifiers = calculateOrderSpecifiers(pageable);
 
@@ -45,7 +45,7 @@ public class QuerydslAuctionRepositoryImpl implements QuerydslAuctionRepository 
                                                       .where(
                                                               auction.deleted.isFalse(),
                                                               lessThanLastAuctionId(lastAuctionId),
-                                                              convertTitleSearchCondition(searchCondition)
+                                                              convertTitleSearchCondition(readAuctionSearchCondition)
                                                       )
                                                       .orderBy(orderSpecifiers.toArray(OrderSpecifier[]::new))
                                                       .limit(pageable.getPageSize() + SLICE_OFFSET)
@@ -75,8 +75,8 @@ public class QuerydslAuctionRepositoryImpl implements QuerydslAuctionRepository 
         return auction.id.lt(lastAuctionId);
     }
 
-    private BooleanExpression convertTitleSearchCondition(final SearchCondition searchCondition) {
-        final String titleSearchCondition = searchCondition.title();
+    private BooleanExpression convertTitleSearchCondition(final ReadAuctionSearchCondition readAuctionSearchCondition) {
+        final String titleSearchCondition = readAuctionSearchCondition.title();
 
         if (titleSearchCondition == null) {
             return null;

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
@@ -7,7 +7,7 @@ import com.ddang.ddang.auction.application.dto.ReadAuctionWithChatRoomIdDto;
 import com.ddang.ddang.auction.application.dto.ReadAuctionsDto;
 import com.ddang.ddang.auction.configuration.DescendingSort;
 import com.ddang.ddang.auction.presentation.dto.request.CreateAuctionRequest;
-import com.ddang.ddang.auction.presentation.dto.request.SearchCondition;
+import com.ddang.ddang.auction.presentation.dto.request.ReadAuctionSearchCondition;
 import com.ddang.ddang.auction.presentation.dto.response.CreateAuctionResponse;
 import com.ddang.ddang.auction.presentation.dto.response.ReadAuctionDetailResponse;
 import com.ddang.ddang.auction.presentation.dto.response.ReadAuctionsResponse;
@@ -76,12 +76,12 @@ public class AuctionController {
             @AuthenticateUser final AuthenticationUserInfo ignored,
             @RequestParam(required = false) final Long lastAuctionId,
             @DescendingSort final Pageable pageable,
-            final SearchCondition searchCondition
+            final ReadAuctionSearchCondition readAuctionSearchCondition
     ) {
         final ReadAuctionsDto readAuctionsDto = auctionService.readAllByLastAuctionId(
                 lastAuctionId,
                 pageable,
-                searchCondition
+                readAuctionSearchCondition
         );
         final ReadAuctionsResponse response = ReadAuctionsResponse.of(readAuctionsDto, calculateBaseImageUrl());
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/AuctionController.java
@@ -7,12 +7,15 @@ import com.ddang.ddang.auction.application.dto.ReadAuctionWithChatRoomIdDto;
 import com.ddang.ddang.auction.application.dto.ReadAuctionsDto;
 import com.ddang.ddang.auction.configuration.DescendingSort;
 import com.ddang.ddang.auction.presentation.dto.request.CreateAuctionRequest;
+import com.ddang.ddang.auction.presentation.dto.request.SearchCondition;
 import com.ddang.ddang.auction.presentation.dto.response.CreateAuctionResponse;
 import com.ddang.ddang.auction.presentation.dto.response.ReadAuctionDetailResponse;
 import com.ddang.ddang.auction.presentation.dto.response.ReadAuctionsResponse;
 import com.ddang.ddang.authentication.configuration.AuthenticateUser;
 import com.ddang.ddang.authentication.domain.dto.AuthenticationUserInfo;
 import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -26,9 +29,6 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
-
-import java.net.URI;
-import java.util.List;
 
 @RestController
 @RequestMapping("/auctions")
@@ -75,9 +75,14 @@ public class AuctionController {
     public ResponseEntity<ReadAuctionsResponse> readAllByLastAuctionId(
             @AuthenticateUser final AuthenticationUserInfo ignored,
             @RequestParam(required = false) final Long lastAuctionId,
-            @DescendingSort Pageable pageable
+            @DescendingSort final Pageable pageable,
+            final SearchCondition searchCondition
     ) {
-        final ReadAuctionsDto readAuctionsDto = auctionService.readAllByLastAuctionId(lastAuctionId, pageable);
+        final ReadAuctionsDto readAuctionsDto = auctionService.readAllByLastAuctionId(
+                lastAuctionId,
+                pageable,
+                searchCondition
+        );
         final ReadAuctionsResponse response = ReadAuctionsResponse.of(readAuctionsDto, calculateBaseImageUrl());
 
         return ResponseEntity.ok(response);

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/request/ReadAuctionSearchCondition.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/request/ReadAuctionSearchCondition.java
@@ -1,4 +1,4 @@
 package com.ddang.ddang.auction.presentation.dto.request;
 
-public record SearchCondition(String title) {
+public record ReadAuctionSearchCondition(String title) {
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/request/SearchCondition.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/presentation/dto/request/SearchCondition.java
@@ -1,0 +1,4 @@
+package com.ddang.ddang.auction.presentation.dto.request;
+
+public record SearchCondition(String title) {
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/exception/GlobalExceptionHandler.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.ddang.ddang.exception;
 
 import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
 import com.ddang.ddang.auction.application.exception.UserForbiddenException;
+import com.ddang.ddang.auction.configuration.exception.InvalidSearchConditionException;
 import com.ddang.ddang.auction.domain.exception.InvalidPriceValueException;
 import com.ddang.ddang.auction.domain.exception.WinnerNotFoundException;
 import com.ddang.ddang.authentication.configuration.exception.UserUnauthorizedException;
@@ -218,7 +219,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(InvalidReporterToAuctionException.class)
-    public ResponseEntity<ExceptionResponse> handleInvalidReporterToAuctionException(final InvalidReporterToAuctionException ex) {
+    public ResponseEntity<ExceptionResponse> handleInvalidReporterToAuctionException(
+            final InvalidReporterToAuctionException ex) {
         logger.warn(String.format(EXCEPTION_FORMAT, InvalidReporterToAuctionException.class), ex);
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
@@ -226,7 +228,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(InvalidReportAuctionException.class)
-    public ResponseEntity<ExceptionResponse> handleInvalidReportAuctionException(final InvalidReportAuctionException ex) {
+    public ResponseEntity<ExceptionResponse> handleInvalidReportAuctionException(
+            final InvalidReportAuctionException ex) {
         logger.warn(String.format(EXCEPTION_FORMAT, InvalidReportAuctionException.class), ex);
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
@@ -234,7 +237,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(AlreadyReportAuctionException.class)
-    public ResponseEntity<ExceptionResponse> handleAlreadyReportAuctionException(final AlreadyReportAuctionException ex) {
+    public ResponseEntity<ExceptionResponse> handleAlreadyReportAuctionException(
+            final AlreadyReportAuctionException ex) {
         logger.warn(String.format(EXCEPTION_FORMAT, AlreadyReportAuctionException.class), ex);
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
@@ -242,7 +246,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(ChatRoomReportNotAccessibleException.class)
-    public ResponseEntity<ExceptionResponse> handleChatRoomReportNotAccessibleExceptionException(final ChatRoomReportNotAccessibleException ex) {
+    public ResponseEntity<ExceptionResponse> handleChatRoomReportNotAccessibleExceptionException(
+            final ChatRoomReportNotAccessibleException ex) {
         logger.warn(String.format(EXCEPTION_FORMAT, ChatRoomReportNotAccessibleException.class), ex);
 
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
@@ -250,7 +255,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(AlreadyReportChatRoomException.class)
-    public ResponseEntity<ExceptionResponse> handleAlreadyReportChatRoomException(final AlreadyReportChatRoomException ex) {
+    public ResponseEntity<ExceptionResponse> handleAlreadyReportChatRoomException(
+            final AlreadyReportChatRoomException ex) {
         logger.warn(String.format(EXCEPTION_FORMAT, AlreadyReportChatRoomException.class), ex);
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
@@ -280,6 +286,15 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         logger.warn(String.format(EXCEPTION_FORMAT, UserUnauthorizedException.class), ex);
 
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                             .body(new ExceptionResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidSearchConditionException.class)
+    public ResponseEntity<ExceptionResponse> handleInvalidSearchConditionException(
+            final InvalidSearchConditionException ex) {
+        logger.warn(String.format(EXCEPTION_FORMAT, UserUnauthorizedException.class), ex);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(ex.getMessage()));
     }
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
@@ -16,7 +16,7 @@ import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.domain.BidUnit;
 import com.ddang.ddang.auction.domain.Price;
 import com.ddang.ddang.auction.infrastructure.persistence.JpaAuctionRepository;
-import com.ddang.ddang.auction.presentation.dto.request.SearchCondition;
+import com.ddang.ddang.auction.presentation.dto.request.ReadAuctionSearchCondition;
 import com.ddang.ddang.authentication.domain.dto.AuthenticationUserInfo;
 import com.ddang.ddang.bid.infrastructure.persistence.JpaBidRepository;
 import com.ddang.ddang.category.application.exception.CategoryNotFoundException;
@@ -922,7 +922,7 @@ class AuctionServiceTest {
         final ReadAuctionsDto actual = auctionService.readAllByLastAuctionId(
                 null,
                 PageRequest.of(1, 1, Sort.by(Order.desc("id"))),
-                new SearchCondition(null)
+                new ReadAuctionSearchCondition(null)
         );
 
         // then

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/application/AuctionServiceTest.java
@@ -16,6 +16,7 @@ import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.domain.BidUnit;
 import com.ddang.ddang.auction.domain.Price;
 import com.ddang.ddang.auction.infrastructure.persistence.JpaAuctionRepository;
+import com.ddang.ddang.auction.presentation.dto.request.SearchCondition;
 import com.ddang.ddang.authentication.domain.dto.AuthenticationUserInfo;
 import com.ddang.ddang.bid.infrastructure.persistence.JpaBidRepository;
 import com.ddang.ddang.category.application.exception.CategoryNotFoundException;
@@ -920,7 +921,8 @@ class AuctionServiceTest {
         // when
         final ReadAuctionsDto actual = auctionService.readAllByLastAuctionId(
                 null,
-                PageRequest.of(1, 1, Sort.by(Order.desc("id")))
+                PageRequest.of(1, 1, Sort.by(Order.desc("id"))),
+                new SearchCondition(null)
         );
 
         // then

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/InitializeCommonAuctionData.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/InitializeCommonAuctionData.java
@@ -27,6 +27,8 @@ public class InitializeCommonAuctionData extends QuerydslAuctionRepositoryImplTe
     Auction auction4;
     Auction auction5;
     Auction auction6;
+    Auction auction7;
+    Auction auction8;
 
     @BeforeEach
     void setUp() {
@@ -127,8 +129,25 @@ public class InitializeCommonAuctionData extends QuerydslAuctionRepositoryImplTe
                           .closingTime(LocalDateTime.now())
                           .seller(seller6)
                           .build();
+        auction7 = Auction.builder()
+                          .title("맥북1을 팝니다")
+                          .description("맥북1을 팝니다")
+                          .bidUnit(new BidUnit(1_000))
+                          .startPrice(new Price(1_000))
+                          .closingTime(LocalDateTime.now())
+                          .seller(seller1)
+                          .build();
+        auction8 = Auction.builder()
+                          .title("맥북2을 팝니다")
+                          .description("맥북2을 팝니다")
+                          .bidUnit(new BidUnit(1_000))
+                          .startPrice(new Price(1_000))
+                          .closingTime(LocalDateTime.now())
+                          .seller(seller2)
+                          .build();
 
-        final List<Auction> auctions = List.of(auction1, auction2, auction3, auction4, auction5);
+        final List<Auction> auctions = List.of(auction1, auction2, auction3, auction4, auction5, auction6, auction7,
+                auction8);
         auctionRepository.saveAll(auctions);
 
         em.flush();

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/InitializeCommonAuctionData.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/InitializeCommonAuctionData.java
@@ -1,0 +1,137 @@
+package com.ddang.ddang.auction.infrastructure.persistence;
+
+import com.ddang.ddang.auction.domain.Auction;
+import com.ddang.ddang.auction.domain.BidUnit;
+import com.ddang.ddang.auction.domain.Price;
+import com.ddang.ddang.category.domain.Category;
+import com.ddang.ddang.configuration.JpaConfiguration;
+import com.ddang.ddang.configuration.QuerydslConfiguration;
+import com.ddang.ddang.user.domain.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@Import({JpaConfiguration.class, QuerydslConfiguration.class})
+public class InitializeCommonAuctionData extends QuerydslAuctionRepositoryImplTest {
+
+    Auction auction1;
+    Auction auction2;
+    Auction auction3;
+    Auction auction4;
+    Auction auction5;
+    Auction auction6;
+
+    @BeforeEach
+    void setUp() {
+        querydslAuctionRepository = new QuerydslAuctionRepositoryImpl(new JPAQueryFactory(em));
+
+        final User seller1 = User.builder()
+                                 .name("회원1234543211")
+                                 .profileImage("profile.png")
+                                 .reliability(4.7d)
+                                 .oauthId("1234543211")
+                                 .build();
+        final User seller2 = User.builder()
+                                 .name("회원1234543212")
+                                 .profileImage("profile.png")
+                                 .reliability(3.5d)
+                                 .oauthId("1234543212")
+                                 .build();
+        final User seller3 = User.builder()
+                                 .name("회원1234543213")
+                                 .profileImage("profile.png")
+                                 .reliability(2.1d)
+                                 .oauthId("1234543213")
+                                 .build();
+        final User seller4 = User.builder()
+                                 .name("회원1234543214")
+                                 .profileImage("profile.png")
+                                 .reliability(5.0d)
+                                 .oauthId("1234543214")
+                                 .build();
+        final User seller5 = User.builder()
+                                 .name("회원1234543215")
+                                 .profileImage("profile.png")
+                                 .reliability(1.5d)
+                                 .oauthId("1234543215")
+                                 .build();
+        final User seller6 = User.builder()
+                                 .name("회원1234543216")
+                                 .profileImage("profile.png")
+                                 .reliability(0.3d)
+                                 .oauthId("1234543216")
+                                 .build();
+
+        final List<User> users = List.of(seller1, seller2, seller3, seller4, seller5, seller6);
+        userRepository.saveAll(users);
+
+        final Category main = new Category("main");
+        final Category sub = new Category("sub");
+
+        main.addSubCategory(sub);
+
+        categoryRepository.save(main);
+
+        auction1 = Auction.builder()
+                          .title("맥북에어를 팝니다")
+                          .description("맥북에어를 팝니다")
+                          .bidUnit(new BidUnit(1_000))
+                          .startPrice(new Price(1_000))
+                          .closingTime(LocalDateTime.now())
+                          .seller(seller1)
+                          .build();
+        auction2 = Auction.builder()
+                          .title("맥북프로를 팝니다")
+                          .description("맥북프로를 팝니다")
+                          .bidUnit(new BidUnit(1_000))
+                          .startPrice(new Price(1_000))
+                          .closingTime(LocalDateTime.now())
+                          .seller(seller2)
+                          .build();
+        auction3 = Auction.builder()
+                          .title("맥북뭐시기를 팝니다")
+                          .description("맥북뭐시기를 팝니다")
+                          .bidUnit(new BidUnit(1_000))
+                          .startPrice(new Price(1_000))
+                          .closingTime(LocalDateTime.now())
+                          .seller(seller3)
+                          .build();
+        auction4 = Auction.builder()
+                          .title("집에가고싶은 맥북을 팝니다")
+                          .description("집에가고싶은 맥북을 팝니다")
+                          .bidUnit(new BidUnit(1_000))
+                          .startPrice(new Price(1_000))
+                          .closingTime(LocalDateTime.now())
+                          .seller(seller4)
+                          .build();
+        auction5 = Auction.builder()
+                          .title("핫식스를 팝니다")
+                          .description("핫식스를 팝니다")
+                          .bidUnit(new BidUnit(1_000))
+                          .startPrice(new Price(1_000))
+                          .closingTime(LocalDateTime.now())
+                          .seller(seller5)
+                          .build();
+        auction6 = Auction.builder()
+                          .title("레드불을 팝니다")
+                          .description("레드불을 팝니다")
+                          .bidUnit(new BidUnit(1_000))
+                          .startPrice(new Price(1_000))
+                          .closingTime(LocalDateTime.now())
+                          .seller(seller6)
+                          .build();
+
+        final List<Auction> auctions = List.of(auction1, auction2, auction3, auction4, auction5);
+        auctionRepository.saveAll(auctions);
+
+        em.flush();
+        em.clear();
+    }
+}

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImplTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImplTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.domain.BidUnit;
 import com.ddang.ddang.auction.domain.Price;
-import com.ddang.ddang.auction.presentation.dto.request.SearchCondition;
+import com.ddang.ddang.auction.presentation.dto.request.ReadAuctionSearchCondition;
 import com.ddang.ddang.category.domain.Category;
 import com.ddang.ddang.category.infrastructure.persistence.JpaCategoryRepository;
 import com.ddang.ddang.configuration.JpaConfiguration;
@@ -187,7 +187,7 @@ class QuerydslAuctionRepositoryImplTest {
         final Slice<Auction> actual = auctionRepository.findAuctionsAllByLastAuctionId(
                 null,
                 PageRequest.of(1, 1, Sort.by(Order.desc("id"))),
-                new SearchCondition(null)
+                new ReadAuctionSearchCondition(null)
         );
 
         // then
@@ -236,7 +236,7 @@ class QuerydslAuctionRepositoryImplTest {
         final Slice<Auction> actual = auctionRepository.findAuctionsAllByLastAuctionId(
                 auction3.getId(),
                 PageRequest.of(1, 1, Sort.by(Order.desc("id"))),
-                new SearchCondition(null)
+                new ReadAuctionSearchCondition(null)
         );
 
         // then
@@ -286,7 +286,7 @@ class QuerydslAuctionRepositoryImplTest {
         final Slice<Auction> actual = auctionRepository.findAuctionsAllByLastAuctionId(
                 auction3.getId(),
                 PageRequest.of(1, 1),
-                new SearchCondition(null)
+                new ReadAuctionSearchCondition(null)
         );
 
         // then
@@ -334,7 +334,7 @@ class QuerydslAuctionRepositoryImplTest {
         final Slice<Auction> actual = auctionRepository.findAuctionsAllByLastAuctionId(
                 null,
                 PageRequest.of(1, 1, Sort.by(Order.desc("closingTime"))),
-                new SearchCondition(null)
+                new ReadAuctionSearchCondition(null)
         );
 
         // then

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImplTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepositoryImplTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.domain.BidUnit;
 import com.ddang.ddang.auction.domain.Price;
+import com.ddang.ddang.auction.presentation.dto.request.SearchCondition;
 import com.ddang.ddang.category.domain.Category;
 import com.ddang.ddang.category.infrastructure.persistence.JpaCategoryRepository;
 import com.ddang.ddang.configuration.JpaConfiguration;
@@ -185,7 +186,8 @@ class QuerydslAuctionRepositoryImplTest {
         // when
         final Slice<Auction> actual = auctionRepository.findAuctionsAllByLastAuctionId(
                 null,
-                PageRequest.of(1, 1, Sort.by(Order.desc("id")))
+                PageRequest.of(1, 1, Sort.by(Order.desc("id"))),
+                new SearchCondition(null)
         );
 
         // then
@@ -233,7 +235,8 @@ class QuerydslAuctionRepositoryImplTest {
 
         final Slice<Auction> actual = auctionRepository.findAuctionsAllByLastAuctionId(
                 auction3.getId(),
-                PageRequest.of(1, 1, Sort.by(Order.desc("id")))
+                PageRequest.of(1, 1, Sort.by(Order.desc("id"))),
+                new SearchCondition(null)
         );
 
         // then
@@ -280,7 +283,11 @@ class QuerydslAuctionRepositoryImplTest {
         em.clear();
 
         // when
-        final Slice<Auction> actual = auctionRepository.findAuctionsAllByLastAuctionId(auction3.getId(), PageRequest.of(1, 1));
+        final Slice<Auction> actual = auctionRepository.findAuctionsAllByLastAuctionId(
+                auction3.getId(),
+                PageRequest.of(1, 1),
+                new SearchCondition(null)
+        );
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
@@ -326,7 +333,8 @@ class QuerydslAuctionRepositoryImplTest {
         // when
         final Slice<Auction> actual = auctionRepository.findAuctionsAllByLastAuctionId(
                 null,
-                PageRequest.of(1, 1, Sort.by(Order.desc("closingTime")))
+                PageRequest.of(1, 1, Sort.by(Order.desc("closingTime"))),
+                new SearchCondition(null)
         );
 
         // then

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/SearchTitleQueryTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/SearchTitleQueryTest.java
@@ -1,0 +1,113 @@
+package com.ddang.ddang.auction.infrastructure.persistence;
+
+import com.ddang.ddang.auction.domain.Auction;
+import com.ddang.ddang.auction.presentation.dto.request.ReadAuctionSearchCondition;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
+@SuppressWarnings("NonAsciiCharacters")
+class SearchTitleQueryTest extends InitializeCommonAuctionData {
+
+    @Test
+    void 검색_결과가_없을때_첫번째_페이지를_요청하면_빈_Slice를_반환한다() {
+        // when
+        final Slice<Auction> actual = querydslAuctionRepository.findAuctionsAllByLastAuctionId(
+                null,
+                PageRequest.of(1, 3),
+                new ReadAuctionSearchCondition("우아한테크코스")
+        );
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).hasSize(0);
+            softAssertions.assertThat(actual.hasNext()).isFalse();
+        });
+    }
+
+    @Test
+    void 검색_결과가_없을때_두번째_페이지_이후의_페이지를_요청하면_빈_Slice를_반환한다() {
+        // when
+        final Slice<Auction> actual = querydslAuctionRepository.findAuctionsAllByLastAuctionId(
+                15L,
+                PageRequest.of(1, 3),
+                new ReadAuctionSearchCondition("우아한테크코스")
+        );
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).hasSize(0);
+            softAssertions.assertThat(actual.hasNext()).isFalse();
+        });
+    }
+
+    @Test
+    void 검색_결과가_페이지_크기보다_작은_경우_첫번째_페이지에_모든_검색_결과를_가진_Slice를_반환한다() {
+        // when
+        final Slice<Auction> actual = querydslAuctionRepository.findAuctionsAllByLastAuctionId(
+                null,
+                PageRequest.of(1, 3),
+                new ReadAuctionSearchCondition("핫식스")
+        );
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).hasSize(1);
+            softAssertions.assertThat(actual.getContent().get(0)).isEqualTo(auction5);
+            softAssertions.assertThat(actual.hasNext()).isFalse();
+        });
+    }
+
+    @Test
+    void 검색_결과가_페이지_크기보다_큰_경우_첫번째_페이지에는_페이지_크기만큼의_검색_결과를_가진_Slice를_반환한다() {
+        // when
+        final Slice<Auction> actual = querydslAuctionRepository.findAuctionsAllByLastAuctionId(
+                null,
+                PageRequest.of(1, 3),
+                new ReadAuctionSearchCondition("맥북")
+        );
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).hasSize(3);
+            softAssertions.assertThat(actual.getContent().get(0)).isEqualTo(auction4);
+            softAssertions.assertThat(actual.getContent().get(1)).isEqualTo(auction3);
+            softAssertions.assertThat(actual.getContent().get(2)).isEqualTo(auction2);
+            softAssertions.assertThat(actual.hasNext()).isTrue();
+        });
+    }
+
+    @Test
+    void 검색_결과가_페이지_크기보다_큰_경우_마지막_페이지를_요청하면_검색_결과를_페이지로_나눈_나머지만큼의_검색_결과를_가진_Slice를_반환한다() {
+        // when
+        final Slice<Auction> actual = querydslAuctionRepository.findAuctionsAllByLastAuctionId(
+                auction2.getId(),
+                PageRequest.of(2, 3),
+                new ReadAuctionSearchCondition("맥북")
+        );
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).hasSize(1);
+            softAssertions.assertThat(actual.getContent().get(0)).isEqualTo(auction1);
+            softAssertions.assertThat(actual.hasNext()).isFalse();
+        });
+    }
+
+    @Test
+    void 검색_결과가_페이지_크기보다_큰_경우_마지막_페이지_이후_페이지를_요청하면_빈_Slice를_반환한다() {
+        // when
+        final Slice<Auction> actual = querydslAuctionRepository.findAuctionsAllByLastAuctionId(
+                auction1.getId(),
+                PageRequest.of(2, 3),
+                new ReadAuctionSearchCondition("맥북")
+        );
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).hasSize(0);
+            softAssertions.assertThat(actual.hasNext()).isFalse();
+        });
+    }
+}

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/SearchTitleQueryTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/SearchTitleQueryTest.java
@@ -71,9 +71,9 @@ class SearchTitleQueryTest extends InitializeCommonAuctionData {
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(actual).hasSize(3);
-            softAssertions.assertThat(actual.getContent().get(0)).isEqualTo(auction4);
-            softAssertions.assertThat(actual.getContent().get(1)).isEqualTo(auction3);
-            softAssertions.assertThat(actual.getContent().get(2)).isEqualTo(auction2);
+            softAssertions.assertThat(actual.getContent().get(0)).isEqualTo(auction8);
+            softAssertions.assertThat(actual.getContent().get(1)).isEqualTo(auction7);
+            softAssertions.assertThat(actual.getContent().get(2)).isEqualTo(auction4);
             softAssertions.assertThat(actual.hasNext()).isTrue();
         });
     }

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
@@ -38,7 +38,7 @@ import com.ddang.ddang.auction.application.dto.ReadRegionsDto;
 import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
 import com.ddang.ddang.auction.configuration.DescendingSortPageableArgumentResolver;
 import com.ddang.ddang.auction.presentation.dto.request.CreateAuctionRequest;
-import com.ddang.ddang.auction.presentation.dto.request.SearchCondition;
+import com.ddang.ddang.auction.presentation.dto.request.ReadAuctionSearchCondition;
 import com.ddang.ddang.authentication.application.AuthenticationUserService;
 import com.ddang.ddang.authentication.application.BlackListTokenService;
 import com.ddang.ddang.authentication.configuration.AuthenticationInterceptor;
@@ -638,7 +638,7 @@ class AuctionControllerTest {
         final ReadAuctionsDto readAuctionsDto = new ReadAuctionsDto(List.of(auction2, auction1), true);
 
         given(mockTokenDecoder.decode(eq(TokenType.ACCESS), anyString())).willReturn(Optional.of(privateClaims));
-        given(auctionService.readAllByLastAuctionId(any(), any(Pageable.class), any(SearchCondition.class)))
+        given(auctionService.readAllByLastAuctionId(any(), any(Pageable.class), any(ReadAuctionSearchCondition.class)))
                 .willReturn(readAuctionsDto);
 
         // when & then

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
@@ -38,6 +38,7 @@ import com.ddang.ddang.auction.application.dto.ReadRegionsDto;
 import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
 import com.ddang.ddang.auction.configuration.DescendingSortPageableArgumentResolver;
 import com.ddang.ddang.auction.presentation.dto.request.CreateAuctionRequest;
+import com.ddang.ddang.auction.presentation.dto.request.SearchCondition;
 import com.ddang.ddang.authentication.application.AuthenticationUserService;
 import com.ddang.ddang.authentication.application.BlackListTokenService;
 import com.ddang.ddang.authentication.configuration.AuthenticationInterceptor;
@@ -637,7 +638,8 @@ class AuctionControllerTest {
         final ReadAuctionsDto readAuctionsDto = new ReadAuctionsDto(List.of(auction2, auction1), true);
 
         given(mockTokenDecoder.decode(eq(TokenType.ACCESS), anyString())).willReturn(Optional.of(privateClaims));
-        given(auctionService.readAllByLastAuctionId(any(), any(Pageable.class))).willReturn(readAuctionsDto);
+        given(auctionService.readAllByLastAuctionId(any(), any(Pageable.class), any(SearchCondition.class)))
+                .willReturn(readAuctionsDto);
 
         // when & then
         mockMvc.perform(get("/auctions")


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->
경매 목록 검색 시 제목 기반의 검색 기능 추가
## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
- [08.31 - 09.01 백엔드 레벨 4 계획](https://www.notion.so/08-31-09-01-93b7ab36e362461a824359b5d7677742) 기준 경매 검색 기능이 `제목`에 한정되어 있어 일단 제목만 가장 간단한 방식으로 구현했습니다
- 그래서 딱히 주의 깊은 코드는 없고 쿼리 개선 시 리펙토링 할 예정입니다 
## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
- closed #349 
<!-- closed #번호 --> 
