### PR TITLE
나의 경매 목록 기능

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,9 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
+            android:name=".feature.myAuction.MyAuctionActivity"
+            android:exported="false" />
+        <activity
             android:name=".feature.profile.ProfileChangeActivity"
             android:exported="false" />
         <activity
@@ -73,9 +76,7 @@
                     android:host="oauth"
                     android:scheme="kakao${KEY_KAKAO}" />
             </intent-filter>
-        </activity>
-
-        <!-- suppress AndroidDomInspection -->
+        </activity> <!-- suppress AndroidDomInspection -->
         <service
             android:name="com.google.android.gms.metadata.ModuleDependencies"
             android:enabled="false"
@@ -97,4 +98,5 @@
             </intent-filter>
         </service>
     </application>
+
 </manifest>

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/common/ViewModelFactory.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/common/ViewModelFactory.kt
@@ -10,6 +10,7 @@ import com.ddangddangddang.android.feature.login.LoginViewModel
 import com.ddangddangddang.android.feature.main.MainViewModel
 import com.ddangddangddang.android.feature.message.MessageViewModel
 import com.ddangddangddang.android.feature.messageRoom.MessageRoomViewModel
+import com.ddangddangddang.android.feature.myAuction.MyAuctionViewModel
 import com.ddangddangddang.android.feature.mypage.MyPageViewModel
 import com.ddangddangddang.android.feature.profile.ProfileChangeViewModel
 import com.ddangddangddang.android.feature.register.RegisterAuctionViewModel
@@ -74,6 +75,9 @@ val viewModelFactory = object : ViewModelProvider.Factory {
                 isAssignableFrom(ReportViewModel::class.java) -> ReportViewModel(auctionRepository)
                 isAssignableFrom(SearchViewModel::class.java) -> SearchViewModel()
                 isAssignableFrom(ProfileChangeViewModel::class.java) -> ProfileChangeViewModel(
+                    userRepository,
+                )
+                isAssignableFrom(MyAuctionViewModel::class.java) -> MyAuctionViewModel(
                     userRepository,
                 )
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionActivity.kt
@@ -74,11 +74,11 @@ class MyAuctionActivity : BindingActivity<ActivityMyAuctionBinding>(R.layout.act
             }
 
             is ErrorType.NETWORK_ERROR -> {
-                showErrorMessage(getString(R.string.all_network_error_message))
+                showErrorMessage(getString(errorType.messageId))
             }
 
             is ErrorType.UNEXPECTED -> {
-                showErrorMessage(getString(R.string.all_unexpected_error_message))
+                showErrorMessage(getString(errorType.messageId))
             }
         }
     }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionActivity.kt
@@ -1,0 +1,29 @@
+package com.ddangddangddang.android.feature.myAuction
+
+import android.os.Bundle
+import androidx.activity.viewModels
+import com.ddangddangddang.android.R
+import com.ddangddangddang.android.databinding.ActivityMyAuctionBinding
+import com.ddangddangddang.android.feature.common.viewModelFactory
+import com.ddangddangddang.android.util.binding.BindingActivity
+
+class MyAuctionActivity : BindingActivity<ActivityMyAuctionBinding>(R.layout.activity_my_auction) {
+    private val viewModel: MyAuctionViewModel by viewModels { viewModelFactory }
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding.viewModel = viewModel
+        setupViewMdoel()
+    }
+
+    private fun setupViewMdoel() {
+        viewModel.event.observe(this) {
+            handleEvent(it)
+        }
+    }
+
+    private fun handleEvent(event: MyAuctionViewModel.Event) {
+        when (event) {
+            MyAuctionViewModel.Event.Exit -> finish()
+        }
+    }
+}

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionActivity.kt
@@ -19,7 +19,7 @@ class MyAuctionActivity : BindingActivity<ActivityMyAuctionBinding>(R.layout.act
     private val auctionScrollListener = object : RecyclerView.OnScrollListener() {
         override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
             super.onScrolled(recyclerView, dx, dy)
-            if (viewModel.isLast) return
+            if (viewModel.isLast.value == true) return
 
             if (!viewModel.loadingAuctionInProgress) {
                 val lastVisibleItemPosition =

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionActivity.kt
@@ -7,6 +7,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.ActivityMyAuctionBinding
+import com.ddangddangddang.android.feature.common.ErrorType
 import com.ddangddangddang.android.feature.common.viewModelFactory
 import com.ddangddangddang.android.feature.detail.AuctionDetailActivity
 import com.ddangddangddang.android.feature.home.AuctionAdapter
@@ -60,23 +61,23 @@ class MyAuctionActivity : BindingActivity<ActivityMyAuctionBinding>(R.layout.act
                 navigateToAuctionDetail(event.auctionId)
             }
 
-            is MyAuctionViewModel.Event.FailureLoadAuctions -> {
-                handleFailureLoadEvent(event)
+            is MyAuctionViewModel.Event.FailureLoadEvent -> {
+                handleErrorEvent(event.type)
             }
         }
     }
 
-    private fun handleFailureLoadEvent(event: MyAuctionViewModel.Event.FailureLoadAuctions) {
-        when (event) {
-            is MyAuctionViewModel.Event.FailureLoadAuctions.FailureFromServer -> {
-                showErrorMessage(event.message)
+    private fun handleErrorEvent(errorType: ErrorType) {
+        when (errorType) {
+            is ErrorType.FAILURE -> {
+                showErrorMessage(errorType.message)
             }
 
-            is MyAuctionViewModel.Event.FailureLoadAuctions.NetworkError -> {
+            is ErrorType.NETWORK_ERROR -> {
                 showErrorMessage(getString(R.string.all_network_error_message))
             }
 
-            is MyAuctionViewModel.Event.FailureLoadAuctions.UnexpectedError -> {
+            is ErrorType.UNEXPECTED -> {
                 showErrorMessage(getString(R.string.all_unexpected_error_message))
             }
         }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionActivity.kt
@@ -5,17 +5,28 @@ import androidx.activity.viewModels
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.ActivityMyAuctionBinding
 import com.ddangddangddang.android.feature.common.viewModelFactory
+import com.ddangddangddang.android.feature.home.AuctionAdapter
+import com.ddangddangddang.android.feature.home.AuctionSpaceItemDecoration
 import com.ddangddangddang.android.util.binding.BindingActivity
 
 class MyAuctionActivity : BindingActivity<ActivityMyAuctionBinding>(R.layout.activity_my_auction) {
     private val viewModel: MyAuctionViewModel by viewModels { viewModelFactory }
+    private val auctionAdapter = AuctionAdapter { auctionId ->
+        viewModel.navigateToAuctionDetail(auctionId)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.viewModel = viewModel
+        if (viewModel.auctions.value == null) viewModel.loadMyAuctions()
         setupViewMdoel()
+        setupAuctionRecyclerView()
     }
 
     private fun setupViewMdoel() {
+        viewModel.auctions.observe(this) {
+            auctionAdapter.setAuctions(it)
+        }
         viewModel.event.observe(this) {
             handleEvent(it)
         }
@@ -24,6 +35,15 @@ class MyAuctionActivity : BindingActivity<ActivityMyAuctionBinding>(R.layout.act
     private fun handleEvent(event: MyAuctionViewModel.Event) {
         when (event) {
             MyAuctionViewModel.Event.Exit -> finish()
+        }
+    }
+
+    private fun setupAuctionRecyclerView() {
+        with(binding.rvMyAuction) {
+            adapter = auctionAdapter
+
+            val space = resources.getDimensionPixelSize(R.dimen.margin_side_layout)
+            addItemDecoration(AuctionSpaceItemDecoration(spanCount = 2, space = space))
         }
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionActivity.kt
@@ -12,6 +12,7 @@ import com.ddangddangddang.android.feature.detail.AuctionDetailActivity
 import com.ddangddangddang.android.feature.home.AuctionAdapter
 import com.ddangddangddang.android.feature.home.AuctionSpaceItemDecoration
 import com.ddangddangddang.android.util.binding.BindingActivity
+import com.ddangddangddang.android.util.view.Toaster
 
 class MyAuctionActivity : BindingActivity<ActivityMyAuctionBinding>(R.layout.activity_my_auction) {
     private val viewModel: MyAuctionViewModel by viewModels { viewModelFactory }
@@ -58,6 +59,26 @@ class MyAuctionActivity : BindingActivity<ActivityMyAuctionBinding>(R.layout.act
             is MyAuctionViewModel.Event.NavigateToAuctionDetail -> {
                 navigateToAuctionDetail(event.auctionId)
             }
+
+            is MyAuctionViewModel.Event.FailureLoadAuctions -> {
+                handleFailureLoadEvent(event)
+            }
+        }
+    }
+
+    private fun handleFailureLoadEvent(event: MyAuctionViewModel.Event.FailureLoadAuctions) {
+        when (event) {
+            is MyAuctionViewModel.Event.FailureLoadAuctions.FailureFromServer -> {
+                showErrorMessage(event.message)
+            }
+
+            is MyAuctionViewModel.Event.FailureLoadAuctions.NetworkError -> {
+                showErrorMessage(getString(R.string.all_network_error_message))
+            }
+
+            is MyAuctionViewModel.Event.FailureLoadAuctions.UnexpectedError -> {
+                showErrorMessage(getString(R.string.all_unexpected_error_message))
+            }
         }
     }
 
@@ -65,6 +86,13 @@ class MyAuctionActivity : BindingActivity<ActivityMyAuctionBinding>(R.layout.act
         val intent = AuctionDetailActivity.getIntent(this, auctionId)
         intent.flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
         startActivity(intent)
+    }
+
+    private fun showErrorMessage(message: String?) {
+        Toaster.showShort(
+            this,
+            message ?: getString(R.string.home_default_error_message),
+        )
     }
 
     private fun setupAuctionRecyclerView() {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionActivity.kt
@@ -1,10 +1,12 @@
 package com.ddangddangddang.android.feature.myAuction
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.ActivityMyAuctionBinding
 import com.ddangddangddang.android.feature.common.viewModelFactory
+import com.ddangddangddang.android.feature.detail.AuctionDetailActivity
 import com.ddangddangddang.android.feature.home.AuctionAdapter
 import com.ddangddangddang.android.feature.home.AuctionSpaceItemDecoration
 import com.ddangddangddang.android.util.binding.BindingActivity
@@ -34,8 +36,17 @@ class MyAuctionActivity : BindingActivity<ActivityMyAuctionBinding>(R.layout.act
 
     private fun handleEvent(event: MyAuctionViewModel.Event) {
         when (event) {
-            MyAuctionViewModel.Event.Exit -> finish()
+            is MyAuctionViewModel.Event.Exit -> finish()
+            is MyAuctionViewModel.Event.NavigateToAuctionDetail -> {
+                navigateToAuctionDetail(event.auctionId)
+            }
         }
+    }
+
+    private fun navigateToAuctionDetail(auctionId: Long) {
+        val intent = AuctionDetailActivity.getIntent(this, auctionId)
+        intent.flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+        startActivity(intent)
     }
 
     private fun setupAuctionRecyclerView() {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionActivity.kt
@@ -13,7 +13,7 @@ import com.ddangddangddang.android.feature.detail.AuctionDetailActivity
 import com.ddangddangddang.android.feature.home.AuctionAdapter
 import com.ddangddangddang.android.feature.home.AuctionSpaceItemDecoration
 import com.ddangddangddang.android.util.binding.BindingActivity
-import com.ddangddangddang.android.util.view.Toaster
+import com.ddangddangddang.android.util.view.showSnackbar
 
 class MyAuctionActivity : BindingActivity<ActivityMyAuctionBinding>(R.layout.activity_my_auction) {
     private val viewModel: MyAuctionViewModel by viewModels { viewModelFactory }
@@ -68,32 +68,23 @@ class MyAuctionActivity : BindingActivity<ActivityMyAuctionBinding>(R.layout.act
     }
 
     private fun handleErrorEvent(errorType: ErrorType) {
-        when (errorType) {
-            is ErrorType.FAILURE -> {
-                showErrorMessage(errorType.message)
-            }
-
-            is ErrorType.NETWORK_ERROR -> {
-                showErrorMessage(getString(errorType.messageId))
-            }
-
-            is ErrorType.UNEXPECTED -> {
-                showErrorMessage(getString(errorType.messageId))
-            }
+        val defaultMessage = getString(R.string.my_auction_load_failed_title)
+        val actionMessage = getString(R.string.all_snackbar_default_action)
+        val message = when (errorType) {
+            is ErrorType.FAILURE -> errorType.message
+            is ErrorType.NETWORK_ERROR -> getString(errorType.messageId)
+            is ErrorType.UNEXPECTED -> getString(errorType.messageId)
         }
+        binding.root.showSnackbar(
+            message = message ?: defaultMessage,
+            actionMessage = actionMessage,
+        )
     }
 
     private fun navigateToAuctionDetail(auctionId: Long) {
         val intent = AuctionDetailActivity.getIntent(this, auctionId)
         intent.flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
         startActivity(intent)
-    }
-
-    private fun showErrorMessage(message: String?) {
-        Toaster.showShort(
-            this,
-            message ?: getString(R.string.home_default_error_message),
-        )
     }
 
     private fun setupAuctionRecyclerView() {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionViewModel.kt
@@ -31,8 +31,8 @@ class MyAuctionViewModel(
     val page: Int
         get() = _page
 
-    private var _isLast = false
-    val isLast: Boolean
+    private val _isLast = MutableLiveData(false)
+    val isLast: LiveData<Boolean>
         get() = _isLast
 
     fun setExitEvent() {
@@ -84,7 +84,7 @@ class MyAuctionViewModel(
             _auctions.value = items + response.auctions.map { it.toPresentation() }
         }
 
-        _isLast = response.isLast
+        _isLast.value = response.isLast
         _page = newPage
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionViewModel.kt
@@ -60,9 +60,17 @@ class MyAuctionViewModel(
                     updateAuctions(response.body, newPage)
                 }
 
-                is ApiResponse.Failure -> TODO()
-                is ApiResponse.NetworkError -> TODO()
-                is ApiResponse.Unexpected -> TODO()
+                is ApiResponse.Failure -> {
+                    _event.value = Event.FailureLoadAuctions.FailureFromServer(response.error)
+                }
+
+                is ApiResponse.NetworkError -> {
+                    _event.value = Event.FailureLoadAuctions.NetworkError
+                }
+
+                is ApiResponse.Unexpected -> {
+                    _event.value = Event.FailureLoadAuctions.UnexpectedError
+                }
             }
             _loadingAuctionsInProgress = false
         }
@@ -83,6 +91,12 @@ class MyAuctionViewModel(
     sealed class Event {
         object Exit : Event()
         data class NavigateToAuctionDetail(val auctionId: Long) : Event()
+
+        sealed class FailureLoadAuctions : Event() {
+            data class FailureFromServer(val message: String?) : FailureLoadAuctions()
+            object NetworkError : FailureLoadAuctions()
+            object UnexpectedError : FailureLoadAuctions()
+        }
     }
 
     companion object {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionViewModel.kt
@@ -1,0 +1,22 @@
+package com.ddangddangddang.android.feature.myAuction
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.ViewModel
+import com.ddangddangddang.android.util.livedata.SingleLiveEvent
+import com.ddangddangddang.data.repository.UserRepository
+
+class MyAuctionViewModel(
+    private val userRepository: UserRepository,
+) : ViewModel() {
+    private val _event: SingleLiveEvent<Event> = SingleLiveEvent()
+    val event: LiveData<Event>
+        get() = _event
+
+    fun setExitEvent() {
+        _event.value = Event.Exit
+    }
+
+    sealed class Event {
+        object Exit : Event()
+    }
+}

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionViewModel.kt
@@ -1,9 +1,15 @@
 package com.ddangddangddang.android.feature.myAuction
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ddangddangddang.android.model.AuctionHomeModel
+import com.ddangddangddang.android.model.mapper.AuctionHomeModelMapper.toPresentation
 import com.ddangddangddang.android.util.livedata.SingleLiveEvent
+import com.ddangddangddang.data.remote.ApiResponse
 import com.ddangddangddang.data.repository.UserRepository
+import kotlinx.coroutines.launch
 
 class MyAuctionViewModel(
     private val userRepository: UserRepository,
@@ -12,8 +18,29 @@ class MyAuctionViewModel(
     val event: LiveData<Event>
         get() = _event
 
+    private val _auctions: MutableLiveData<List<AuctionHomeModel>> = MutableLiveData()
+    val auctions: LiveData<List<AuctionHomeModel>>
+        get() = _auctions
+
     fun setExitEvent() {
         _event.value = Event.Exit
+    }
+
+    fun navigateToAuctionDetail(auctionId: Long) {
+    }
+
+    fun loadMyAuctions() {
+        viewModelScope.launch {
+            when (val response = userRepository.getMyAuctionPreviews()) {
+                is ApiResponse.Success -> {
+                    _auctions.value = response.body.auctions.map { it.toPresentation() }
+                }
+
+                is ApiResponse.Failure -> TODO()
+                is ApiResponse.NetworkError -> TODO()
+                is ApiResponse.Unexpected -> TODO()
+            }
+        }
     }
 
     sealed class Event {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionViewModel.kt
@@ -78,11 +78,11 @@ class MyAuctionViewModel(
     }
 
     private fun updateAuctions(response: AuctionPreviewsResponse, newPage: Int) {
-        if (newPage == 1) {
-            _auctions.value = response.auctions.map { it.toPresentation() }
+        val newItems = response.auctions.map { it.toPresentation() }
+        _auctions.value = if (newPage == DEFAULT_PAGE) {
+            newItems
         } else {
-            val items = _auctions.value ?: emptyList()
-            _auctions.value = items + response.auctions.map { it.toPresentation() }
+            (_auctions.value ?: emptyList()) + newItems
         }
 
         _isLast.value = response.isLast

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionViewModel.kt
@@ -27,6 +27,7 @@ class MyAuctionViewModel(
     }
 
     fun navigateToAuctionDetail(auctionId: Long) {
+        _event.value = Event.NavigateToAuctionDetail(auctionId)
     }
 
     fun loadMyAuctions() {
@@ -45,5 +46,6 @@ class MyAuctionViewModel(
 
     sealed class Event {
         object Exit : Event()
+        data class NavigateToAuctionDetail(val auctionId: Long) : Event()
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/myAuction/MyAuctionViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ddangddangddang.android.feature.common.ErrorType
 import com.ddangddangddang.android.model.AuctionHomeModel
 import com.ddangddangddang.android.model.mapper.AuctionHomeModelMapper.toPresentation
 import com.ddangddangddang.android.util.livedata.SingleLiveEvent
@@ -61,15 +62,15 @@ class MyAuctionViewModel(
                 }
 
                 is ApiResponse.Failure -> {
-                    _event.value = Event.FailureLoadAuctions.FailureFromServer(response.error)
+                    _event.value = Event.FailureLoadEvent(ErrorType.FAILURE(response.error))
                 }
 
                 is ApiResponse.NetworkError -> {
-                    _event.value = Event.FailureLoadAuctions.NetworkError
+                    _event.value = Event.FailureLoadEvent(ErrorType.NETWORK_ERROR)
                 }
 
                 is ApiResponse.Unexpected -> {
-                    _event.value = Event.FailureLoadAuctions.UnexpectedError
+                    _event.value = Event.FailureLoadEvent(ErrorType.UNEXPECTED)
                 }
             }
             _loadingAuctionsInProgress = false
@@ -92,11 +93,7 @@ class MyAuctionViewModel(
         object Exit : Event()
         data class NavigateToAuctionDetail(val auctionId: Long) : Event()
 
-        sealed class FailureLoadAuctions : Event() {
-            data class FailureFromServer(val message: String?) : FailureLoadAuctions()
-            object NetworkError : FailureLoadAuctions()
-            object UnexpectedError : FailureLoadAuctions()
-        }
+        data class FailureLoadEvent(val type: ErrorType) : Event()
     }
 
     companion object {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/mypage/MyPageFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/mypage/MyPageFragment.kt
@@ -15,6 +15,7 @@ import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.FragmentMyPageBinding
 import com.ddangddangddang.android.feature.common.viewModelFactory
 import com.ddangddangddang.android.feature.login.LoginActivity
+import com.ddangddangddang.android.feature.myAuction.MyAuctionActivity
 import com.ddangddangddang.android.feature.profile.ProfileChangeActivity
 import com.ddangddangddang.android.model.ProfileModel
 import com.ddangddangddang.android.util.binding.BindingFragment
@@ -63,6 +64,7 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
             }
 
             MyPageViewModel.MyPageEvent.NavigateToMyAuctions -> {
+                navigateToMyAuction()
             }
 
             MyPageViewModel.MyPageEvent.NavigateToMyParticipateAuctions -> {
@@ -74,6 +76,10 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
             MyPageViewModel.MyPageEvent.NavigateToPrivacyPolicy -> showPrivacyPolicy()
             MyPageViewModel.MyPageEvent.LogoutFailed -> notifyLogoutFailed()
         }
+    }
+
+    private fun navigateToMyAuction() {
+        startActivity(Intent(requireContext(), MyAuctionActivity::class.java))
     }
 
     private fun notifyLogoutSuccessfully() {

--- a/android/app/src/main/res/layout/activity_my_auction.xml
+++ b/android/app/src/main/res/layout/activity_my_auction.xml
@@ -41,6 +41,15 @@
                 android:textStyle="bold" />
         </androidx.appcompat.widget.Toolbar>
 
+        <TextView
+            isVisible="@{viewModel.isLast() &amp;&amp; (viewModel.auctions.size() == 0)}"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:gravity="center"
+            android:text="@string/my_auction_list_not_exist"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tb_my_auction" />
+
 
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/srl_reload_auctions"
@@ -53,11 +62,12 @@
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rv_my_auction"
+                isVisible="@{viewModel.auctions.size() != 0}"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-                tools:listitem="@layout/item_home_auction"
-                app:spanCount="2" />
+                app:spanCount="2"
+                tools:listitem="@layout/item_home_auction" />
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/activity_my_auction.xml
+++ b/android/app/src/main/res/layout/activity_my_auction.xml
@@ -16,7 +16,7 @@
         tools:context=".feature.myAuction.MyAuctionActivity">
 
         <androidx.appcompat.widget.Toolbar
-            android:id="@+id/tb_home"
+            android:id="@+id/tb_my_auction"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             app:layout_constraintStart_toStartOf="parent"
@@ -40,6 +40,25 @@
                 android:textSize="@dimen/textsize_main_header"
                 android:textStyle="bold" />
         </androidx.appcompat.widget.Toolbar>
+
+
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/srl_reload_auctions"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tb_my_auction">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_my_auction"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                tools:listitem="@layout/item_home_auction"
+                app:spanCount="2" />
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/activity_my_auction.xml
+++ b/android/app/src/main/res/layout/activity_my_auction.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.ddangddangddang.android.feature.myAuction.MyAuctionViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".feature.myAuction.MyAuctionActivity">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/tb_home"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginStart="@dimen/margin_side_layout"
+                android:contentDescription="@string/all_app_bar_back_key_description"
+                android:onClick="@{() -> viewModel.setExitEvent()}"
+                android:src="@drawable/ic_left_24"
+                app:tint="@color/black_900" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_side_layout"
+                android:text="@string/my_auction_list_title"
+                android:textColor="@color/black_900"
+                android:textSize="@dimen/textsize_main_header"
+                android:textStyle="bold" />
+        </androidx.appcompat.widget.Toolbar>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/activity_profile_change.xml
+++ b/android/app/src/main/res/layout/activity_profile_change.xml
@@ -34,7 +34,7 @@
                     android:layout_width="24dp"
                     android:layout_height="24dp"
                     android:layout_marginStart="@dimen/margin_side_layout"
-                    android:contentDescription="@string/profile_change_profile_image_description"
+                    android:contentDescription="@string/all_app_bar_back_key_description"
                     android:onClick="@{() -> viewModel.setExitEvent()}"
                     android:src="@drawable/ic_left_24"
                     app:tint="@color/black_900" />

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -156,7 +156,7 @@
     <string name="search_notice_no_auction">아이쿠! 올라온 경매가 없습니다!</string>
     <string name="search_notice_input_keyword">검색창에 상품명을 입력해주세요.</string>
 
-    <!-- profileChange-->
+    <!-- profileChange -->
     <string name="profile_change">회원 정보 수정</string>
     <string name="profile_change_profile_image_button_description">회원 프로필 수정 버튼</string>
     <string name="profile_change_nickname">닉네임</string>
@@ -164,4 +164,7 @@
     <string name="profile_change_profile_image_description">선택된 회원 프로필 이미지</string>
     <string name="profile_change_confirm">확인</string>
     <string name="profile_change_success">회원 정보 수정 성공</string>
+
+    <!-- my_auction -->
+    <string name="my_auction_list_title">나의 경매 목록</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -167,4 +167,5 @@
 
     <!-- my_auction -->
     <string name="my_auction_list_title">나의 경매 목록</string>
+    <string name="my_auction_list_not_exist">등록한 경매 상품이 아직 없습니다</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -168,4 +168,5 @@
     <!-- my_auction -->
     <string name="my_auction_list_title">나의 경매 목록</string>
     <string name="my_auction_list_not_exist">등록한 경매 상품이 아직 없습니다</string>
+    <string name="my_auction_load_failed_title">내 경매 목록을 불러오는데 실패했습니다</string>
 </resources>

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/UserRemoteDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/UserRemoteDataSource.kt
@@ -32,8 +32,8 @@ class UserRemoteDataSource(private val service: AuctionService) {
         return service.updateProfile(fileBody, body)
     }
 
-    suspend fun getMyAuctionPreviews(): ApiResponse<AuctionPreviewsResponse> =
-        service.fetchMyAuctionPreviews()
+    suspend fun getMyAuctionPreviews(page: Int): ApiResponse<AuctionPreviewsResponse> =
+        service.fetchMyAuctionPreviews(page)
 
     suspend fun updateDeviceToken(deviceTokenRequest: UpdateDeviceTokenRequest): ApiResponse<Unit> =
         service.updateDeviceToken(deviceTokenRequest)

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/UserRemoteDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/UserRemoteDataSource.kt
@@ -2,6 +2,7 @@ package com.ddangddangddang.data.datasource
 
 import com.ddangddangddang.data.model.request.ProfileUpdateRequest
 import com.ddangddangddang.data.model.request.UpdateDeviceTokenRequest
+import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
 import com.ddangddangddang.data.model.response.ProfileResponse
 import com.ddangddangddang.data.remote.ApiResponse
 import com.ddangddangddang.data.remote.AuctionService
@@ -30,6 +31,9 @@ class UserRemoteDataSource(private val service: AuctionService) {
             .toRequestBody("application/json".toMediaType())
         return service.updateProfile(fileBody, body)
     }
+
+    suspend fun getMyAuctionPreviews(): ApiResponse<AuctionPreviewsResponse> =
+        service.fetchMyAuctionPreviews()
 
     suspend fun updateDeviceToken(deviceTokenRequest: UpdateDeviceTokenRequest): ApiResponse<Unit> =
         service.updateDeviceToken(deviceTokenRequest)

--- a/android/data/src/main/java/com/ddangddangddang/data/remote/AuctionService.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/remote/AuctionService.kt
@@ -102,6 +102,9 @@ interface AuctionService {
         @Part("request") body: RequestBody,
     ): ApiResponse<ProfileResponse>
 
+    @GET("/users/auctions/mine")
+    suspend fun fetchMyAuctionPreviews(): ApiResponse<AuctionPreviewsResponse>
+
     @POST("reports/auctions")
     suspend fun reportAuction(@Body reportRequest: ReportRequest): ApiResponse<Unit>
 

--- a/android/data/src/main/java/com/ddangddangddang/data/remote/AuctionService.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/remote/AuctionService.kt
@@ -103,7 +103,9 @@ interface AuctionService {
     ): ApiResponse<ProfileResponse>
 
     @GET("/users/auctions/mine")
-    suspend fun fetchMyAuctionPreviews(): ApiResponse<AuctionPreviewsResponse>
+    suspend fun fetchMyAuctionPreviews(
+        @Query("page") page: Int,
+    ): ApiResponse<AuctionPreviewsResponse>
 
     @POST("reports/auctions")
     suspend fun reportAuction(@Body reportRequest: ReportRequest): ApiResponse<Unit>

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/UserRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/UserRepository.kt
@@ -2,6 +2,7 @@ package com.ddangddangddang.data.repository
 
 import com.ddangddangddang.data.model.request.ProfileUpdateRequest
 import com.ddangddangddang.data.model.request.UpdateDeviceTokenRequest
+import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
 import com.ddangddangddang.data.model.response.ProfileResponse
 import com.ddangddangddang.data.remote.ApiResponse
 import java.io.File
@@ -13,6 +14,8 @@ interface UserRepository {
         image: File,
         profileUpdateRequest: ProfileUpdateRequest,
     ): ApiResponse<ProfileResponse>
+
+    suspend fun getMyAuctionPreviews(): ApiResponse<AuctionPreviewsResponse>
 
     suspend fun updateDeviceToken(deviceTokenRequest: UpdateDeviceTokenRequest): ApiResponse<Unit>
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/UserRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/UserRepository.kt
@@ -15,7 +15,7 @@ interface UserRepository {
         profileUpdateRequest: ProfileUpdateRequest,
     ): ApiResponse<ProfileResponse>
 
-    suspend fun getMyAuctionPreviews(): ApiResponse<AuctionPreviewsResponse>
+    suspend fun getMyAuctionPreviews(page: Int): ApiResponse<AuctionPreviewsResponse>
 
     suspend fun updateDeviceToken(deviceTokenRequest: UpdateDeviceTokenRequest): ApiResponse<Unit>
 }

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/UserRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/UserRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.ddangddangddang.data.repository
 import com.ddangddangddang.data.datasource.UserRemoteDataSource
 import com.ddangddangddang.data.model.request.ProfileUpdateRequest
 import com.ddangddangddang.data.model.request.UpdateDeviceTokenRequest
+import com.ddangddangddang.data.model.response.AuctionPreviewsResponse
 import com.ddangddangddang.data.model.response.ProfileResponse
 import com.ddangddangddang.data.remote.ApiResponse
 import com.ddangddangddang.data.remote.AuctionService
@@ -15,6 +16,10 @@ class UserRepositoryImpl(private val remoteDataSource: UserRemoteDataSource) : U
         profileUpdateRequest: ProfileUpdateRequest,
     ): ApiResponse<ProfileResponse> {
         return remoteDataSource.updateProfile(image, profileUpdateRequest)
+    }
+
+    override suspend fun getMyAuctionPreviews(): ApiResponse<AuctionPreviewsResponse> {
+        return remoteDataSource.getMyAuctionPreviews()
     }
 
     override suspend fun updateDeviceToken(deviceTokenRequest: UpdateDeviceTokenRequest): ApiResponse<Unit> {

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/UserRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/UserRepositoryImpl.kt
@@ -18,8 +18,8 @@ class UserRepositoryImpl(private val remoteDataSource: UserRemoteDataSource) : U
         return remoteDataSource.updateProfile(image, profileUpdateRequest)
     }
 
-    override suspend fun getMyAuctionPreviews(): ApiResponse<AuctionPreviewsResponse> {
-        return remoteDataSource.getMyAuctionPreviews()
+    override suspend fun getMyAuctionPreviews(page: Int): ApiResponse<AuctionPreviewsResponse> {
+        return remoteDataSource.getMyAuctionPreviews(page)
     }
 
     override suspend fun updateDeviceToken(deviceTokenRequest: UpdateDeviceTokenRequest): ApiResponse<Unit> {


### PR DESCRIPTION
## 📄 작업 내용 요약
나의 경매 목록을 볼 수 있는 기능을 추가했습니다.


## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<img width="701" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/83772cbb-381d-4a45-96b1-13c75f025df1">
만약 응답 성공시, 요청했던 페이지가 1이라면, 이전 정보는 빼고 새로 리스트를 설정했습니다.

<img width="640" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/471e57c8-849c-410d-a306-701d8b673fd2">
상품을 성공적으로 불러왔는데, 상품이 1개도 없을 경우 텍스트를 화면에 보여주기 위해 isLast를 라이브데이터로 했습니다.

### 현재 상황
- 내 경매 목록에서 상세 상품으로 들어가서 상품을 삭제하고 다시 돌아왔을때, 목록에서 제거되지 않습니다. 일단 기본적으로 서버에서 지금 내 경매 목록에 대해서는 삭제된 상품도 같이 보내주고 있습니다.
만약 서버에서 정책을 바꿔서, 삭제한 상품도 나의 경매 목록에서 보여주지 않도록 된다면, 상세 페이지에서 추가적인 작업이 필요할 것 같습니다. (삭제한 상품의 id정보를 돌려주지 않기 때문에, 만약 필요하다면, 상세 페이지에서 삭제시 상품의 정보를 종료 결과로 보내줘야 할 수도 있을 것 같습니다. 지금 아마 검색쪽에서도 같은 문제가 있을 것 같네요)


## 📎 Issue 번호
- close: #395 
