### PR TITLE
회원 정보 페이지에서 프로필 이미지 scaleType 수정 및 회원 수정 정보 요청 시 응답 실패 로직 추가

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/profile/ProfileChangeActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/profile/ProfileChangeActivity.kt
@@ -11,10 +11,12 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.ActivityProfileChangeBinding
+import com.ddangddangddang.android.feature.common.ErrorType
 import com.ddangddangddang.android.model.ProfileModel
 import com.ddangddangddang.android.util.binding.BindingActivity
 import com.ddangddangddang.android.util.compat.getParcelableCompat
 import com.ddangddangddang.android.util.view.Toaster
+import com.ddangddangddang.android.util.view.showSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -61,6 +63,10 @@ class ProfileChangeActivity :
             is ProfileChangeViewModel.Event.SuccessProfileChange -> {
                 changeSuccessProfile()
             }
+
+            is ProfileChangeViewModel.Event.FailureChangeProfileEvent -> {
+                notifyProfileChangeFailed(event.errorType)
+            }
         }
     }
 
@@ -68,6 +74,20 @@ class ProfileChangeActivity :
         Toaster.showShort(this, getString(R.string.profile_change_success))
         setResult(Activity.RESULT_OK)
         finish()
+    }
+
+    private fun notifyProfileChangeFailed(type: ErrorType) {
+        val defaultMessage = getString(R.string.profile_change_failed)
+        val actionMessage = getString(R.string.all_snackbar_default_action)
+        val message = when (type) {
+            is ErrorType.FAILURE -> type.message
+            is ErrorType.NETWORK_ERROR -> getString(type.messageId)
+            is ErrorType.UNEXPECTED -> getString(type.messageId)
+        }
+        binding.root.showSnackbar(
+            message = message ?: defaultMessage,
+            actionMessage = actionMessage,
+        )
     }
 
     companion object {

--- a/android/app/src/main/res/drawable/ic_camera_20_18.xml
+++ b/android/app/src/main/res/drawable/ic_camera_20_18.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="18dp"
+    android:viewportWidth="20"
+    android:viewportHeight="18">
+  <path
+      android:pathData="M10,13.2C11.767,13.2 13.2,11.767 13.2,10C13.2,8.233 11.767,6.8 10,6.8C8.232,6.8 6.8,8.233 6.8,10C6.8,11.767 8.232,13.2 10,13.2Z"
+      android:fillColor="#323232"/>
+  <path
+      android:pathData="M7,0L5.17,2H2C0.9,2 0,2.9 0,4V16C0,17.1 0.9,18 2,18H18C19.1,18 20,17.1 20,16V4C20,2.9 19.1,2 18,2H14.83L13,0H7ZM10,15C7.24,15 5,12.76 5,10C5,7.24 7.24,5 10,5C12.76,5 15,7.24 15,10C15,12.76 12.76,15 10,15Z"
+      android:fillColor="#323232"/>
+</vector>

--- a/android/app/src/main/res/layout/activity_profile_change.xml
+++ b/android/app/src/main/res/layout/activity_profile_change.xml
@@ -91,19 +91,19 @@
             android:layout_marginTop="38dp"
             android:backgroundTint="#D9D9D9"
             android:onClick="@{()->viewModel.selectProfileImage()}"
-            app:cardCornerRadius="18dp"
+            app:cardCornerRadius="17.5dp"
             app:layout_constraintBottom_toBottomOf="@id/cv_image"
             app:layout_constraintEnd_toEndOf="@id/cv_image">
 
             <ImageView
                 android:id="@+id/iv_delete_image"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:adjustViewBounds="true"
                 android:contentDescription="@string/profile_change_profile_image_button_description"
-                android:scaleType="center"
-                android:src="@drawable/ic_camera_24" />
+                android:scaleType="fitXY"
+                android:src="@drawable/ic_camera_20_18" />
 
         </androidx.cardview.widget.CardView>
 

--- a/android/app/src/main/res/layout/activity_profile_change.xml
+++ b/android/app/src/main/res/layout/activity_profile_change.xml
@@ -86,12 +86,12 @@
 
         <androidx.cardview.widget.CardView
             android:id="@+id/cv_camera"
-            android:layout_width="35dp"
-            android:layout_height="35dp"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
             android:layout_marginTop="38dp"
             android:backgroundTint="#D9D9D9"
             android:onClick="@{()->viewModel.selectProfileImage()}"
-            app:cardCornerRadius="17.5dp"
+            app:cardCornerRadius="18dp"
             app:layout_constraintBottom_toBottomOf="@id/cv_image"
             app:layout_constraintEnd_toEndOf="@id/cv_image">
 

--- a/android/app/src/main/res/layout/view_profile.xml
+++ b/android/app/src/main/res/layout/view_profile.xml
@@ -24,12 +24,13 @@
             app:layout_constraintTop_toTopOf="parent">
 
             <ImageView
+                android:id="@+id/iv_profile_image"
                 imageUrl="@{profile.profileImage}"
                 placeholder="@{@drawable/img_default_profile}"
-                android:id="@+id/iv_profile_image"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/all_profile_image_description"
+                android:scaleType="centerCrop"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -39,36 +40,36 @@
         </androidx.cardview.widget.CardView>
 
         <TextView
-            android:text="@{profile.name}"
             android:id="@+id/tv_nickname"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
+            android:text="@{profile.name}"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toTopOf="@id/iv_reliability_icon"
             app:layout_constraintStart_toEndOf="@id/cv_profile_image"
             app:layout_constraintTop_toTopOf="@id/cv_profile_image"
-            app:layout_constraintBottom_toTopOf="@id/iv_reliability_icon"
             app:layout_constraintVertical_chainStyle="packed"
-            android:textStyle="bold"
-            android:textSize="16sp"
             tools:text="카붕이" />
 
         <ImageView
             android:id="@+id/iv_reliability_icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
             android:contentDescription="@string/all_reliability_icon_description"
             android:src="@drawable/ic_star_18"
-            android:layout_marginTop="4dp"
+            app:layout_constraintBottom_toBottomOf="@id/cv_profile_image"
             app:layout_constraintStart_toStartOf="@id/tv_nickname"
-            app:layout_constraintTop_toBottomOf="@id/tv_nickname"
-            app:layout_constraintBottom_toBottomOf="@id/cv_profile_image" />
+            app:layout_constraintTop_toBottomOf="@id/tv_nickname" />
 
         <TextView
-            android:text="@{@string/all_reliability(profile.reliability)}"
             android:id="@+id/tv_reliability_score"
             android:layout_width="wrap_content"
-            android:layout_marginStart="4dp"
             android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:text="@{@string/all_reliability(profile.reliability)}"
             android:textSize="14sp"
             app:layout_constraintBottom_toBottomOf="@id/iv_reliability_icon"
             app:layout_constraintStart_toEndOf="@id/iv_reliability_icon"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -166,6 +166,7 @@
     <string name="profile_change_profile_image_description">선택된 회원 프로필 이미지</string>
     <string name="profile_change_confirm">확인</string>
     <string name="profile_change_success">회원 정보 수정 성공</string>
+    <string name="profile_change_failed">프로필 정보 수정에 실패했습니다</string>
 
     <!-- my_participate_auction -->
     <string name="my_participate_auction_list_title">내가 참여한 경매 목록</string>


### PR DESCRIPTION
## 📄 작업 내용 요약
회원 정보 페이지에서 프로필 이미지 scaleType 수정 및 회원 수정 정보 요청 시 응답 실패 로직 추가

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
view_profile.xml 파일에서 실제 변경점은 scaleType = "centerCrop" 밖에 없습니다. 나머지는 코드 정렬하다가 수정 된 것입니다.

## 📎 Issue 번호
- close: #424 
