### PR TITLE
홈 전체 경매 목록 조회 바뀐 API 맞게 수정 및 정렬 연동

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/AuctionAdapter.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/AuctionAdapter.kt
@@ -7,6 +7,17 @@ import com.ddangddangddang.android.model.AuctionHomeModel
 
 class AuctionAdapter(private val onItemClick: (Long) -> Unit) :
     ListAdapter<AuctionHomeModel, AuctionViewHolder>(AuctionDiffUtil) {
+
+    fun setAuctions(list: List<AuctionHomeModel>) {
+        submitList(list)
+    }
+
+    fun setAuctions(list: List<AuctionHomeModel>, callback: () -> Unit) {
+        submitList(list) {
+            callback()
+        }
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AuctionViewHolder {
         return AuctionViewHolder.create(parent, onItemClick)
     }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/AuctionAdapter.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/AuctionAdapter.kt
@@ -8,14 +8,8 @@ import com.ddangddangddang.android.model.AuctionHomeModel
 class AuctionAdapter(private val onItemClick: (Long) -> Unit) :
     ListAdapter<AuctionHomeModel, AuctionViewHolder>(AuctionDiffUtil) {
 
-    fun setAuctions(list: List<AuctionHomeModel>) {
-        submitList(list)
-    }
-
-    fun setAuctions(list: List<AuctionHomeModel>, callback: () -> Unit) {
-        submitList(list) {
-            callback()
-        }
+    fun setAuctions(list: List<AuctionHomeModel>, callback: (() -> Unit)? = null) {
+        submitList(list, callback)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AuctionViewHolder {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/AuctionAdapter.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/AuctionAdapter.kt
@@ -15,10 +15,6 @@ class AuctionAdapter(private val onItemClick: (Long) -> Unit) :
         holder.bind(currentList[position])
     }
 
-    fun setAuctions(list: List<AuctionHomeModel>) {
-        submitList(list)
-    }
-
     companion object {
         private val AuctionDiffUtil = object : DiffUtil.ItemCallback<AuctionHomeModel>() {
             override fun areItemsTheSame(

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/AuctionSpaceItemDecoration.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/AuctionSpaceItemDecoration.kt
@@ -15,7 +15,7 @@ class AuctionSpaceItemDecoration(private val spanCount: Int, private val space: 
         val position = parent.getChildAdapterPosition(view)
         val column = position % spanCount // 1부터 시작
 
-        if (position < spanCount) outRect.top = space
+        outRect.top = space / 2
         if (column == 0) {
             outRect.left = space
             outRect.right = space / 2
@@ -23,6 +23,6 @@ class AuctionSpaceItemDecoration(private val spanCount: Int, private val space: 
             outRect.left = space / 2
             outRect.right = space
         }
-        outRect.bottom = space
+        outRect.bottom = space / 2
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
@@ -40,7 +40,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
         binding.viewModel = viewModel
         setupViewModel()
         setupAuctionRecyclerView()
-        if (viewModel.lastAuctionId.value == null) {
+        if (viewModel.page == 0) {
             viewModel.loadAuctions()
         }
         setupReloadAuctions()

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
@@ -49,8 +49,8 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
 
     private fun setupViewModel() {
         viewModel.auctions.observe(viewLifecycleOwner) {
-            auctionAdapter.submitList(it) {
-                binding.rvAuction.scrollToPosition(0)
+            auctionAdapter.setAuctions(it) {
+                if (viewModel.page == 1) binding.rvAuction.scrollToPosition(0)
             }
         }
         viewModel.event.observe(viewLifecycleOwner) { handleEvent(it) }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
@@ -84,7 +84,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
     private fun showErrorMessage(message: String?) {
         message?.let {
             Toaster.showShort(requireContext(), it)
-            return@let
+            return
         }
         Toaster.showShort(requireContext(), getString(R.string.home_default_error_message))
     }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
@@ -12,6 +12,7 @@ import com.ddangddangddang.android.feature.common.viewModelFactory
 import com.ddangddangddang.android.feature.detail.AuctionDetailActivity
 import com.ddangddangddang.android.feature.register.RegisterAuctionActivity
 import com.ddangddangddang.android.util.binding.BindingFragment
+import com.ddangddangddang.android.util.view.Toaster
 
 class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home) {
     private val viewModel: HomeViewModel by viewModels { viewModelFactory }
@@ -64,6 +65,8 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
             is HomeViewModel.HomeEvent.NavigateToRegisterAuction -> {
                 navigateToRegisterAuction()
             }
+
+            is HomeViewModel.HomeEvent.FailureLoadAuctions -> showErrorMessage(event.message)
         }
     }
 
@@ -76,6 +79,14 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
     private fun navigateToRegisterAuction() {
         val intent = RegisterAuctionActivity.getIntent(requireContext())
         startActivity(intent)
+    }
+
+    private fun showErrorMessage(message: String?) {
+        message?.let {
+            Toaster.showShort(requireContext(), it)
+            return@let
+        }
+        Toaster.showShort(requireContext(), getString(R.string.home_default_error_message))
     }
 
     private fun setupAuctionRecyclerView() {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
@@ -80,11 +80,10 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
     }
 
     private fun showErrorMessage(message: String?) {
-        message?.let {
-            Toaster.showShort(requireContext(), it)
-            return
-        }
-        Toaster.showShort(requireContext(), getString(R.string.home_default_error_message))
+        Toaster.showShort(
+            requireContext(),
+            message ?: getString(R.string.home_default_error_message),
+        )
     }
 
     private fun setupAuctionRecyclerView() {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
@@ -41,9 +41,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
         binding.viewModel = viewModel
         setupViewModel()
         setupAuctionRecyclerView()
-        if (viewModel.page == 0) {
-            viewModel.loadAuctions()
-        }
+        if (viewModel.page == 0) viewModel.loadAuctions()
         setupReloadAuctions()
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
@@ -47,7 +47,11 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
     }
 
     private fun setupViewModel() {
-        viewModel.auctions.observe(viewLifecycleOwner) { auctionAdapter.setAuctions(it) }
+        viewModel.auctions.observe(viewLifecycleOwner) {
+            auctionAdapter.submitList(it) {
+                binding.rvAuction.scrollToPosition(0)
+            }
+        }
         viewModel.event.observe(viewLifecycleOwner) { handleEvent(it) }
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.ddangddangddang.android.model.AuctionHomeModel
 import com.ddangddangddang.android.model.mapper.AuctionHomeModelMapper.toPresentation
 import com.ddangddangddang.android.util.livedata.SingleLiveEvent
+import com.ddangddangddang.data.model.SortType
 import com.ddangddangddang.data.remote.ApiResponse
 import com.ddangddangddang.data.repository.AuctionRepository
 import kotlinx.coroutines.launch
@@ -14,15 +15,14 @@ import kotlinx.coroutines.launch
 class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
     val auctions: LiveData<List<AuctionHomeModel>> =
         repository.observeAuctionPreviews().map { auctionPreviews ->
-//            lastAuctionId.value = auctionPreviews.lastOrNull()?.id
             auctionPreviews.map { it.toPresentation() }
         }
-
-//    val page: MutableLiveData<Int> = MutableLiveData(1)
 
     private var _loadingAuctionsInProgress: Boolean = false
     val loadingAuctionInProgress: Boolean
         get() = _loadingAuctionsInProgress
+
+    private var sortType: SortType = SortType.NEW
 
     private var _page = 0
     val page: Int
@@ -42,7 +42,7 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
             _page++
             when (
                 val response =
-                    repository.getAuctionPreviews(page = _page, size = SIZE_AUCTION_LOAD)
+                    repository.getAuctionPreviews(page = _page, size = SIZE_AUCTION_LOAD, sortType = sortType)
             ) {
                 is ApiResponse.Success -> {
                     _isLast = response.body.isLast
@@ -71,7 +71,7 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
                 _page = 1
                 when (
                     val response =
-                        repository.getAuctionPreviews(page = _page, size = SIZE_AUCTION_LOAD)
+                        repository.getAuctionPreviews(page = _page, size = SIZE_AUCTION_LOAD, sortType = sortType)
                 ) {
                     is ApiResponse.Success -> {
                         _isLast = response.body.isLast
@@ -84,6 +84,11 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
                 _loadingAuctionsInProgress = false
             }
         }
+    }
+
+    fun changeFilter(type: SortType) {
+        sortType = type
+        reloadAuctions()
     }
 
     sealed class HomeEvent {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
@@ -36,7 +36,9 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
         get() = _event
 
     fun loadAuctions() {
-        fetchAuctions()
+        if (!loadingAuctionInProgress) {
+            fetchAuctions()
+        }
     }
 
     fun navigateToAuctionDetail(auctionId: Long) {
@@ -48,7 +50,7 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
     }
 
     fun reloadAuctions() {
-        if (loadingAuctionInProgress.not()) {
+        if (!loadingAuctionInProgress) {
             _page = 0
             fetchAuctions()
         }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
@@ -23,7 +23,7 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
         get() = _loadingAuctionsInProgress
 
     private var sortType: SortType = SortType.NEW
-    private var _page = DEFAULT_PAGE
+    private var _page = 0
     val page: Int
         get() = _page
 
@@ -81,10 +81,6 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
         sortType = type
         reloadAuctions()
     }
-
-//    private enum class LoadType {
-//        LOAD, RELOAD
-//    }
 
     sealed class HomeEvent {
         data class NavigateToAuctionDetail(val auctionId: Long) : HomeEvent()

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
@@ -23,7 +23,6 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
         get() = _loadingAuctionsInProgress
 
     private var sortType: SortType = SortType.NEW
-
     private var _page = 0
     val page: Int
         get() = _page

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
@@ -36,7 +36,6 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
         get() = _event
 
     fun loadAuctions() {
-        _page++
         fetchAuctions()
     }
 
@@ -50,7 +49,7 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
 
     fun reloadAuctions() {
         if (loadingAuctionInProgress.not()) {
-            _page = 1
+            _page = 0
             fetchAuctions()
         }
     }
@@ -58,6 +57,7 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
     private fun fetchAuctions() {
         viewModelScope.launch {
             _loadingAuctionsInProgress = true
+            _page++
             when (
                 val response =
                     repository.getAuctionPreviews(page = _page, size = SIZE_AUCTION_LOAD, sortType = sortType)
@@ -68,12 +68,15 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
 
                 is ApiResponse.Failure -> {
                     _event.value = HomeEvent.FailureLoadAuctions(response.error)
+                    _page--
                 }
                 is ApiResponse.NetworkError -> {
                     _event.value = HomeEvent.FailureLoadAuctions(response.exception.message)
+                    _page--
                 }
                 is ApiResponse.Unexpected -> {
                     _event.value = HomeEvent.FailureLoadAuctions(response.t?.message)
+                    _page--
                 }
             }
             _loadingAuctionsInProgress = false

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeViewModel.kt
@@ -1,7 +1,6 @@
 package com.ddangddangddang.android.feature.home
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
@@ -15,15 +14,19 @@ import kotlinx.coroutines.launch
 class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
     val auctions: LiveData<List<AuctionHomeModel>> =
         repository.observeAuctionPreviews().map { auctionPreviews ->
-            lastAuctionId.value = auctionPreviews.lastOrNull()?.id
+//            lastAuctionId.value = auctionPreviews.lastOrNull()?.id
             auctionPreviews.map { it.toPresentation() }
         }
 
-    val lastAuctionId: MutableLiveData<Long?> = MutableLiveData()
+//    val page: MutableLiveData<Int> = MutableLiveData(1)
 
     private var _loadingAuctionsInProgress: Boolean = false
     val loadingAuctionInProgress: Boolean
         get() = _loadingAuctionsInProgress
+
+    private var _page = 0
+    val page: Int
+        get() = _page
 
     private var _isLast = false
     val isLast: Boolean
@@ -36,9 +39,10 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
     fun loadAuctions() {
         _loadingAuctionsInProgress = true
         viewModelScope.launch {
+            _page++
             when (
                 val response =
-                    repository.getAuctionPreviews(lastAuctionId.value, SIZE_AUCTION_LOAD)
+                    repository.getAuctionPreviews(page = _page, size = SIZE_AUCTION_LOAD)
             ) {
                 is ApiResponse.Success -> {
                     _isLast = response.body.isLast
@@ -64,9 +68,10 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
         if (loadingAuctionInProgress.not()) {
             _loadingAuctionsInProgress = true
             viewModelScope.launch {
+                _page = 1
                 when (
                     val response =
-                        repository.getAuctionPreviews(null, SIZE_AUCTION_LOAD)
+                        repository.getAuctionPreviews(page = _page, size = SIZE_AUCTION_LOAD)
                 ) {
                     is ApiResponse.Success -> {
                         _isLast = response.body.isLast
@@ -87,6 +92,6 @@ class HomeViewModel(private val repository: AuctionRepository) : ViewModel() {
     }
 
     companion object {
-        private val SIZE_AUCTION_LOAD = 10
+        private const val SIZE_AUCTION_LOAD = 10
     }
 }

--- a/android/app/src/main/res/layout/fragment_home.xml
+++ b/android/app/src/main/res/layout/fragment_home.xml
@@ -8,6 +8,8 @@
         <variable
             name="viewModel"
             type="com.ddangddangddang.android.feature.home.HomeViewModel" />
+
+        <import type="com.ddangddangddang.data.model.SortType" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -46,7 +48,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingHorizontal="@dimen/margin_side_layout"
-                android:visibility="gone"
                 app:checkedChip="@id/chip_home_filter_new"
                 app:chipSpacingHorizontal="16dp"
                 app:selectionRequired="true"
@@ -58,6 +59,7 @@
                     style="@style/App.Custom.HomeFilterChip"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:onClick="@{() -> viewModel.changeFilter(SortType.NEW)}"
                     android:text="@string/home_filter_new" />
 
                 <com.google.android.material.chip.Chip
@@ -65,6 +67,7 @@
                     style="@style/App.Custom.HomeFilterChip"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:onClick="@{() -> viewModel.changeFilter(SortType.AUCTIONEER)}"
                     android:text="@string/home_filter_auctioneer" />
 
                 <com.google.android.material.chip.Chip
@@ -72,6 +75,7 @@
                     style="@style/App.Custom.HomeFilterChip"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:onClick="@{() -> viewModel.changeFilter(SortType.CLOSING_TIME)}"
                     android:text="@string/home_filter_closing_time" />
 
                 <com.google.android.material.chip.Chip
@@ -79,6 +83,7 @@
                     style="@style/App.Custom.HomeFilterChip"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:onClick="@{() -> viewModel.changeFilter(SortType.RELIABILITY)}"
                     android:text="@string/home_filter_reliability" />
             </com.google.android.material.chip.ChipGroup>
         </HorizontalScrollView>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="home_auctioneer_count">(%d)</string>
     <string name="home_auctioneer_count_description">경매 참여 인원수</string>
     <string name="home_register_auction_button_description">경매 등록 페이지로 이동하는 버튼</string>
+    <string name="home_default_error_message">경매 목록을 성공적으로 불러오지 못했습니다.</string>
 
     <!-- detail -->
     <string name="detail_auction_description">상품 설명</string>

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
@@ -18,10 +18,12 @@ import java.io.File
 
 class AuctionRemoteDataSource(private val service: AuctionService) {
     suspend fun getAuctionPreviews(
-        lastAuctionId: Long?,
-        size: Int,
+        page: Int,
+        size: Int?,
+        sortType: String?,
+        title: String?,
     ): ApiResponse<AuctionPreviewsResponse> =
-        service.fetchAuctionPreviews(lastAuctionId, size)
+        service.fetchAuctionPreviews(page, size, sortType, title)
 
     suspend fun getAuctionDetail(id: Long): ApiResponse<AuctionDetailResponse> =
         service.fetchAuctionDetail(id)

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
@@ -24,7 +24,7 @@ class AuctionRemoteDataSource(private val service: AuctionService) {
         sortType: SortType?,
         title: String?,
     ): ApiResponse<AuctionPreviewsResponse> =
-        service.fetchAuctionPreviews(page, size, sortType?.name, title)
+        service.fetchAuctionPreviews(page, size, sortType?.nameBy, title)
 
     suspend fun getAuctionDetail(id: Long): ApiResponse<AuctionDetailResponse> =
         service.fetchAuctionDetail(id)

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
@@ -1,5 +1,6 @@
 package com.ddangddangddang.data.datasource
 
+import com.ddangddangddang.data.model.SortType
 import com.ddangddangddang.data.model.request.AuctionBidRequest
 import com.ddangddangddang.data.model.request.RegisterAuctionRequest
 import com.ddangddangddang.data.model.request.ReportRequest
@@ -20,10 +21,10 @@ class AuctionRemoteDataSource(private val service: AuctionService) {
     suspend fun getAuctionPreviews(
         page: Int,
         size: Int?,
-        sortType: String?,
+        sortType: SortType?,
         title: String?,
     ): ApiResponse<AuctionPreviewsResponse> =
-        service.fetchAuctionPreviews(page, size, sortType, title)
+        service.fetchAuctionPreviews(page, size, sortType?.name, title)
 
     suspend fun getAuctionDetail(id: Long): ApiResponse<AuctionDetailResponse> =
         service.fetchAuctionDetail(id)

--- a/android/data/src/main/java/com/ddangddangddang/data/model/SortType.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/model/SortType.kt
@@ -1,5 +1,5 @@
 package com.ddangddangddang.data.model
 
 enum class SortType(name: String) {
-    NEW("new"), AUCTIONEER("auctioneer"), CLOSING_TIME("closing_time"), RELIABILITY("reliability")
+    NEW("new"), AUCTIONEER("auctioneer"), CLOSING_TIME("closingTime"), RELIABILITY("reliability")
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/model/SortType.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/model/SortType.kt
@@ -1,0 +1,5 @@
+package com.ddangddangddang.data.model
+
+enum class SortType(name: String) {
+    NEW("new"), AUCTIONEER("auctioneer"), CLOSING_TIME("closing_time"), RELIABILITY("reliability")
+}

--- a/android/data/src/main/java/com/ddangddangddang/data/model/SortType.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/model/SortType.kt
@@ -1,5 +1,5 @@
 package com.ddangddangddang.data.model
 
-enum class SortType(name: String) {
+enum class SortType(val nameBy: String) {
     NEW("new"), AUCTIONEER("auctioneer"), CLOSING_TIME("closingTime"), RELIABILITY("reliability")
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/remote/AuctionService.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/remote/AuctionService.kt
@@ -28,8 +28,10 @@ import retrofit2.http.Query
 interface AuctionService {
     @GET("/auctions")
     suspend fun fetchAuctionPreviews(
-        @Query("lastAuctionId") id: Long?,
-        @Query("size") size: Int,
+        @Query("page") page: Int,
+        @Query("size") size: Int?,
+        @Query("sortType") sortType: String?,
+        @Query("title") title: String?,
     ): ApiResponse<AuctionPreviewsResponse>
 
     @GET("/auctions/{id}")

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
@@ -1,6 +1,7 @@
 package com.ddangddangddang.data.repository
 
 import androidx.lifecycle.LiveData
+import com.ddangddangddang.data.model.SortType
 import com.ddangddangddang.data.model.request.RegisterAuctionRequest
 import com.ddangddangddang.data.model.response.AuctionDetailResponse
 import com.ddangddangddang.data.model.response.AuctionPreviewResponse
@@ -14,7 +15,7 @@ interface AuctionRepository {
     suspend fun getAuctionPreviews(
         page: Int,
         size: Int? = null,
-        sortType: String? = null,
+        sortType: SortType? = null,
         title: String? = null,
     ): ApiResponse<AuctionPreviewsResponse>
 

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
@@ -12,8 +12,10 @@ interface AuctionRepository {
     fun observeAuctionPreviews(): LiveData<List<AuctionPreviewResponse>>
 
     suspend fun getAuctionPreviews(
-        lastAuctionId: Long?,
-        size: Int,
+        page: Int,
+        size: Int? = null,
+        sortType: String? = null,
+        title: String? = null,
     ): ApiResponse<AuctionPreviewsResponse>
 
     suspend fun getAuctionDetail(id: Long): ApiResponse<AuctionDetailResponse>

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.ddangddangddang.data.repository
 import androidx.lifecycle.LiveData
 import com.ddangddangddang.data.datasource.AuctionLocalDataSource
 import com.ddangddangddang.data.datasource.AuctionRemoteDataSource
+import com.ddangddangddang.data.model.SortType
 import com.ddangddangddang.data.model.request.AuctionBidRequest
 import com.ddangddangddang.data.model.request.RegisterAuctionRequest
 import com.ddangddangddang.data.model.request.ReportRequest
@@ -25,7 +26,7 @@ class AuctionRepositoryImpl private constructor(
     override suspend fun getAuctionPreviews(
         page: Int,
         size: Int?,
-        sortType: String?,
+        sortType: SortType?,
         title: String?,
     ): ApiResponse<AuctionPreviewsResponse> {
         val response = remoteDataSource.getAuctionPreviews(page, size, sortType, title)

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
@@ -23,12 +23,14 @@ class AuctionRepositoryImpl private constructor(
     }
 
     override suspend fun getAuctionPreviews(
-        lastAuctionId: Long?,
-        size: Int,
+        page: Int,
+        size: Int?,
+        sortType: String?,
+        title: String?,
     ): ApiResponse<AuctionPreviewsResponse> {
-        val response = remoteDataSource.getAuctionPreviews(lastAuctionId, size)
+        val response = remoteDataSource.getAuctionPreviews(page, size, sortType, title)
         if (response is ApiResponse.Success) {
-            if (lastAuctionId == null) localDataSource.clearAuctionPreviews()
+            if (page == 1) localDataSource.clearAuctionPreviews()
             localDataSource.addAuctionPreviews(response.body.auctions)
         }
         return response


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
바뀐 서버 API에 맞게 Repository와 ViewModel을 수정하고, 정렬을 연동했습니다.

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
SortType이라는 Enum class를 생성했습니다. 현재 API 명세에서는 sortType을 String으로 받고 있는데, 이를 개발자가 수동으로 일일히 입력해야한다면 오타의 발생 가능성이 매우 크고 sortType의 이름이 바뀌었을 때 sortType을 사용하는 모든 코드를 수정해주어야하기 때문입니다.
```kotlin
enum class SortType(name: String) {
    NEW("new"), AUCTIONEER("auctioneer"), CLOSING_TIME("closing_time"), RELIABILITY("reliability")
}
```
데이터소스에서는 다음과 같이 사용합니다.
```kotlin
suspend fun getAuctionPreviews(
     page: Int,
     size: Int?,
     sortType: SortType?,
     title: String?,
): ApiResponse<AuctionPreviewsResponse> = service.fetchAuctionPreviews(page, size, sortType?.name, title)
```

정렬의 경우 ViewModel에 sortType을 보관하는 변수를 생성했습니다.
이를 통해, 정렬을 바꾼 후 reload를 하더라도 설정한 정렬대로 reload 될 수 있게합니다.
```kotlin
val response = repository.getAuctionPreviews(page = _page, size = SIZE_AUCTION_LOAD, sortType = sortType)
```

## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 
- closed: #372 