### PR TITLE
프로덕션 환경의 FCM 설정과 로컬 환경의 FCM 분리

### DIFF
--- a/backend/ddang/src/main/java/com/ddang/ddang/configuration/fcm/LocalFcmConfiguration.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/configuration/fcm/LocalFcmConfiguration.java
@@ -1,0 +1,40 @@
+package com.ddang.ddang.configuration.fcm;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("local")
+public class LocalFcmConfiguration {
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() {
+        final FirebaseApp firebaseApps = findFirebaseApps();
+
+        return FirebaseMessaging.getInstance(firebaseApps);
+    }
+
+    private FirebaseApp findFirebaseApps() {
+        final List<FirebaseApp> apps = FirebaseApp.getApps();
+
+        if (!apps.isEmpty()) {
+            for (final FirebaseApp app : apps) {
+                if (FirebaseApp.DEFAULT_APP_NAME.equals(app.getName())) {
+                    return app;
+                }
+            }
+        }
+
+        final FirebaseOptions options = FirebaseOptions.builder()
+                                                       .setCredentials(new MockGoogleCredentials("test-token"))
+                                                       .setProjectId("test-project")
+                                                       .build();
+
+        return FirebaseApp.initializeApp(options);
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/configuration/fcm/ProdFcmConfiguration.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/configuration/fcm/ProdFcmConfiguration.java
@@ -16,8 +16,8 @@ import java.util.List;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
-@Profile("!test")
-public class FcmConfiguration {
+@Profile("!test && !local")
+public class ProdFcmConfiguration {
 
     @Value("${fcm.key.path}")
     private String FCM_PRIVATE_KEY_PATH;


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->
프로덕션 환경의 FCM 설정과 로컬 환경의 FCM 분리
## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
프로덕션만 신경쓰다보니 로컬에서 실행이 안되는 이슈가 발생했습니다 
그래서 일단 LocalFcmConfiguration과 ProdFcmConfiguration로 분리했는데 LocalFcmConfiguration와 테스트용 MockFcmConfiguration의 코드는 동일합니다

분리한 이유는 LocalFcmConfiguration과 MockFcmConfiguration의 용도와 라이프 사이클이 다르다고 생각했기 때문입니다 
일단 프로덕션 영역에 테스트 코드가 존재하면 안된다고 생각하는 편이므로 실제 동일한 코드를 사용하더라도 의미가 다르다면 분리를 해야 한다고 생각하며 
로컬의 경우 테스트를 위해 로컬과 프로덕션의 FCM을 분리하면서 로컬에서 성능 테스트용과 같은 FCM을 사용할 일이 있다고 생각했기 때문입니다 
## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
- closed #386 
<!-- closed #번호 --> 
