### PR TITLE
인앱 자동 업데이트 기능 추가

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -106,6 +106,9 @@ dependencies {
     // hilt
     implementation "com.google.dagger:hilt-android:2.44"
     kapt "com.google.dagger:hilt-compiler:2.44"
+
+    // app update manager
+    implementation 'com.google.android.play:app-update-ktx:2.1.0'
 }
 kapt {
     correctErrorTypes true

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/splash/SplashActivity.kt
@@ -2,21 +2,72 @@ package com.ddangddangddang.android.feature.splash
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.ActivitySplashBinding
 import com.ddangddangddang.android.feature.login.LoginActivity
 import com.ddangddangddang.android.feature.main.MainActivity
 import com.ddangddangddang.android.util.binding.BindingActivity
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.appupdate.AppUpdateOptions
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.UpdateAvailability
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class SplashActivity : BindingActivity<ActivitySplashBinding>(R.layout.activity_splash) {
     private val viewModel: SplashViewModel by viewModels()
+
+    private val updateResultLauncher =
+        registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
+            if (result.resultCode == RESULT_OK) {
+                Log.d("mendel", "업데이트 완료")
+                viewModel.checkTokenExist()
+            }
+        }
+
+    private val appUpdateManager by lazy {
+        AppUpdateManagerFactory.create(this)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setupObserve()
-        viewModel.checkTokenExist()
+
+        appUpdateManager.appUpdateInfo.addOnSuccessListener { appUpdateInfo ->
+            if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
+                appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)
+            ) {
+                appUpdateManager.startUpdateFlowForResult(
+                    appUpdateInfo,
+                    updateResultLauncher,
+                    AppUpdateOptions.newBuilder(AppUpdateType.IMMEDIATE).build(),
+                )
+                Log.d("mendel", "업데이트 해야함...")
+            } else {
+                Log.d("mendel", "업데이트 통과")
+                viewModel.checkTokenExist()
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        appUpdateManager.appUpdateInfo.addOnSuccessListener { appUpdateInfo ->
+            if (appUpdateInfo.updateAvailability()
+                == UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS
+            ) {
+                Log.d("mendel", "업데이트 도중 돌아옴")
+                // If an in-app update is already running, resume the update.
+                appUpdateManager.startUpdateFlowForResult(
+                    appUpdateInfo,
+                    updateResultLauncher,
+                    AppUpdateOptions.newBuilder(AppUpdateType.IMMEDIATE).build(),
+                )
+            }
+        }
     }
 
     private fun setupObserve() {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/splash/SplashActivity.kt
@@ -10,6 +10,7 @@ import com.ddangddangddang.android.databinding.ActivitySplashBinding
 import com.ddangddangddang.android.feature.login.LoginActivity
 import com.ddangddangddang.android.feature.main.MainActivity
 import com.ddangddangddang.android.util.binding.BindingActivity
+import com.ddangddangddang.android.util.view.Toaster
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.appupdate.AppUpdateOptions
 import com.google.android.play.core.install.model.AppUpdateType
@@ -40,14 +41,20 @@ class SplashActivity : BindingActivity<ActivitySplashBinding>(R.layout.activity_
             if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
                 appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)
             ) {
+                Log.d("mendel", "업데이트 할거 있고, 지금 당장 할 수 있음")
                 appUpdateManager.startUpdateFlowForResult(
                     appUpdateInfo,
                     updateResultLauncher,
                     AppUpdateOptions.newBuilder(AppUpdateType.IMMEDIATE).build(),
                 )
-                Log.d("mendel", "업데이트 해야함...")
+            } else if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
+                !appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)
+            ) {
+                Log.d("mendel", "업데이트 할게 있지만, 현재 즉시 업데이트 하지 못하는 상황")
+                Toaster.showShort(this, getString(R.string.all_must_update_to_latest_version))
+                finish()
             } else {
-                Log.d("mendel", "업데이트 통과")
+                Log.d("mendel", "업데이트 할거 없음. 통과")
                 viewModel.checkTokenExist()
             }
         }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="all_reliability">(%.1f)</string>
     <string name="all_network_error_message">인터넷이 연결되어 있는지 확인해주세요.</string>
     <string name="all_unexpected_error_message">예기치 못한 오류가 발생했습니다. 다시 시도해주세요.</string>
+    <string name="all_must_update_to_latest_version">최신 버전으로 업데이트가 필요합니다.</string>
 
     <!-- home -->
     <string name="home">경매 상품 목록</string>


### PR DESCRIPTION
## 📄 작업 내용 요약
앱 업데이트 매니저 로직 추가

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<img width="891" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/64561c0d-f800-40e9-bc66-cf066736572d">
첫 번째 빨간 박스의 조건문 의미는, 앱을 업데이트 할 상위 버전이 플레이스토어에 존재하고, 즉시 업데이트할 수 있는 경우(만약 다른 앱이 백그라운드에서 업데이트 중이면 즉시 못하는 상황이라고 함)에 startUpdateFlowForResult 를 실행해서 업데이트를 진행 페이지로 이동합니다.

<img width="665" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/4a6ff43b-d40a-4d9a-a802-5ab37c5f2a7b">

만약 업데이트 페이지에서 뒤로가기를 누르면, 다시 스플래시로 오게 되는데, 만약 앱 업데이트 진행중이였다면, 다시 앱 업데이트 페이지로 이동시킵니다.

<img width="783" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/e5ac0246-e476-4b49-bcb6-7de0f9d9eadb">
업데이트가 완료되면, 토큰 유효성 검사해서 자동 로그인 시도를 합니다.


## 📎 Issue 번호
- close: #435 