### PR TITLE
프로덕션 환경의 FCM 설정과 테스트 환경의 FCM 분리

### DIFF
--- a/backend/ddang/src/main/java/com/ddang/ddang/configuration/fcm/FcmConfiguration.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/configuration/fcm/FcmConfiguration.java
@@ -13,42 +13,34 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile("!test")
 public class FcmConfiguration {
-
-    private static final FirebaseOptions TEST_OPTIONS = FirebaseOptions.builder()
-                                                                       .setCredentials(new MockGoogleCredentials("test-token"))
-                                                                       .setProjectId("test-project")
-                                                                       .build();
-    private static final FirebaseApp FIREBASE_APP = FirebaseApp.initializeApp(TEST_OPTIONS);
-
-    @Value("${fcm.enabled}")
-    private boolean enabled;
 
     @Value("${fcm.key.path}")
     private String FCM_PRIVATE_KEY_PATH;
 
     @Bean
     FirebaseMessaging firebaseMessaging() throws IOException {
-        if (!enabled) {
-            return FirebaseMessaging.getInstance(FIREBASE_APP);
-        }
-
         final FileInputStream refreshToken = new FileInputStream(FCM_PRIVATE_KEY_PATH);
-
         final List<FirebaseApp> firebaseApps = FirebaseApp.getApps();
+
         if (firebaseApps.isEmpty()) {
             return makeNewInstance(refreshToken);
         }
 
+        refreshToken.close();
         return findExistingInstance(firebaseApps);
     }
 
     private FirebaseMessaging makeNewInstance(final InputStream refreshToken) throws IOException {
-        FirebaseOptions options = FirebaseOptions.builder()
+        final FirebaseOptions options = FirebaseOptions.builder()
                                                  .setCredentials(GoogleCredentials.fromStream(refreshToken))
                                                  .build();
+        refreshToken.close();
+
         return FirebaseMessaging.getInstance(FirebaseApp.initializeApp(options));
     }
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/configuration/FcmConfiguration.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/configuration/FcmConfiguration.java
@@ -1,0 +1,41 @@
+package com.ddang.ddang.configuration;
+
+import com.ddang.ddang.configuration.fcm.MockGoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("test")
+public class FcmConfiguration {
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() {
+        final FirebaseApp firebaseApps = findFirebaseApps();
+
+        return FirebaseMessaging.getInstance(firebaseApps);
+    }
+
+    private FirebaseApp findFirebaseApps() {
+        final List<FirebaseApp> apps = FirebaseApp.getApps();
+
+        if (!apps.isEmpty()) {
+            for (final FirebaseApp app : apps) {
+                if (FirebaseApp.DEFAULT_APP_NAME.equals(app.getName())) {
+                    return app;
+                }
+            }
+        }
+
+        final FirebaseOptions options = FirebaseOptions.builder()
+                                                       .setCredentials(new MockGoogleCredentials("test-token"))
+                                                       .setProjectId("test-project")
+                                                       .build();
+
+        return FirebaseApp.initializeApp(options);
+    }
+}

--- a/backend/ddang/src/test/resources/application.yml
+++ b/backend/ddang/src/test/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  profiles:
+    default: test
+
   datasource:
     url: jdbc:h2:mem:testdb
     username: sa


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->
프로덕션 환경의 FCM 설정과 테스트 환경의 FCM 분리
## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
- 프로덕션
  - 테스트용 FirebaseMessaging 관련 설정 삭제
  - FileInputStream close()
  - `@Profiles`를 통해 테스트 환경이 아닌 경우에만 해당 `@Configuration`이 동작하도록 설정
- 테스트
  - 테스트용 FirebaseMessaging 빈 등록 설정 추가
  - `static`을 사용하지 않고 단 하나의 인스턴스만 생성하도록 변경
## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
- closed #386 
<!-- closed #번호 --> 
