### PR TITLE
쪽지방 페이지 전송 버튼 활성화 유무 설정 및 글자 기울어져서 잘리는 현상 수정

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
@@ -85,16 +85,16 @@ class MessageRoomActivity :
 
     private fun getDefaultFailureMessageByFailureEvent(event: MessageRoomViewModel.MessageRoomEvent.FailureEvent): String {
         return when (event) {
-            is MessageRoomViewModel.MessageRoomEvent.FailureEvent.LoadMessages -> {
-                getString(R.string.all_unexpected_error_message)
+            is MessageRoomViewModel.MessageRoomEvent.FailureEvent.LoadRoomInfo -> {
+                getString(R.string.message_room_load_room_info_failed)
             }
 
-            is MessageRoomViewModel.MessageRoomEvent.FailureEvent.LoadRoomInfo -> {
-                getString(R.string.all_unexpected_error_message)
+            is MessageRoomViewModel.MessageRoomEvent.FailureEvent.LoadMessages -> {
+                getString(R.string.message_room_load_messages_failed)
             }
 
             is MessageRoomViewModel.MessageRoomEvent.FailureEvent.SendMessage -> {
-                getString(R.string.all_unexpected_error_message)
+                getString(R.string.message_room_send_message_failed)
             }
         }
     }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ddangddangddang.android.feature.common.ErrorType
 import com.ddangddangddang.android.model.MessageModel
 import com.ddangddangddang.android.model.MessageRoomDetailModel
 import com.ddangddangddang.android.model.mapper.MessageModelMapper.toPresentation
@@ -47,11 +48,18 @@ class MessageRoomViewModel @Inject constructor(
                 }
 
                 is ApiResponse.Failure -> {
-                    _event.value = MessageRoomEvent.LoadRoomInfoFailed
+                    _event.value =
+                        MessageRoomEvent.FailureEvent.LoadRoomInfo(ErrorType.FAILURE(response.error))
                 }
 
-                is ApiResponse.NetworkError -> {}
-                is ApiResponse.Unexpected -> {}
+                is ApiResponse.NetworkError -> {
+                    _event.value =
+                        MessageRoomEvent.FailureEvent.LoadRoomInfo(ErrorType.NETWORK_ERROR)
+                }
+
+                is ApiResponse.Unexpected -> {
+                    _event.value = MessageRoomEvent.FailureEvent.LoadRoomInfo(ErrorType.UNEXPECTED)
+                }
             }
         }
     }
@@ -67,9 +75,20 @@ class MessageRoomViewModel @Inject constructor(
                         addMessages(response.body.map { it.toPresentation().toViewItem() })
                     }
 
-                    is ApiResponse.Failure -> {}
-                    is ApiResponse.NetworkError -> {}
-                    is ApiResponse.Unexpected -> {}
+                    is ApiResponse.Failure -> {
+                        _event.value =
+                            MessageRoomEvent.FailureEvent.LoadMessages(ErrorType.FAILURE(response.error))
+                    }
+
+                    is ApiResponse.NetworkError -> {
+                        _event.value =
+                            MessageRoomEvent.FailureEvent.LoadMessages(ErrorType.NETWORK_ERROR)
+                    }
+
+                    is ApiResponse.Unexpected -> {
+                        _event.value =
+                            MessageRoomEvent.FailureEvent.LoadMessages(ErrorType.UNEXPECTED)
+                    }
                 }
                 isMessageLoading = false
             }
@@ -101,9 +120,20 @@ class MessageRoomViewModel @Inject constructor(
                         loadMessages()
                     }
 
-                    is ApiResponse.Failure -> {}
-                    is ApiResponse.NetworkError -> {}
-                    is ApiResponse.Unexpected -> {}
+                    is ApiResponse.Failure -> {
+                        _event.value =
+                            MessageRoomEvent.FailureEvent.SendMessage(ErrorType.FAILURE(response.error))
+                    }
+
+                    is ApiResponse.NetworkError -> {
+                        _event.value =
+                            MessageRoomEvent.FailureEvent.SendMessage(ErrorType.NETWORK_ERROR)
+                    }
+
+                    is ApiResponse.Unexpected -> {
+                        _event.value =
+                            MessageRoomEvent.FailureEvent.SendMessage(ErrorType.UNEXPECTED)
+                    }
                 }
             }
         }
@@ -127,6 +157,10 @@ class MessageRoomViewModel @Inject constructor(
         object Exit : MessageRoomEvent()
         data class Report(val roomId: Long) : MessageRoomEvent()
         data class NavigateToAuctionDetail(val auctionId: Long) : MessageRoomEvent()
-        object LoadRoomInfoFailed : MessageRoomEvent()
+        sealed class FailureEvent(val type: ErrorType) : MessageRoomEvent() {
+            class LoadRoomInfo(type: ErrorType) : FailureEvent(type)
+            class LoadMessages(type: ErrorType) : FailureEvent(type)
+            class SendMessage(type: ErrorType) : FailureEvent(type)
+        }
     }
 }

--- a/android/app/src/main/res/layout/activity_message_room.xml
+++ b/android/app/src/main/res/layout/activity_message_room.xml
@@ -224,6 +224,7 @@
                 android:layout_height="match_parent"
                 android:layout_marginStart="12dp"
                 android:background="@drawable/bg_stroke_gray_radius_1dp"
+                android:enabled="@{viewModel.messageRoomInfo.chatAvailable}"
                 android:insetTop="0dp"
                 android:insetBottom="0dp"
                 android:minWidth="0dp"

--- a/android/app/src/main/res/layout/item_my_message.xml
+++ b/android/app/src/main/res/layout/item_my_message.xml
@@ -36,6 +36,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/padding_vertical_filter_chips"
             android:text="@{item.createdDateTime}"
+            android:paddingHorizontal="4dp"
             android:textColor="@color/black_400"
             android:textSize="12sp"
             android:textStyle="italic"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -114,7 +114,7 @@
     <string name="message_room_message_submit">전송</string>
     <string name="message_room_load_room_info_failed">채팅방 정보를 불러오는데 실패했습니다\n잠시 후에 다시 시도해주세요</string>
     <string name="message_room_load_messages_failed">메시지 정보를 불러오는데 실패했습니다\n잠시 후에 다시 시도해주세요</string>
-    <string name="message_room_send_message_failed">메시지 전송 중 문제가 실패했습니다\n잠시 후에 다시 시도해주세요</string>
+    <string name="message_room_send_message_failed">메시지 전송에 실패했습니다\n잠시 후에 다시 시도해주세요</string>
     <string name="message_room_created_introduce_text">쪽지방이 생성됐습니다.</string>
     <string name="message_room_auction_bid_price">%,d원</string>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -112,7 +112,9 @@
     <string name="message_room_report_description">쪽지 상대 신고 버튼입니다</string>
     <string name="message_room_message_input_hint">메시지를 입력해주세요</string>
     <string name="message_room_message_submit">전송</string>
-    <string name="message_room_toast_load_room_info_failed">채팅방 정보를 불러오는데 문제가 생겼습니다\n잠시후에 다시 시도해주세요</string>
+    <string name="message_room_load_room_info_failed">채팅방 정보를 불러오는데 문제가 생겼습니다\n잠시후에 다시 시도해주세요</string>
+    <string name="message_room_load_messages_failed">메시지 정보를 불러오는데 문제가 생겼습니다\n잠시후에 다시 시도해주세요</string>
+    <string name="message_room_send_message_failed">메시지 전송 중 문제가 생겼습니다\n잠시후에 다시 시도해주세요</string>
     <string name="message_room_created_introduce_text">쪽지방이 생성됐습니다.</string>
     <string name="message_room_auction_bid_price">%,d원</string>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -112,9 +112,9 @@
     <string name="message_room_report_description">쪽지 상대 신고 버튼입니다</string>
     <string name="message_room_message_input_hint">메시지를 입력해주세요</string>
     <string name="message_room_message_submit">전송</string>
-    <string name="message_room_load_room_info_failed">채팅방 정보를 불러오는데 문제가 생겼습니다\n잠시후에 다시 시도해주세요</string>
-    <string name="message_room_load_messages_failed">메시지 정보를 불러오는데 문제가 생겼습니다\n잠시후에 다시 시도해주세요</string>
-    <string name="message_room_send_message_failed">메시지 전송 중 문제가 생겼습니다\n잠시후에 다시 시도해주세요</string>
+    <string name="message_room_load_room_info_failed">채팅방 정보를 불러오는데 실패했습니다\n잠시 후에 다시 시도해주세요</string>
+    <string name="message_room_load_messages_failed">메시지 정보를 불러오는데 실패했습니다\n잠시 후에 다시 시도해주세요</string>
+    <string name="message_room_send_message_failed">메시지 전송 중 문제가 실패했습니다\n잠시 후에 다시 시도해주세요</string>
     <string name="message_room_created_introduce_text">쪽지방이 생성됐습니다.</string>
     <string name="message_room_auction_bid_price">%,d원</string>
 


### PR DESCRIPTION
## 📄 작업 내용 요약
-  쪽지 전송 버튼 활성화 유무 기능 추가
-  메시지 전송 시간 양쪽 사이드 글자 잘려보이던 현상 수정
- 쪽지방 페이지에서 통신 실패 시, ErrorType 적용

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
내용이 작아서 없는 것 같습니다. 
굳이 꼽자면, 메시지 룸에서 서버 통신 실패의 종류를 세 가지로 sealedclass 로 묶었습니다.
![image](https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/cabeb140-7668-4140-bcb5-6487546537b3)


## 📎 Issue 번호
- close: #422 
