### PR TITLE
검색 기능 서버 연동

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/common/ViewModelFactory.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/common/ViewModelFactory.kt
@@ -71,7 +71,7 @@ val viewModelFactory = object : ViewModelProvider.Factory {
                 )
 
                 isAssignableFrom(ReportViewModel::class.java) -> ReportViewModel(auctionRepository)
-                isAssignableFrom(SearchViewModel::class.java) -> SearchViewModel()
+                isAssignableFrom(SearchViewModel::class.java) -> SearchViewModel(auctionRepository)
                 else -> throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
             }
         } as T

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchFragment.kt
@@ -17,7 +17,7 @@ import com.ddangddangddang.android.feature.home.AuctionAdapter
 import com.ddangddangddang.android.feature.home.AuctionSpaceItemDecoration
 import com.ddangddangddang.android.model.AuctionHomeModel
 import com.ddangddangddang.android.util.binding.BindingFragment
-import com.ddangddangddang.android.util.view.showSnackbar
+import com.ddangddangddang.android.util.view.Toaster
 
 class SearchFragment : BindingFragment<FragmentSearchBinding>(R.layout.fragment_search) {
     private val viewModel: SearchViewModel by viewModels { viewModelFactory }
@@ -27,7 +27,6 @@ class SearchFragment : BindingFragment<FragmentSearchBinding>(R.layout.fragment_
     private val auctionScrollListener = object : RecyclerView.OnScrollListener() {
         override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
             super.onScrolled(recyclerView, dx, dy)
-
             if (viewModel.isLast) return
 
             if (!viewModel.loadingAuctionInProgress) {
@@ -95,9 +94,9 @@ class SearchFragment : BindingFragment<FragmentSearchBinding>(R.layout.fragment_
     }
 
     private fun showNoticeMessage(message: String?) {
-        binding.root.showSnackbar(
+        Toaster.showShort(
+            requireContext(),
             message ?: getString(R.string.search_notice_default_error),
-            getString(R.string.all_snackbar_default_action),
         )
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchFragment.kt
@@ -1,11 +1,9 @@
 package com.ddangddangddang.android.feature.search
 
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.view.inputmethod.EditorInfo
-import android.view.inputmethod.InputMethodManager
 import androidx.fragment.app.viewModels
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.FragmentSearchBinding
@@ -57,36 +55,7 @@ class SearchFragment : BindingFragment<FragmentSearchBinding>(R.layout.fragment_
     }
 
     private fun changeAuctions(auctions: List<AuctionHomeModel>) {
-        hideKeyboard()
-        hideNoticeInputKeyword()
         auctionAdapter.submitList(auctions)
-
-        if (auctions.isEmpty()) {
-            showNoticeNoAuctions()
-            return
-        }
-        showAuctions()
-    }
-
-    private fun hideKeyboard() {
-        val imm = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(binding.etSearchKeyword.windowToken, 0)
-    }
-
-    private fun hideNoticeInputKeyword() {
-        if (binding.tvNoticeInputKeyword.visibility == View.VISIBLE) {
-            binding.tvNoticeInputKeyword.visibility = View.INVISIBLE
-        }
-    }
-
-    private fun showNoticeNoAuctions() {
-        binding.tvNoticeNoAuctions.visibility = View.VISIBLE
-        binding.rvSearchAuctions.visibility = View.INVISIBLE
-    }
-
-    private fun showAuctions() {
-        binding.tvNoticeNoAuctions.visibility = View.INVISIBLE
-        binding.rvSearchAuctions.visibility = View.VISIBLE
     }
 
     private fun navigateToAuctionDetail(auctionId: Long) {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchFragment.kt
@@ -51,10 +51,8 @@ class SearchFragment : BindingFragment<FragmentSearchBinding>(R.layout.fragment_
 
     private fun setupViewModel() {
         binding.viewModel = viewModel
-        viewModel.event.observe(viewLifecycleOwner) { event ->
-            when (event) {
-                is SearchViewModel.SearchEvent.KeywordSubmit -> changeAuctions(event.auctions)
-            }
+        viewModel.auctions.observe(viewLifecycleOwner) {
+            changeAuctions(it)
         }
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchFragment.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.FragmentSearchBinding
+import com.ddangddangddang.android.feature.common.ErrorType
 import com.ddangddangddang.android.feature.common.viewModelFactory
 import com.ddangddangddang.android.feature.detail.AuctionDetailActivity
 import com.ddangddangddang.android.feature.home.AuctionAdapter
@@ -77,8 +78,11 @@ class SearchFragment : BindingFragment<FragmentSearchBinding>(R.layout.fragment_
         }
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                SearchViewModel.SearchEvent.KeywordLimit -> showNoticeMessage(getString(R.string.search_notice_keyword_limit))
-                is SearchViewModel.SearchEvent.LoadFailureNotice -> showNoticeMessage(event.message)
+                SearchViewModel.SearchEvent.KeywordLimit -> notifyFailureMessage(
+                    ErrorType.FAILURE(getString(R.string.search_notice_keyword_limit)),
+                )
+
+                is SearchViewModel.SearchEvent.LoadFailureNotice -> notifyFailureMessage(event.error)
             }
         }
     }
@@ -93,7 +97,12 @@ class SearchFragment : BindingFragment<FragmentSearchBinding>(R.layout.fragment_
         imm.hideSoftInputFromWindow(binding.etSearchKeyword.windowToken, 0)
     }
 
-    private fun showNoticeMessage(message: String?) {
+    private fun notifyFailureMessage(type: ErrorType) {
+        val message = when (type) {
+            is ErrorType.FAILURE -> type.message
+            is ErrorType.NETWORK_ERROR -> getString(type.messageId)
+            is ErrorType.UNEXPECTED -> getString(type.messageId)
+        }
         Toaster.showShort(
             requireContext(),
             message ?: getString(R.string.search_notice_default_error),

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchViewModel.kt
@@ -14,6 +14,10 @@ class SearchViewModel : ViewModel() {
 
     val keyword: MutableLiveData<String> = MutableLiveData("")
 
+    private val _auctions: MutableLiveData<List<AuctionHomeModel>> = MutableLiveData()
+    val auctions: LiveData<List<AuctionHomeModel>>
+        get() = _auctions
+
     fun submitKeyword() {
         // repository에서 검색 결과 List를 가져오는 코드
         val dummy = listOf(
@@ -21,10 +25,10 @@ class SearchViewModel : ViewModel() {
             AuctionHomeModel(1, "ihi", "", 1000, AuctionHomeStatusModel.UNBIDDEN, 0),
             AuctionHomeModel(2, "ihi", "", 1000, AuctionHomeStatusModel.SUCCESS, 0),
         )
-        _event.value = SearchEvent.KeywordSubmit(dummy)
+
+        _auctions.value = dummy
     }
 
     sealed class SearchEvent {
-        data class KeywordSubmit(val auctions: List<AuctionHomeModel>) : SearchEvent()
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchViewModel.kt
@@ -70,7 +70,7 @@ class SearchViewModel(private val repository: AuctionRepository) : ViewModel() {
                         )
                 ) {
                     is ApiResponse.Success -> {
-                        updateAuctions(response)
+                        updateAuctions(response.body)
                         _page = newPage
                     }
 
@@ -101,15 +101,15 @@ class SearchViewModel(private val repository: AuctionRepository) : ViewModel() {
         _searchStatus.value = SearchStatus.ExistData
     }
 
-    private fun updateAuctions(response: ApiResponse.Success<AuctionPreviewsResponse>) {
+    private fun updateAuctions(response: AuctionPreviewsResponse) {
         _auctions.value?.let { items ->
-            val newItems = response.body.auctions.map { it.toPresentation() }
+            val newItems = response.auctions.map { it.toPresentation() }
             _auctions.value = if (_page == DEFAULT_PAGE) {
                 newItems
             } else {
                 items + newItems
             }
-            _isLast = response.body.isLast
+            _isLast = response.isLast
         }
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ddangddangddang.android.feature.common.ErrorType
 import com.ddangddangddang.android.model.AuctionHomeModel
 import com.ddangddangddang.android.model.mapper.AuctionHomeModelMapper.toPresentation
 import com.ddangddangddang.android.util.livedata.SingleLiveEvent
@@ -75,15 +76,15 @@ class SearchViewModel(private val repository: AuctionRepository) : ViewModel() {
                     }
 
                     is ApiResponse.Failure -> {
-                        _event.value = SearchEvent.LoadFailureNotice(response.error)
+                        _event.value = SearchEvent.LoadFailureNotice(ErrorType.FAILURE(response.error))
                     }
 
                     is ApiResponse.NetworkError -> {
-                        _event.value = SearchEvent.LoadFailureNotice(response.exception.message)
+                        _event.value = SearchEvent.LoadFailureNotice(ErrorType.NETWORK_ERROR)
                     }
 
                     is ApiResponse.Unexpected -> {
-                        _event.value = SearchEvent.LoadFailureNotice(response.t?.message)
+                        _event.value = SearchEvent.LoadFailureNotice(ErrorType.UNEXPECTED)
                     }
                 }
                 _loadingAuctionInProgress = false
@@ -115,7 +116,7 @@ class SearchViewModel(private val repository: AuctionRepository) : ViewModel() {
 
     sealed class SearchEvent {
         object KeywordLimit : SearchEvent()
-        class LoadFailureNotice(val message: String?) : SearchEvent()
+        class LoadFailureNotice(val error: ErrorType) : SearchEvent()
     }
 
     sealed class SearchStatus {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchViewModel.kt
@@ -44,10 +44,7 @@ class SearchViewModel(private val repository: AuctionRepository) : ViewModel() {
 
     fun submitKeyword() { // 검색
         if (!checkKeywordLimit()) return
-        if (!_loadingAuctionInProgress) {
-            initAuctions()
-            fetchAuctions(DEFAULT_PAGE)
-        }
+        if (!_loadingAuctionInProgress) fetchAuctions(DEFAULT_PAGE)
     }
 
     private fun checkKeywordLimit(): Boolean {
@@ -58,10 +55,6 @@ class SearchViewModel(private val repository: AuctionRepository) : ViewModel() {
             }
         }
         return true
-    }
-
-    private fun initAuctions() {
-        _auctions.value = emptyList()
     }
 
     private fun fetchAuctions(newPage: Int) {
@@ -110,7 +103,12 @@ class SearchViewModel(private val repository: AuctionRepository) : ViewModel() {
 
     private fun updateAuctions(response: ApiResponse.Success<AuctionPreviewsResponse>) {
         _auctions.value?.let { items ->
-            _auctions.value = items + response.body.auctions.map { it.toPresentation() }
+            val newItems = response.body.auctions.map { it.toPresentation() }
+            _auctions.value = if (_page == DEFAULT_PAGE) {
+                newItems
+            } else {
+                items + newItems
+            }
             _isLast = response.body.isLast
         }
     }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchViewModel.kt
@@ -3,47 +3,145 @@ package com.ddangddangddang.android.feature.search
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.ddangddangddang.android.model.AuctionHomeModel
-import com.ddangddangddang.android.model.AuctionHomeStatusModel
+import com.ddangddangddang.android.model.mapper.AuctionHomeModelMapper.toPresentation
 import com.ddangddangddang.android.util.livedata.SingleLiveEvent
+import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
+import com.ddangddangddang.data.remote.ApiResponse
+import com.ddangddangddang.data.repository.AuctionRepository
+import kotlinx.coroutines.launch
+import com.ddangddangddang.android.feature.search.SearchViewModel.SearchEvent as SearchEvent1
 
-class SearchViewModel : ViewModel() {
-    private val _event: SingleLiveEvent<SearchEvent> = SingleLiveEvent()
-    val event: LiveData<SearchEvent>
+class SearchViewModel(private val repository: AuctionRepository) : ViewModel() {
+    private val _event: SingleLiveEvent<SearchEvent1> = SingleLiveEvent()
+    val event: LiveData<SearchEvent1>
         get() = _event
 
     val keyword: MutableLiveData<String> = MutableLiveData("")
 
-    private val _auctions: MutableLiveData<List<AuctionHomeModel>> = MutableLiveData()
+    private val _auctions: MutableLiveData<List<AuctionHomeModel>> = MutableLiveData(emptyList())
     val auctions: LiveData<List<AuctionHomeModel>>
         get() = _auctions
 
-    private val _searchStatus: MutableLiveData<SearchStatus> = MutableLiveData(SearchStatus.BeforeSearch)
+    private var _loadingAuctionInProgress = false
+    val loadingAuctionInProgress: Boolean
+        get() = _loadingAuctionInProgress
+
+    private var _isLast = false
+    val isLast: Boolean
+        get() = _isLast
+
+    private var _lastAuctionId: Long? = null
+    val lastAuctionId: Long?
+        get() = _lastAuctionId
+
+    private val _searchStatus: MutableLiveData<SearchStatus> =
+        MutableLiveData(SearchStatus.BeforeSearch)
     val searchStatus: LiveData<SearchStatus>
         get() = _searchStatus
 
     fun submitKeyword() {
-        // repository에서 검색 결과 List를 가져오는 코드
-        val dummy = listOf(
-            AuctionHomeModel(0, "ihi", "", 1000, AuctionHomeStatusModel.UNBIDDEN, 0),
-            AuctionHomeModel(1, "ihi", "", 1000, AuctionHomeStatusModel.UNBIDDEN, 0),
-            AuctionHomeModel(2, "ihi", "", 1000, AuctionHomeStatusModel.SUCCESS, 0),
-        )
+        if (!checkKeywordLimit()) return
+        if (!_loadingAuctionInProgress) {
+            _loadingAuctionInProgress = true
+            viewModelScope.launch {
+                keyword.value?.let {
+                    when (
+                        val response =
+                            repository.getAuctionPreviews(_lastAuctionId, SIZE_AUCTION_LOAD, it)
+                    ) {
+                        is ApiResponse.Success -> {
+                            initAuctions()
+                            updateAuctions(response)
+                        }
+                        is ApiResponse.Failure -> {
+                            _event.value = SearchEvent.LoadFailureNotice(response.error)
+                        }
+                        is ApiResponse.NetworkError -> {
+                            _event.value = SearchEvent.LoadFailureNotice(response.exception.message)
+                        }
+                        is ApiResponse.Unexpected -> {
+                            _event.value = SearchEvent.LoadFailureNotice(response.t?.message)
+                        }
+                    }
+                    _loadingAuctionInProgress = false
+                }
+            }
+        }
 
-        _auctions.value = dummy
-
-        if (dummy.isEmpty()) {
+        if (_auctions.value.isNullOrEmpty()) {
             _searchStatus.value = SearchStatus.NoData
             return
         }
         _searchStatus.value = SearchStatus.ExistData
     }
 
-    sealed class SearchEvent
+    private fun checkKeywordLimit(): Boolean {
+        keyword.value?.let {
+            if (it.length !in 2..20) {
+                _event.value = SearchEvent.KeywordLimit
+                return false
+            }
+        }
+        return true
+    }
+
+    private fun initAuctions() {
+        _lastAuctionId = null
+        _auctions.value = emptyList()
+    }
+
+    private fun updateAuctions(response: ApiResponse.Success<AuctionPreviewsResponse>) {
+        _auctions.value?.let { items ->
+            _auctions.value = items + response.body.auctions.map { it.toPresentation() }
+            _isLast = response.body.isLast
+            _lastAuctionId = response.body.auctions.maxOf { it.id }
+        }
+    }
+
+    fun loadAuctions() {
+        // repository에서 검색 결과 List를 가져오는 코드
+        if (!_loadingAuctionInProgress) {
+            _loadingAuctionInProgress = true
+            viewModelScope.launch {
+                keyword.value?.let {
+                    when (
+                        val response =
+                            repository.getAuctionPreviews(_lastAuctionId, SIZE_AUCTION_LOAD, it)
+                    ) {
+                        is ApiResponse.Success -> {
+                            updateAuctions(response)
+                        }
+
+                        is ApiResponse.Failure -> {
+                            _event.value = SearchEvent.LoadFailureNotice(response.error)
+                        }
+                        is ApiResponse.NetworkError -> {
+                            _event.value = SearchEvent.LoadFailureNotice(response.exception.message)
+                        }
+                        is ApiResponse.Unexpected -> {
+                            _event.value = SearchEvent.LoadFailureNotice(response.t?.message)
+                        }
+                    }
+                    _loadingAuctionInProgress = false
+                }
+            }
+        }
+    }
+
+    sealed class SearchEvent {
+        object KeywordLimit : SearchEvent()
+        class LoadFailureNotice(val message: String?) : SearchEvent()
+    }
 
     sealed class SearchStatus {
         object BeforeSearch : SearchStatus()
         object NoData : SearchStatus()
         object ExistData : SearchStatus()
+    }
+
+    companion object {
+        private const val SIZE_AUCTION_LOAD = 10
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchViewModel.kt
@@ -11,11 +11,10 @@ import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
 import com.ddangddangddang.data.remote.ApiResponse
 import com.ddangddangddang.data.repository.AuctionRepository
 import kotlinx.coroutines.launch
-import com.ddangddangddang.android.feature.search.SearchViewModel.SearchEvent as SearchEvent1
 
 class SearchViewModel(private val repository: AuctionRepository) : ViewModel() {
-    private val _event: SingleLiveEvent<SearchEvent1> = SingleLiveEvent()
-    val event: LiveData<SearchEvent1>
+    private val _event: SingleLiveEvent<SearchEvent> = SingleLiveEvent()
+    val event: LiveData<SearchEvent>
         get() = _event
 
     val keyword: MutableLiveData<String> = MutableLiveData("")

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchViewModel.kt
@@ -63,7 +63,7 @@ class SearchViewModel(private val repository: AuctionRepository) : ViewModel() {
                 _loadingAuctionInProgress = true
                 when (
                     val response =
-                        repository.getAuctionPreviews(
+                        repository.getAuctionPreviewsByTitle(
                             page = newPage,
                             size = SIZE_AUCTION_LOAD,
                             title = it,

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/search/SearchViewModel.kt
@@ -18,6 +18,10 @@ class SearchViewModel : ViewModel() {
     val auctions: LiveData<List<AuctionHomeModel>>
         get() = _auctions
 
+    private val _searchStatus: MutableLiveData<SearchStatus> = MutableLiveData(SearchStatus.BeforeSearch)
+    val searchStatus: LiveData<SearchStatus>
+        get() = _searchStatus
+
     fun submitKeyword() {
         // repository에서 검색 결과 List를 가져오는 코드
         val dummy = listOf(
@@ -27,8 +31,19 @@ class SearchViewModel : ViewModel() {
         )
 
         _auctions.value = dummy
+
+        if (dummy.isEmpty()) {
+            _searchStatus.value = SearchStatus.NoData
+            return
+        }
+        _searchStatus.value = SearchStatus.ExistData
     }
 
-    sealed class SearchEvent {
+    sealed class SearchEvent
+
+    sealed class SearchStatus {
+        object BeforeSearch : SearchStatus()
+        object NoData : SearchStatus()
+        object ExistData : SearchStatus()
     }
 }

--- a/android/app/src/main/res/layout/fragment_search.xml
+++ b/android/app/src/main/res/layout/fragment_search.xml
@@ -5,6 +5,9 @@
 
     <data>
 
+        <import type="android.view.View" />
+        <import type="com.ddangddangddang.android.feature.search.SearchViewModel.SearchStatus" />
+
         <variable
             name="viewModel"
             type="com.ddangddangddang.android.feature.search.SearchViewModel" />
@@ -77,7 +80,7 @@
             android:text="@string/search_notice_no_auction"
             android:textColor="@color/black_400"
             android:textSize="@dimen/textsize_sub_header"
-            android:visibility="gone"
+            android:visibility="@{viewModel.searchStatus instanceof SearchStatus.NoData ? View.VISIBLE : View.INVISIBLE}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -90,6 +93,7 @@
             android:text="@string/search_notice_input_keyword"
             android:textColor="@color/black_400"
             android:textSize="@dimen/textsize_sub_header"
+            android:visibility="@{viewModel.searchStatus instanceof SearchStatus.BeforeSearch ? View.VISIBLE : View.INVISIBLE}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -99,7 +103,7 @@
             android:id="@+id/rv_search_auctions"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:visibility="invisible"
+            android:visibility="@{viewModel.searchStatus instanceof SearchStatus.ExistData ? View.VISIBLE : View.INVISIBLE}"
             app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -151,4 +151,6 @@
     <string name="search_keyword">검색</string>
     <string name="search_notice_no_auction">아이쿠! 올라온 경매가 없습니다!</string>
     <string name="search_notice_input_keyword">검색창에 상품명을 입력해주세요.</string>
+    <string name="search_notice_keyword_limit">검색어를 2~20자 사이로 입력해주세요.</string>
+    <string name="search_notice_default_error">에러가 발생했습니다. 다시 시도해주세요.</string>
 </resources>

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
@@ -26,6 +26,13 @@ class AuctionRemoteDataSource(private val service: AuctionService) {
     ): ApiResponse<AuctionPreviewsResponse> =
         service.fetchAuctionPreviews(page, size, sortType?.nameBy, title)
 
+    suspend fun getAuctionPreviews(
+        lastAuctionId: Long?,
+        size: Int,
+        title: String,
+    ): ApiResponse<AuctionPreviewsResponse> =
+        service.fetchAuctionPreviews(lastAuctionId, size, title)
+
     suspend fun getAuctionDetail(id: Long): ApiResponse<AuctionDetailResponse> =
         service.fetchAuctionDetail(id)
 

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
@@ -26,7 +26,7 @@ class AuctionRemoteDataSource(private val service: AuctionService) {
     ): ApiResponse<AuctionPreviewsResponse> =
         service.fetchAuctionPreviews(page, size, sortType?.nameBy, title)
 
-    suspend fun getAuctionPreviews(
+    suspend fun getAuctionPreviewsByTitle(
         page: Int,
         size: Int?,
         title: String,

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuctionRemoteDataSource.kt
@@ -27,11 +27,11 @@ class AuctionRemoteDataSource(private val service: AuctionService) {
         service.fetchAuctionPreviews(page, size, sortType?.nameBy, title)
 
     suspend fun getAuctionPreviews(
-        lastAuctionId: Long?,
-        size: Int,
+        page: Int,
+        size: Int?,
         title: String,
     ): ApiResponse<AuctionPreviewsResponse> =
-        service.fetchAuctionPreviews(lastAuctionId, size, title)
+        service.fetchAuctionPreviews(page = page, size = size, sortType = null, title = title)
 
     suspend fun getAuctionDetail(id: Long): ApiResponse<AuctionDetailResponse> =
         service.fetchAuctionDetail(id)

--- a/android/data/src/main/java/com/ddangddangddang/data/remote/AuctionService.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/remote/AuctionService.kt
@@ -36,13 +36,6 @@ interface AuctionService {
         @Query("title") title: String?,
     ): ApiResponse<AuctionPreviewsResponse>
 
-    @GET("/auctions")
-    suspend fun fetchAuctionPreviews(
-        @Query("lastAuctionId") id: Long?,
-        @Query("size") size: Int,
-        @Query("title") title: String,
-    ): ApiResponse<AuctionPreviewsResponse>
-
     @GET("/auctions/{id}")
     suspend fun fetchAuctionDetail(@Path("id") id: Long): ApiResponse<AuctionDetailResponse>
 

--- a/android/data/src/main/java/com/ddangddangddang/data/remote/AuctionService.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/remote/AuctionService.kt
@@ -36,6 +36,13 @@ interface AuctionService {
         @Query("title") title: String?,
     ): ApiResponse<AuctionPreviewsResponse>
 
+    @GET("/auctions")
+    suspend fun fetchAuctionPreviews(
+        @Query("lastAuctionId") id: Long?,
+        @Query("size") size: Int,
+        @Query("title") title: String,
+    ): ApiResponse<AuctionPreviewsResponse>
+
     @GET("/auctions/{id}")
     suspend fun fetchAuctionDetail(@Path("id") id: Long): ApiResponse<AuctionDetailResponse>
 

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
@@ -19,6 +19,12 @@ interface AuctionRepository {
         title: String? = null,
     ): ApiResponse<AuctionPreviewsResponse>
 
+    suspend fun getAuctionPreviews(
+        lastAuctionId: Long?,
+        size: Int,
+        title: String,
+    ): ApiResponse<AuctionPreviewsResponse>
+
     suspend fun getAuctionDetail(id: Long): ApiResponse<AuctionDetailResponse>
 
     suspend fun registerAuction(

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
@@ -19,7 +19,7 @@ interface AuctionRepository {
         title: String? = null,
     ): ApiResponse<AuctionPreviewsResponse>
 
-    suspend fun getAuctionPreviews(
+    suspend fun getAuctionPreviewsByTitle(
         page: Int,
         size: Int?,
         title: String,

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepository.kt
@@ -20,8 +20,8 @@ interface AuctionRepository {
     ): ApiResponse<AuctionPreviewsResponse>
 
     suspend fun getAuctionPreviews(
-        lastAuctionId: Long?,
-        size: Int,
+        page: Int,
+        size: Int?,
         title: String,
     ): ApiResponse<AuctionPreviewsResponse>
 

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
@@ -37,12 +37,12 @@ class AuctionRepositoryImpl private constructor(
         return response
     }
 
-    override suspend fun getAuctionPreviews(
+    override suspend fun getAuctionPreviewsByTitle(
         page: Int,
         size: Int?,
         title: String,
     ): ApiResponse<AuctionPreviewsResponse> {
-        return remoteDataSource.getAuctionPreviews(page = page, size = size, title = title)
+        return remoteDataSource.getAuctionPreviewsByTitle(page = page, size = size, title = title)
     }
 
     override suspend fun getAuctionDetail(id: Long): ApiResponse<AuctionDetailResponse> {

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
@@ -37,6 +37,14 @@ class AuctionRepositoryImpl private constructor(
         return response
     }
 
+    override suspend fun getAuctionPreviews(
+        lastAuctionId: Long?,
+        size: Int,
+        title: String,
+    ): ApiResponse<AuctionPreviewsResponse> {
+        return remoteDataSource.getAuctionPreviews(lastAuctionId, size, title)
+    }
+
     override suspend fun getAuctionDetail(id: Long): ApiResponse<AuctionDetailResponse> {
         val response = remoteDataSource.getAuctionDetail(id)
         if (response is ApiResponse.Success) {

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuctionRepositoryImpl.kt
@@ -38,11 +38,11 @@ class AuctionRepositoryImpl private constructor(
     }
 
     override suspend fun getAuctionPreviews(
-        lastAuctionId: Long?,
-        size: Int,
+        page: Int,
+        size: Int?,
         title: String,
     ): ApiResponse<AuctionPreviewsResponse> {
-        return remoteDataSource.getAuctionPreviews(lastAuctionId, size, title)
+        return remoteDataSource.getAuctionPreviews(page = page, size = size, title = title)
     }
 
     override suspend fun getAuctionDetail(id: Long): ApiResponse<AuctionDetailResponse> {


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## :page_facing_up: 작업 내용 요약
검색 기능 서버 연동을 진행했습니다. HomeFragment와 내용은 유사합니다.

## 🙋🏻리뷰 시 주의 깊게 확인해야 하는 코드
1. ViewModel에서 auctions를 라이브데이터로 만들었고, Fragment에서 이 auctions를 옵저빙하고 있습니다.
2. 그 외에 이벤트는 EditText의 값을 검사하여 Length가 2~20 범위가 아니거나, 통신 시 에러 메시지가 던져졌을 때 ~스낵바를 띄우는 용도로 사용하고 있습니다.~
스낵바를 보여주려니 키보드를 내려줘야하는데, 그럼 사용자는 다시 검색창을 눌러야하므로 누를게 많아서 번거롭다고 판단했습니다. 따라서 스낵바에서 토스트로 변경했습니다.
3. SearchStatus를 추가하여 현재 상태가 검색 전인지, 검색 후 데이터가 없는 상태인지, 검색 후 데이터가 있는 상태인지에 따라 적절한 뷰가 띄워지도록 visibility를 설정했습니다.
4. 원래 있던 getAuctionPreviews가 DataSource 내부 LiveData와 연관이 되어있어 검색에서는 사용할 수 없었습니다. 따라서 오버로딩을 통해 인자 수를 다르게 하여, local에 저장하지 않고 오직 list 결과값을 리턴하는 함수를 만들었습니다.
함수명을 다르게해서 구분하면 좋을 것 같긴한데... 이에 동의하신다면 좋은 네이밍 추천 받습니다!

## :paperclip: Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 
- closed: #362 