### PR TITLE
안드로이드 12이하 버전 알림 권한 및 알림 수신 대응

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainActivity.kt
@@ -130,7 +130,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
             messageId = R.string.alarm_dialog_check_permission_under_tiramisu_message,
             negativeStringId = R.string.all_dialog_default_negative_button,
             positiveStringId = R.string.alarm_dialog_check_permission_under_tiramisu_positive_button,
-            actionNegative = ::openNotificationSettings,
+            actionPositive = ::openNotificationSettings,
             isCancelable = false,
         )
     }

--- a/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
@@ -7,6 +7,7 @@ import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.ddangddangddang.android.R
@@ -21,6 +22,8 @@ import kotlinx.coroutines.withContext
 import java.net.URL
 
 class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
+    private val notificationManager by lazy { NotificationManagerCompat.from(applicationContext) }
+
     private val defaultImage: Bitmap by lazy {
         BitmapFactory.decodeResource(
             resources,
@@ -39,12 +42,18 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         if (remoteMessage.data.isNotEmpty()) {
-            if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
+            if (checkNotificationPermission()) {
                 val notification = createMessageReceivedNotification(remoteMessage)
-                NotificationManagerCompat.from(applicationContext)
-                    .notify(System.currentTimeMillis().toInt(), notification)
+                notificationManager.notify(System.currentTimeMillis().toInt(), notification)
             }
         }
+    }
+
+    private fun checkNotificationPermission(): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+        }
+        return notificationManager.areNotificationsEnabled()
     }
 
     private fun createMessageReceivedNotification(remoteMessage: RemoteMessage): Notification {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -144,6 +144,8 @@
     <string name="alarm_dialog_check_permission_message">채팅방 생성 및 채팅 수신, 자신보다 높은 입찰가를 제시한 사용자의 등장, 공지사항에 대한 알림을 받기 위해 알림 권한이 필요합니다.</string>
     <string name="alarm_dialog_check_permission_positive_button">알겠습니다</string>
     <string name="alarm_snackbar_how_to_grant_permission">알림을 수신하고 싶으신 경우, 앱 설정에서 알림 권한을 허용할 수 있습니다</string>
+    <string name="alarm_dialog_check_permission_under_tiramisu_message">알림 수신을 허용하시겠습니까?</string>
+    <string name="alarm_dialog_check_permission_under_tiramisu_positive_button">허용</string>
 
     <!-- search -->
     <string name="search">경매 상품 검색</string>


### PR DESCRIPTION
## 📄 작업 내용 요약
안드로이드 12이하 버전 알림 권한 및 알림 수신 대응

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
현재 코드에서는 안드로이드 12 이하일 때 만약 알림 권한이 없다면 권한 설정 다이얼로그를 띄우는데 안드로이드 12 이하의 경우 알림 권한 초기값이 true라고 합나디.
그래서 처음 앱을 시작하는 사용자에게 알림 권한 설정 다이얼로그를 띄우기 위해서는 내부에서 첫 실행 여부를 확인할 수 있는 값을 관리해야 합니다!
땅땅땅에서는 첫 실행시에 권한 설정 다이얼로그를 띄울지 아니면 사용자가 권한을 취소한 경우에만 띄울지 논의가 필요합니다!

## 📎 Issue 번호
- Close: #389 
