### PR TITLE
경매 알림 수신 기능 추가

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
@@ -11,6 +11,7 @@ import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.ddangddangddang.android.R
+import com.ddangddangddang.android.feature.detail.AuctionDetailActivity
 import com.ddangddangddang.android.feature.messageRoom.MessageRoomActivity
 import com.ddangddangddang.data.model.request.UpdateDeviceTokenRequest
 import com.ddangddangddang.data.repository.UserRepository
@@ -49,7 +50,7 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         if (remoteMessage.data.isNotEmpty()) {
             if (checkNotificationPermission()) {
-                val notification = createMessageReceivedNotification(remoteMessage)
+                val notification = createMessageReceivedNotification(remoteMessage) ?: return
                 notificationManager.notify(System.currentTimeMillis().toInt(), notification)
             }
         }
@@ -62,22 +63,18 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
         return notificationManager.areNotificationsEnabled()
     }
 
-    private fun createMessageReceivedNotification(remoteMessage: RemoteMessage): Notification {
+    private fun createMessageReceivedNotification(remoteMessage: RemoteMessage): Notification? {
         return runBlocking {
+            val type =
+                NotificationType.of(remoteMessage.data["type"] ?: "") ?: return@runBlocking null
+            val pendingIntent = when (type) {
+                NotificationType.MESSAGE -> getMessageRoomPendingIntent(remoteMessage)
+                NotificationType.BID -> getAuctionDetailPendingIntent(remoteMessage)
+            }
             val image =
                 runCatching {
                     getBitmapFromUrl(remoteMessage.data["image"] ?: "")
                 }.getOrDefault(defaultImage)
-            val requestCode = System.currentTimeMillis().toInt()
-            val roomId = remoteMessage.data["redirectUrl"]?.split("/")?.last()?.toLong() ?: -1
-            val intent = MessageRoomActivity.getIntent(applicationContext, roomId)
-            val pendingIntent =
-                PendingIntent.getActivity(
-                    applicationContext,
-                    requestCode,
-                    intent,
-                    FLAG_IMMUTABLE,
-                )
 
             NotificationCompat.Builder(applicationContext, CHANNEL_ID).apply {
                 setSmallIcon(R.drawable.img_logo)
@@ -98,5 +95,29 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
             val input = connection.getInputStream()
             BitmapFactory.decodeStream(input)
         }
+    }
+
+    private fun getMessageRoomPendingIntent(remoteMessage: RemoteMessage): PendingIntent? {
+        val requestCode = System.currentTimeMillis().toInt()
+        val roomId = remoteMessage.data["redirectUrl"]?.split("/")?.last()?.toLong() ?: -1
+        val intent = MessageRoomActivity.getIntent(applicationContext, roomId)
+        return PendingIntent.getActivity(
+            applicationContext,
+            requestCode,
+            intent,
+            FLAG_IMMUTABLE,
+        )
+    }
+
+    private fun getAuctionDetailPendingIntent(remoteMessage: RemoteMessage): PendingIntent? {
+        val requestCode = System.currentTimeMillis().toInt()
+        val auctionId = remoteMessage.data["redirectUrl"]?.split("/")?.last()?.toLong() ?: -1
+        val intent = AuctionDetailActivity.getIntent(applicationContext, auctionId)
+        return PendingIntent.getActivity(
+            applicationContext,
+            requestCode,
+            intent,
+            FLAG_IMMUTABLE,
+        )
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/notification/NotificationType.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/notification/NotificationType.kt
@@ -1,0 +1,11 @@
+package com.ddangddangddang.android.notification
+
+enum class NotificationType(private val value: String) {
+    MESSAGE("message"), BID("bid");
+
+    companion object {
+        fun of(value: String): NotificationType? {
+            return values().find { it.value == value }
+        }
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
알림 type에 따라 채팅방 또는 경매 상세 페이지 pending intent를 가진 알림을 생성하도록 하였습니다.

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
이전 채팅방 알림 수신 기능과 거의 동일합니다.
`NotificationType`이 없는 경우 예외를 발생시켜 디버깅이 쉽도록 하려고 하였으나 추후에 논리 오류에 대한 로깅 처리를 추가하기로 팀원들과 합의하여 현재는 `NotificationType`이 없는 경우 null을 반환하고 알림 기능이 동작하지 않도록 처리했습니다.

## 📎 Issue 번호
- close : #437 
