### PR TITLE
컨트롤러 슬라이스 테스트 설정 공통화

### DIFF
--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/presentation/AuctionControllerTest.java
@@ -26,7 +26,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.ddang.ddang.auction.application.AuctionService;
 import com.ddang.ddang.auction.application.dto.CreateAuctionDto;
 import com.ddang.ddang.auction.application.dto.CreateInfoAuctionDto;
 import com.ddang.ddang.auction.application.dto.ReadAuctionDto;
@@ -38,8 +37,6 @@ import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
 import com.ddang.ddang.auction.configuration.DescendingSortPageableArgumentResolver;
 import com.ddang.ddang.auction.presentation.dto.request.CreateAuctionRequest;
 import com.ddang.ddang.auction.presentation.dto.request.ReadAuctionSearchCondition;
-import com.ddang.ddang.authentication.application.AuthenticationUserService;
-import com.ddang.ddang.authentication.application.BlackListTokenService;
 import com.ddang.ddang.authentication.configuration.AuthenticationInterceptor;
 import com.ddang.ddang.authentication.configuration.AuthenticationPrincipalArgumentResolver;
 import com.ddang.ddang.authentication.domain.TokenDecoder;
@@ -47,81 +44,37 @@ import com.ddang.ddang.authentication.domain.TokenType;
 import com.ddang.ddang.authentication.domain.dto.AuthenticationStore;
 import com.ddang.ddang.authentication.infrastructure.jwt.PrivateClaims;
 import com.ddang.ddang.category.application.exception.CategoryNotFoundException;
-import com.ddang.ddang.chat.application.ChatRoomService;
-import com.ddang.ddang.configuration.RestDocsConfiguration;
+import com.ddang.ddang.configuration.CommonControllerSliceTest;
 import com.ddang.ddang.exception.GlobalExceptionHandler;
 import com.ddang.ddang.image.infrastructure.local.exception.EmptyImageException;
 import com.ddang.ddang.image.infrastructure.local.exception.StoreImageFailureException;
 import com.ddang.ddang.image.infrastructure.local.exception.UnsupportedImageFileExtensionException;
 import com.ddang.ddang.region.application.exception.RegionNotFoundException;
 import com.ddang.ddang.user.application.exception.UserNotFoundException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-@WebMvcTest(controllers = {AuctionController.class},
-        excludeFilters = {
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfigurer.class),
-                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.ddang\\.ddang\\.authentication\\.configuration\\..*")
-        }
-)
-@AutoConfigureRestDocs
-@Import(RestDocsConfiguration.class)
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-class AuctionControllerTest {
-
-    @MockBean
-    AuctionService auctionService;
-
-    @MockBean
-    ChatRoomService chatRoomService;
-
-    @MockBean
-    BlackListTokenService blackListTokenService;
-
-    @MockBean
-    AuthenticationUserService authenticationUserService;
-
-    @Autowired
-    AuctionController auctionController;
-
-    @Autowired
-    RestDocumentationResultHandler restDocs;
-
-    @Autowired
-    ObjectMapper objectMapper;
+class AuctionControllerTest extends CommonControllerSliceTest {
 
     TokenDecoder mockTokenDecoder;
 
     MockMvc mockMvc;
 
     @BeforeEach
-    void setUp(@Autowired RestDocumentationContextProvider provider) {
+    void setUp() {
         mockTokenDecoder = mock(TokenDecoder.class);
 
         final AuthenticationStore store = new AuthenticationStore();

--- a/backend/ddang/src/test/java/com/ddang/ddang/authentication/presentation/AuthenticationControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/authentication/presentation/AuthenticationControllerTest.java
@@ -1,44 +1,5 @@
 package com.ddang.ddang.authentication.presentation;
 
-import com.ddang.ddang.authentication.application.AuthenticationService;
-import com.ddang.ddang.authentication.application.AuthenticationUserService;
-import com.ddang.ddang.authentication.application.BlackListTokenService;
-import com.ddang.ddang.authentication.application.dto.TokenDto;
-import com.ddang.ddang.authentication.application.exception.InvalidWithdrawalException;
-import com.ddang.ddang.authentication.configuration.Oauth2TypeConverter;
-import com.ddang.ddang.authentication.domain.exception.InvalidTokenException;
-import com.ddang.ddang.authentication.domain.exception.UnsupportedSocialLoginException;
-import com.ddang.ddang.authentication.infrastructure.oauth2.Oauth2Type;
-import com.ddang.ddang.authentication.presentation.dto.request.LoginTokenRequest;
-import com.ddang.ddang.authentication.presentation.dto.request.LogoutRequest;
-import com.ddang.ddang.authentication.presentation.dto.request.RefreshTokenRequest;
-import com.ddang.ddang.authentication.presentation.dto.request.WithdrawalRequest;
-import com.ddang.ddang.configuration.RestDocsConfiguration;
-import com.ddang.ddang.exception.GlobalExceptionHandler;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.context.annotation.Import;
-import org.springframework.format.support.FormattingConversionService;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -58,40 +19,36 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = {AuthenticationController.class},
-        excludeFilters = {
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfigurer.class),
-                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.ddang\\.ddang\\.authentication\\.configuration\\..*")
-        }
-)
-@AutoConfigureRestDocs
-@Import(RestDocsConfiguration.class)
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+import com.ddang.ddang.authentication.application.dto.TokenDto;
+import com.ddang.ddang.authentication.application.exception.InvalidWithdrawalException;
+import com.ddang.ddang.authentication.configuration.Oauth2TypeConverter;
+import com.ddang.ddang.authentication.domain.exception.InvalidTokenException;
+import com.ddang.ddang.authentication.domain.exception.UnsupportedSocialLoginException;
+import com.ddang.ddang.authentication.infrastructure.oauth2.Oauth2Type;
+import com.ddang.ddang.authentication.presentation.dto.request.LoginTokenRequest;
+import com.ddang.ddang.authentication.presentation.dto.request.LogoutRequest;
+import com.ddang.ddang.authentication.presentation.dto.request.RefreshTokenRequest;
+import com.ddang.ddang.authentication.presentation.dto.request.WithdrawalRequest;
+import com.ddang.ddang.configuration.CommonControllerSliceTest;
+import com.ddang.ddang.exception.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.format.support.FormattingConversionService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
 @SuppressWarnings("NonAsciiCharacters")
-class AuthenticationControllerTest {
-
-    @MockBean
-    AuthenticationService authenticationService;
-
-    @MockBean
-    BlackListTokenService blackListTokenService;
-
-    @Autowired
-    AuthenticationController authenticationController;
-
-    @MockBean
-    AuthenticationUserService authenticationUserService;
-
-    @Autowired
-    RestDocumentationResultHandler restDocs;
-
-    @Autowired
-    ObjectMapper objectMapper;
+class AuthenticationControllerTest extends CommonControllerSliceTest {
 
     MockMvc mockMvc;
 
     @BeforeEach
-    void setUp(@Autowired RestDocumentationContextProvider provider) {
+    void setUp() {
         final FormattingConversionService formattingConversionService = new FormattingConversionService();
         formattingConversionService.addConverter(new Oauth2TypeConverter());
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/bid/presentation/BidControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/bid/presentation/BidControllerTest.java
@@ -1,52 +1,5 @@
 package com.ddang.ddang.bid.presentation;
 
-import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
-import com.ddang.ddang.authentication.application.AuthenticationUserService;
-import com.ddang.ddang.authentication.application.BlackListTokenService;
-import com.ddang.ddang.authentication.configuration.AuthenticationInterceptor;
-import com.ddang.ddang.authentication.configuration.AuthenticationPrincipalArgumentResolver;
-import com.ddang.ddang.authentication.domain.TokenDecoder;
-import com.ddang.ddang.authentication.domain.TokenType;
-import com.ddang.ddang.authentication.domain.dto.AuthenticationStore;
-import com.ddang.ddang.authentication.infrastructure.jwt.PrivateClaims;
-import com.ddang.ddang.bid.application.BidService;
-import com.ddang.ddang.bid.application.dto.CreateBidDto;
-import com.ddang.ddang.bid.application.dto.ReadBidDto;
-import com.ddang.ddang.bid.application.exception.InvalidAuctionToBidException;
-import com.ddang.ddang.bid.application.exception.InvalidBidPriceException;
-import com.ddang.ddang.bid.application.exception.InvalidBidderException;
-import com.ddang.ddang.bid.presentation.dto.request.CreateBidRequest;
-import com.ddang.ddang.configuration.RestDocsConfiguration;
-import com.ddang.ddang.exception.GlobalExceptionHandler;
-import com.ddang.ddang.user.application.exception.UserNotFoundException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.context.annotation.Import;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -66,42 +19,45 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = {BidController.class},
-        excludeFilters = {
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfigurer.class),
-                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.ddang\\.ddang\\.authentication\\.configuration\\..*")
-        }
-)
-@AutoConfigureRestDocs
-@Import(RestDocsConfiguration.class)
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
+import com.ddang.ddang.authentication.configuration.AuthenticationInterceptor;
+import com.ddang.ddang.authentication.configuration.AuthenticationPrincipalArgumentResolver;
+import com.ddang.ddang.authentication.domain.TokenDecoder;
+import com.ddang.ddang.authentication.domain.TokenType;
+import com.ddang.ddang.authentication.domain.dto.AuthenticationStore;
+import com.ddang.ddang.authentication.infrastructure.jwt.PrivateClaims;
+import com.ddang.ddang.bid.application.dto.CreateBidDto;
+import com.ddang.ddang.bid.application.dto.ReadBidDto;
+import com.ddang.ddang.bid.application.exception.InvalidAuctionToBidException;
+import com.ddang.ddang.bid.application.exception.InvalidBidPriceException;
+import com.ddang.ddang.bid.application.exception.InvalidBidderException;
+import com.ddang.ddang.bid.presentation.dto.request.CreateBidRequest;
+import com.ddang.ddang.configuration.CommonControllerSliceTest;
+import com.ddang.ddang.exception.GlobalExceptionHandler;
+import com.ddang.ddang.user.application.exception.UserNotFoundException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
 @SuppressWarnings("NonAsciiCharacters")
-class BidControllerTest {
-
-    @MockBean
-    BidService bidService;
-
-    @MockBean
-    BlackListTokenService blackListTokenService;
-
-    @MockBean
-    AuthenticationUserService authenticationUserService;
-
-    @Autowired
-    BidController bidController;
-
-    @Autowired
-    RestDocumentationResultHandler restDocs;
-
-    @Autowired
-    ObjectMapper objectMapper;
+class BidControllerTest extends CommonControllerSliceTest {
 
     TokenDecoder mockTokenDecoder;
 
     MockMvc mockMvc;
 
     @BeforeEach
-    void setUp(@Autowired RestDocumentationContextProvider provider) {
+    void setUp() {
         mockTokenDecoder = mock(TokenDecoder.class);
 
         final AuthenticationStore store = new AuthenticationStore();

--- a/backend/ddang/src/test/java/com/ddang/ddang/category/presentation/CategoryControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/category/presentation/CategoryControllerTest.java
@@ -9,58 +9,26 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.ddang.ddang.category.application.CategoryService;
 import com.ddang.ddang.category.application.dto.ReadCategoryDto;
 import com.ddang.ddang.category.application.exception.CategoryNotFoundException;
-import com.ddang.ddang.configuration.RestDocsConfiguration;
-import java.util.List;
-
+import com.ddang.ddang.configuration.CommonControllerSliceTest;
 import com.ddang.ddang.exception.GlobalExceptionHandler;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-@WebMvcTest(controllers = {CategoryController.class},
-        excludeFilters = {
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfigurer.class),
-                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.ddang\\.ddang\\.authentication\\.configuration\\..*")
-        }
-)
-@AutoConfigureRestDocs
-@Import(RestDocsConfiguration.class)
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-class CategoryControllerTest {
-
-    @MockBean
-    CategoryService categoryService;
-
-    @Autowired
-    CategoryController categoryController;
-
-    @Autowired
-    RestDocumentationResultHandler restDocs;
+class CategoryControllerTest extends CommonControllerSliceTest {
 
     MockMvc mockMvc;
 
     @BeforeEach
-    void setUp(@Autowired RestDocumentationContextProvider provider) {
+    void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(categoryController)
                                  .setControllerAdvice(new GlobalExceptionHandler())
                                  .apply(MockMvcRestDocumentation.documentationConfiguration(provider))

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/presentation/ChatRoomControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/presentation/ChatRoomControllerTest.java
@@ -1,64 +1,5 @@
 package com.ddang.ddang.chat.presentation;
 
-import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
-import com.ddang.ddang.auction.domain.exception.WinnerNotFoundException;
-import com.ddang.ddang.authentication.application.AuthenticationUserService;
-import com.ddang.ddang.authentication.application.BlackListTokenService;
-import com.ddang.ddang.authentication.configuration.AuthenticationInterceptor;
-import com.ddang.ddang.authentication.configuration.AuthenticationPrincipalArgumentResolver;
-import com.ddang.ddang.authentication.domain.TokenDecoder;
-import com.ddang.ddang.authentication.domain.TokenType;
-import com.ddang.ddang.authentication.domain.dto.AuthenticationStore;
-import com.ddang.ddang.authentication.infrastructure.jwt.PrivateClaims;
-import com.ddang.ddang.chat.application.ChatRoomService;
-import com.ddang.ddang.chat.application.MessageService;
-import com.ddang.ddang.chat.application.dto.CreateChatRoomDto;
-import com.ddang.ddang.chat.application.dto.CreateMessageDto;
-import com.ddang.ddang.chat.application.dto.ReadAuctionInChatRoomDto;
-import com.ddang.ddang.chat.application.dto.ReadChatRoomWithLastMessageDto;
-import com.ddang.ddang.chat.application.dto.ReadLastMessageDto;
-import com.ddang.ddang.chat.application.dto.ReadMessageDto;
-import com.ddang.ddang.chat.application.dto.ReadParticipatingChatRoomDto;
-import com.ddang.ddang.chat.application.dto.ReadUserInChatRoomDto;
-import com.ddang.ddang.chat.application.exception.ChatRoomNotFoundException;
-import com.ddang.ddang.chat.application.exception.InvalidAuctionToChatException;
-import com.ddang.ddang.chat.application.exception.InvalidUserToChat;
-import com.ddang.ddang.chat.application.exception.MessageNotFoundException;
-import com.ddang.ddang.chat.presentation.dto.request.CreateChatRoomRequest;
-import com.ddang.ddang.chat.presentation.dto.request.CreateMessageRequest;
-import com.ddang.ddang.chat.presentation.dto.request.ReadMessageRequest;
-import com.ddang.ddang.chat.presentation.dto.response.ReadMessageResponse;
-import com.ddang.ddang.configuration.RestDocsConfiguration;
-import com.ddang.ddang.exception.GlobalExceptionHandler;
-import com.ddang.ddang.user.application.exception.UserNotFoundException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.context.annotation.Import;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -82,45 +23,56 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = {ChatRoomController.class},
-        excludeFilters = {
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfigurer.class),
-                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.ddang\\.ddang\\.authentication\\.configuration\\..*")
-        }
-)
-@AutoConfigureRestDocs
-@Import(RestDocsConfiguration.class)
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
+import com.ddang.ddang.auction.domain.exception.WinnerNotFoundException;
+import com.ddang.ddang.authentication.configuration.AuthenticationInterceptor;
+import com.ddang.ddang.authentication.configuration.AuthenticationPrincipalArgumentResolver;
+import com.ddang.ddang.authentication.domain.TokenDecoder;
+import com.ddang.ddang.authentication.domain.TokenType;
+import com.ddang.ddang.authentication.domain.dto.AuthenticationStore;
+import com.ddang.ddang.authentication.infrastructure.jwt.PrivateClaims;
+import com.ddang.ddang.chat.application.dto.CreateChatRoomDto;
+import com.ddang.ddang.chat.application.dto.CreateMessageDto;
+import com.ddang.ddang.chat.application.dto.ReadAuctionInChatRoomDto;
+import com.ddang.ddang.chat.application.dto.ReadChatRoomWithLastMessageDto;
+import com.ddang.ddang.chat.application.dto.ReadLastMessageDto;
+import com.ddang.ddang.chat.application.dto.ReadMessageDto;
+import com.ddang.ddang.chat.application.dto.ReadParticipatingChatRoomDto;
+import com.ddang.ddang.chat.application.dto.ReadUserInChatRoomDto;
+import com.ddang.ddang.chat.application.exception.ChatRoomNotFoundException;
+import com.ddang.ddang.chat.application.exception.InvalidAuctionToChatException;
+import com.ddang.ddang.chat.application.exception.InvalidUserToChat;
+import com.ddang.ddang.chat.application.exception.MessageNotFoundException;
+import com.ddang.ddang.chat.presentation.dto.request.CreateChatRoomRequest;
+import com.ddang.ddang.chat.presentation.dto.request.CreateMessageRequest;
+import com.ddang.ddang.chat.presentation.dto.request.ReadMessageRequest;
+import com.ddang.ddang.chat.presentation.dto.response.ReadMessageResponse;
+import com.ddang.ddang.configuration.CommonControllerSliceTest;
+import com.ddang.ddang.exception.GlobalExceptionHandler;
+import com.ddang.ddang.user.application.exception.UserNotFoundException;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
 @SuppressWarnings("NonAsciiCharacters")
-class ChatRoomControllerTest {
-
-    @MockBean
-    BlackListTokenService blackListTokenService;
-
-    @MockBean
-    ChatRoomService chatRoomService;
-
-    @MockBean
-    MessageService messageService;
-
-    @MockBean
-    AuthenticationUserService authenticationUserService;
-
-    @Autowired
-    ChatRoomController chatRoomController;
-
-    @Autowired
-    ObjectMapper objectMapper;
-
-    @Autowired
-    RestDocumentationResultHandler restDocs;
+class ChatRoomControllerTest extends CommonControllerSliceTest {
 
     TokenDecoder mockTokenDecoder;
 
     MockMvc mockMvc;
 
     @BeforeEach
-    void setUp(@Autowired RestDocumentationContextProvider provider) {
+    void setUp() {
         mockTokenDecoder = mock(TokenDecoder.class);
 
         final AuthenticationStore store = new AuthenticationStore();

--- a/backend/ddang/src/test/java/com/ddang/ddang/configuration/CommonControllerSliceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/configuration/CommonControllerSliceTest.java
@@ -1,0 +1,149 @@
+package com.ddang.ddang.configuration;
+
+import com.ddang.ddang.auction.application.AuctionService;
+import com.ddang.ddang.auction.presentation.AuctionController;
+import com.ddang.ddang.authentication.application.AuthenticationService;
+import com.ddang.ddang.authentication.application.AuthenticationUserService;
+import com.ddang.ddang.authentication.application.BlackListTokenService;
+import com.ddang.ddang.authentication.presentation.AuthenticationController;
+import com.ddang.ddang.bid.application.BidService;
+import com.ddang.ddang.bid.presentation.BidController;
+import com.ddang.ddang.category.application.CategoryService;
+import com.ddang.ddang.category.presentation.CategoryController;
+import com.ddang.ddang.chat.application.ChatRoomService;
+import com.ddang.ddang.chat.application.MessageService;
+import com.ddang.ddang.chat.presentation.ChatRoomController;
+import com.ddang.ddang.device.application.DeviceTokenService;
+import com.ddang.ddang.device.presentation.DeviceTokenController;
+import com.ddang.ddang.image.application.ImageService;
+import com.ddang.ddang.image.presentation.ImageController;
+import com.ddang.ddang.region.application.RegionService;
+import com.ddang.ddang.region.presentation.RegionController;
+import com.ddang.ddang.report.application.AuctionReportService;
+import com.ddang.ddang.report.application.ChatRoomReportService;
+import com.ddang.ddang.report.presentation.ReportController;
+import com.ddang.ddang.user.application.UserService;
+import com.ddang.ddang.user.presentation.UserAuctionController;
+import com.ddang.ddang.user.presentation.UserController;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@WebMvcTest(
+        controllers = {
+                AuctionController.class,
+                AuthenticationController.class,
+                BidController.class,
+                CategoryController.class,
+                ChatRoomController.class,
+                DeviceTokenController.class,
+                ImageController.class,
+                RegionController.class,
+                ReportController.class,
+                UserAuctionController.class,
+                UserController.class
+        },
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfigurer.class),
+                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.ddang\\.ddang\\.authentication\\.configuration\\..*")
+        }
+)
+@AutoConfigureRestDocs
+@Import(RestDocsConfiguration.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public abstract class CommonControllerSliceTest {
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected RestDocumentationResultHandler restDocs;
+
+    @Autowired
+    protected RestDocumentationContextProvider provider;
+
+    @Autowired
+    protected AuctionController auctionController;
+
+    @Autowired
+    protected AuthenticationController authenticationController;
+
+    @Autowired
+    protected CategoryController categoryController;
+
+    @Autowired
+    protected BidController bidController;
+
+    @Autowired
+    protected ChatRoomController chatRoomController;
+
+    @Autowired
+    protected DeviceTokenController deviceTokenController;
+
+    @Autowired
+    protected ImageController imageController;
+
+    @Autowired
+    protected RegionController regionController;
+
+    @Autowired
+    protected ReportController reportController;
+
+    @Autowired
+    protected UserAuctionController userAuctionController;
+
+    @Autowired
+    protected UserController userController;
+
+    @MockBean
+    protected AuctionService auctionService;
+
+    @MockBean
+    protected ChatRoomService chatRoomService;
+
+    @MockBean
+    protected BlackListTokenService blackListTokenService;
+
+    @MockBean
+    protected AuthenticationUserService authenticationUserService;
+
+    @MockBean
+    protected AuthenticationService authenticationService;
+
+    @MockBean
+    protected BidService bidService;
+
+    @MockBean
+    protected CategoryService categoryService;
+
+    @MockBean
+    protected MessageService messageService;
+
+    @MockBean
+    protected DeviceTokenService deviceTokenService;
+
+    @MockBean
+    protected ImageService imageService;
+
+    @MockBean
+    protected RegionService regionService;
+
+    @MockBean
+    protected AuctionReportService auctionReportService;
+
+    @MockBean
+    protected ChatRoomReportService chatRoomReportService;
+
+    @MockBean
+    protected UserService userService;
+}

--- a/backend/ddang/src/test/java/com/ddang/ddang/device/presentation/DeviceTokenControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/device/presentation/DeviceTokenControllerTest.java
@@ -1,43 +1,5 @@
 package com.ddang.ddang.device.presentation;
 
-import com.ddang.ddang.auction.configuration.DescendingSortPageableArgumentResolver;
-import com.ddang.ddang.authentication.application.AuthenticationUserService;
-import com.ddang.ddang.authentication.application.BlackListTokenService;
-import com.ddang.ddang.authentication.configuration.AuthenticationInterceptor;
-import com.ddang.ddang.authentication.configuration.AuthenticationPrincipalArgumentResolver;
-import com.ddang.ddang.authentication.domain.TokenDecoder;
-import com.ddang.ddang.authentication.domain.TokenType;
-import com.ddang.ddang.authentication.domain.dto.AuthenticationStore;
-import com.ddang.ddang.authentication.infrastructure.jwt.PrivateClaims;
-import com.ddang.ddang.configuration.RestDocsConfiguration;
-import com.ddang.ddang.device.application.DeviceTokenService;
-import com.ddang.ddang.device.application.dto.PersistDeviceTokenDto;
-import com.ddang.ddang.device.presentation.dto.request.UpdateDeviceTokenRequest;
-import com.ddang.ddang.exception.GlobalExceptionHandler;
-import com.ddang.ddang.user.application.exception.UserNotFoundException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.context.annotation.Import;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import java.util.Optional;
-
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -56,42 +18,36 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = {DeviceTokenController.class},
-        excludeFilters = {
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfigurer.class),
-                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.ddang\\.ddang\\.authentication\\.configuration\\..*")
-        }
-)
-@AutoConfigureRestDocs
-@Import(RestDocsConfiguration.class)
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+import com.ddang.ddang.auction.configuration.DescendingSortPageableArgumentResolver;
+import com.ddang.ddang.authentication.configuration.AuthenticationInterceptor;
+import com.ddang.ddang.authentication.configuration.AuthenticationPrincipalArgumentResolver;
+import com.ddang.ddang.authentication.domain.TokenDecoder;
+import com.ddang.ddang.authentication.domain.TokenType;
+import com.ddang.ddang.authentication.domain.dto.AuthenticationStore;
+import com.ddang.ddang.authentication.infrastructure.jwt.PrivateClaims;
+import com.ddang.ddang.configuration.CommonControllerSliceTest;
+import com.ddang.ddang.device.application.dto.PersistDeviceTokenDto;
+import com.ddang.ddang.device.presentation.dto.request.UpdateDeviceTokenRequest;
+import com.ddang.ddang.exception.GlobalExceptionHandler;
+import com.ddang.ddang.user.application.exception.UserNotFoundException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
 @SuppressWarnings("NonAsciiCharacters")
-class DeviceTokenControllerTest {
-
-    @MockBean
-    DeviceTokenService deviceTokenService;
-
-    @MockBean
-    BlackListTokenService blackListTokenService;
-
-    @MockBean
-    AuthenticationUserService authenticationUserService;
-
-    @Autowired
-    DeviceTokenController deviceTokenController;
-
-    @Autowired
-    RestDocumentationResultHandler restDocs;
-
-    @Autowired
-    ObjectMapper objectMapper;
+class DeviceTokenControllerTest extends CommonControllerSliceTest {
 
     TokenDecoder mockTokenDecoder;
 
     MockMvc mockMvc;
 
     @BeforeEach
-    void setUp(@Autowired RestDocumentationContextProvider provider) {
+    void setUp() {
         mockTokenDecoder = mock(TokenDecoder.class);
 
         final AuthenticationStore store = new AuthenticationStore();

--- a/backend/ddang/src/test/java/com/ddang/ddang/image/presentation/ProfileImageControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/image/presentation/ProfileImageControllerTest.java
@@ -7,42 +7,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.ddang.ddang.configuration.CommonControllerSliceTest;
 import com.ddang.ddang.exception.GlobalExceptionHandler;
-import com.ddang.ddang.image.application.ImageService;
 import com.ddang.ddang.image.application.exception.ImageNotFoundException;
 import java.net.MalformedURLException;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-@WebMvcTest(controllers = {ImageController.class},
-        excludeFilters = {
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfigurer.class),
-                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.ddang\\.ddang\\.authentication\\.configuration\\..*")
-        }
-)
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-class ProfileImageControllerTest {
-
-    @MockBean
-    ImageService imageService;
-
-    @Autowired
-    ImageController imageController;
+class ProfileImageControllerTest extends CommonControllerSliceTest {
 
     MockMvc mockMvc;
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/region/presentation/RegionControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/region/presentation/RegionControllerTest.java
@@ -11,58 +11,27 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.ddang.ddang.configuration.RestDocsConfiguration;
+import com.ddang.ddang.configuration.CommonControllerSliceTest;
 import com.ddang.ddang.exception.GlobalExceptionHandler;
-import com.ddang.ddang.region.application.RegionService;
 import com.ddang.ddang.region.application.dto.ReadRegionDto;
 import com.ddang.ddang.region.application.exception.RegionNotFoundException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-@WebMvcTest(controllers = {RegionController.class},
-        excludeFilters = {
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfigurer.class),
-                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.ddang\\.ddang\\.authentication\\.configuration\\..*")
-        }
-)
-@AutoConfigureRestDocs
-@Import(RestDocsConfiguration.class)
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-class RegionControllerTest {
-
-    @MockBean
-    RegionService regionService;
-
-    @Autowired
-    RegionController regionController;
-
-    @Autowired
-    RestDocumentationResultHandler restDocs;
+class RegionControllerTest extends CommonControllerSliceTest {
 
     MockMvc mockMvc;
 
     @BeforeEach
-    void setUp(@Autowired RestDocumentationContextProvider provider) {
+    void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(regionController)
                                  .setControllerAdvice(new GlobalExceptionHandler())
                                  .apply(MockMvcRestDocumentation.documentationConfiguration(provider))

--- a/backend/ddang/src/test/java/com/ddang/ddang/report/presentation/ReportControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/report/presentation/ReportControllerTest.java
@@ -1,63 +1,5 @@
 package com.ddang.ddang.report.presentation;
 
-import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
-import com.ddang.ddang.authentication.application.AuthenticationUserService;
-import com.ddang.ddang.authentication.application.BlackListTokenService;
-import com.ddang.ddang.authentication.configuration.AuthenticationInterceptor;
-import com.ddang.ddang.authentication.configuration.AuthenticationPrincipalArgumentResolver;
-import com.ddang.ddang.authentication.domain.TokenDecoder;
-import com.ddang.ddang.authentication.domain.TokenType;
-import com.ddang.ddang.authentication.domain.dto.AuthenticationStore;
-import com.ddang.ddang.authentication.infrastructure.jwt.PrivateClaims;
-import com.ddang.ddang.chat.application.exception.ChatRoomNotFoundException;
-import com.ddang.ddang.configuration.RestDocsConfiguration;
-import com.ddang.ddang.exception.GlobalExceptionHandler;
-import com.ddang.ddang.report.application.AuctionReportService;
-import com.ddang.ddang.report.application.ChatRoomReportService;
-import com.ddang.ddang.report.application.dto.CreateAuctionReportDto;
-import com.ddang.ddang.report.application.dto.CreateChatRoomReportDto;
-import com.ddang.ddang.report.application.dto.ReadAuctionInReportDto;
-import com.ddang.ddang.report.application.dto.ReadAuctionReportDto;
-import com.ddang.ddang.report.application.dto.ReadChatRoomInReportDto;
-import com.ddang.ddang.report.application.dto.ReadChatRoomReportDto;
-import com.ddang.ddang.report.application.dto.ReadReporterDto;
-import com.ddang.ddang.report.application.dto.ReadUserInReportDto;
-import com.ddang.ddang.report.application.exception.AlreadyReportAuctionException;
-import com.ddang.ddang.report.application.exception.AlreadyReportChatRoomException;
-import com.ddang.ddang.report.application.exception.InvalidChatRoomReportException;
-import com.ddang.ddang.report.application.exception.InvalidReportAuctionException;
-import com.ddang.ddang.report.application.exception.InvalidReporterToAuctionException;
-import com.ddang.ddang.report.presentation.dto.request.CreateAuctionReportRequest;
-import com.ddang.ddang.report.presentation.dto.request.CreateChatRoomReportRequest;
-import com.ddang.ddang.user.application.exception.UserNotFoundException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.context.annotation.Import;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -76,45 +18,55 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = {ReportController.class},
-        excludeFilters = {
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfigurer.class),
-                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.ddang\\.ddang\\.authentication\\.configuration\\..*")
-        }
-)
-@AutoConfigureRestDocs
-@Import(RestDocsConfiguration.class)
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+import com.ddang.ddang.auction.application.exception.AuctionNotFoundException;
+import com.ddang.ddang.authentication.configuration.AuthenticationInterceptor;
+import com.ddang.ddang.authentication.configuration.AuthenticationPrincipalArgumentResolver;
+import com.ddang.ddang.authentication.domain.TokenDecoder;
+import com.ddang.ddang.authentication.domain.TokenType;
+import com.ddang.ddang.authentication.domain.dto.AuthenticationStore;
+import com.ddang.ddang.authentication.infrastructure.jwt.PrivateClaims;
+import com.ddang.ddang.chat.application.exception.ChatRoomNotFoundException;
+import com.ddang.ddang.configuration.CommonControllerSliceTest;
+import com.ddang.ddang.exception.GlobalExceptionHandler;
+import com.ddang.ddang.report.application.dto.CreateAuctionReportDto;
+import com.ddang.ddang.report.application.dto.CreateChatRoomReportDto;
+import com.ddang.ddang.report.application.dto.ReadAuctionInReportDto;
+import com.ddang.ddang.report.application.dto.ReadAuctionReportDto;
+import com.ddang.ddang.report.application.dto.ReadChatRoomInReportDto;
+import com.ddang.ddang.report.application.dto.ReadChatRoomReportDto;
+import com.ddang.ddang.report.application.dto.ReadReporterDto;
+import com.ddang.ddang.report.application.dto.ReadUserInReportDto;
+import com.ddang.ddang.report.application.exception.AlreadyReportAuctionException;
+import com.ddang.ddang.report.application.exception.AlreadyReportChatRoomException;
+import com.ddang.ddang.report.application.exception.InvalidChatRoomReportException;
+import com.ddang.ddang.report.application.exception.InvalidReportAuctionException;
+import com.ddang.ddang.report.application.exception.InvalidReporterToAuctionException;
+import com.ddang.ddang.report.presentation.dto.request.CreateAuctionReportRequest;
+import com.ddang.ddang.report.presentation.dto.request.CreateChatRoomReportRequest;
+import com.ddang.ddang.user.application.exception.UserNotFoundException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
 @SuppressWarnings("NonAsciiCharacters")
-class ReportControllerTest {
-
-    @MockBean
-    AuctionReportService auctionReportService;
-
-    @MockBean
-    ChatRoomReportService chatRoomReportService;
-
-    @MockBean
-    BlackListTokenService blackListTokenService;
-
-    @MockBean
-    AuthenticationUserService authenticationUserService;
-
-    @Autowired
-    ReportController reportController;
-
-    @Autowired
-    RestDocumentationResultHandler restDocs;
-
-    @Autowired
-    ObjectMapper objectMapper;
+class ReportControllerTest extends CommonControllerSliceTest {
 
     TokenDecoder mockTokenDecoder;
 
     MockMvc mockMvc;
 
     @BeforeEach
-    void setUp(@Autowired RestDocumentationContextProvider provider) {
+    void setUp() {
         mockTokenDecoder = mock(TokenDecoder.class);
 
         final AuthenticationStore store = new AuthenticationStore();

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/presentation/UserAuctionControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/presentation/UserAuctionControllerTest.java
@@ -18,84 +18,41 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.ddang.ddang.auction.application.AuctionService;
 import com.ddang.ddang.auction.application.dto.ReadAuctionDto;
 import com.ddang.ddang.auction.application.dto.ReadAuctionsDto;
 import com.ddang.ddang.auction.application.dto.ReadRegionDto;
 import com.ddang.ddang.auction.application.dto.ReadRegionsDto;
 import com.ddang.ddang.auction.configuration.DescendingSortPageableArgumentResolver;
-import com.ddang.ddang.authentication.application.AuthenticationUserService;
-import com.ddang.ddang.authentication.application.BlackListTokenService;
 import com.ddang.ddang.authentication.configuration.AuthenticationInterceptor;
 import com.ddang.ddang.authentication.configuration.AuthenticationPrincipalArgumentResolver;
 import com.ddang.ddang.authentication.domain.TokenDecoder;
 import com.ddang.ddang.authentication.domain.TokenType;
 import com.ddang.ddang.authentication.domain.dto.AuthenticationStore;
 import com.ddang.ddang.authentication.infrastructure.jwt.PrivateClaims;
-import com.ddang.ddang.configuration.RestDocsConfiguration;
+import com.ddang.ddang.configuration.CommonControllerSliceTest;
 import com.ddang.ddang.exception.GlobalExceptionHandler;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-@WebMvcTest(controllers = {UserAuctionController.class},
-        excludeFilters = {
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfigurer.class),
-                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.ddang\\.ddang\\.authentication\\.configuration\\..*")
-        }
-)
-@AutoConfigureRestDocs
-@Import(RestDocsConfiguration.class)
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-class UserAuctionControllerTest {
-
-    @MockBean
-    AuctionService auctionService;
-
-    @MockBean
-    BlackListTokenService blackListTokenService;
-
-    @MockBean
-    AuthenticationUserService authenticationUserService;
-
-    @Autowired
-    UserAuctionController userAuctionController;
-
-    @Autowired
-    RestDocumentationResultHandler restDocs;
-
-    @Autowired
-    ObjectMapper objectMapper;
+class UserAuctionControllerTest extends CommonControllerSliceTest {
 
     TokenDecoder mockTokenDecoder;
 
     MockMvc mockMvc;
 
     @BeforeEach
-    void setUp(@Autowired RestDocumentationContextProvider provider) {
+    void setUp() {
         mockTokenDecoder = mock(TokenDecoder.class);
 
         final AuthenticationStore store = new AuthenticationStore();

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/presentation/UserControllerTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/presentation/UserControllerTest.java
@@ -1,45 +1,5 @@
 package com.ddang.ddang.user.presentation;
 
-import com.ddang.ddang.authentication.application.AuthenticationUserService;
-import com.ddang.ddang.authentication.application.BlackListTokenService;
-import com.ddang.ddang.authentication.configuration.AuthenticationInterceptor;
-import com.ddang.ddang.authentication.configuration.AuthenticationPrincipalArgumentResolver;
-import com.ddang.ddang.authentication.domain.TokenDecoder;
-import com.ddang.ddang.authentication.domain.TokenType;
-import com.ddang.ddang.authentication.domain.dto.AuthenticationStore;
-import com.ddang.ddang.authentication.infrastructure.jwt.PrivateClaims;
-import com.ddang.ddang.configuration.RestDocsConfiguration;
-import com.ddang.ddang.exception.GlobalExceptionHandler;
-import com.ddang.ddang.user.application.UserService;
-import com.ddang.ddang.user.application.dto.ReadUserDto;
-import com.ddang.ddang.user.application.exception.UserNotFoundException;
-import com.ddang.ddang.user.presentation.dto.request.UpdateUserRequest;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.context.annotation.Import;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import java.util.Optional;
-
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -59,42 +19,38 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = {UserController.class},
-        excludeFilters = {
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfigurer.class),
-                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.ddang\\.ddang\\.authentication\\.configuration\\..*")
-        }
-)
-@AutoConfigureRestDocs
-@Import(RestDocsConfiguration.class)
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+import com.ddang.ddang.authentication.configuration.AuthenticationInterceptor;
+import com.ddang.ddang.authentication.configuration.AuthenticationPrincipalArgumentResolver;
+import com.ddang.ddang.authentication.domain.TokenDecoder;
+import com.ddang.ddang.authentication.domain.TokenType;
+import com.ddang.ddang.authentication.domain.dto.AuthenticationStore;
+import com.ddang.ddang.authentication.infrastructure.jwt.PrivateClaims;
+import com.ddang.ddang.configuration.CommonControllerSliceTest;
+import com.ddang.ddang.exception.GlobalExceptionHandler;
+import com.ddang.ddang.user.application.dto.ReadUserDto;
+import com.ddang.ddang.user.application.exception.UserNotFoundException;
+import com.ddang.ddang.user.presentation.dto.request.UpdateUserRequest;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
 @SuppressWarnings("NonAsciiCharacters")
-class UserControllerTest {
-
-    @MockBean
-    UserService userService;
-
-    @MockBean
-    BlackListTokenService blackListTokenService;
-
-    @MockBean
-    AuthenticationUserService authenticationUserService;
-
-    @Autowired
-    UserController userController;
-
-    @Autowired
-    RestDocumentationResultHandler restDocs;
-
-    @Autowired
-    ObjectMapper objectMapper;
+class UserControllerTest extends CommonControllerSliceTest {
 
     TokenDecoder mockTokenDecoder;
 
     MockMvc mockMvc;
 
     @BeforeEach
-    void setUp(@Autowired RestDocumentationContextProvider provider) {
+    void setUp() {
         mockTokenDecoder = mock(TokenDecoder.class);
 
         final AuthenticationStore store = new AuthenticationStore();


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->
- 컨트롤러 슬라이스 테스트 설정 공통화
  - 각 컨트롤러 슬라이스 테스트마다 별도의 ApplicationContext를 사용하던 것을 하나의 ApplicationContext를 재활용하도록 변경했습니다
  - 로컬에서 확인했을 때에는 이전 21초 걸리던 테스트가 지금은 17초로 감소했습니다 
  - 깃허브 액션에서 캐싱되지 않은 작업 처리할 때 jacoco 테스트 과정이 2분 44초에서 2분 21초에서 감소했습니다 
## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
- CommonControllerSliceTest
  - 설정 다 몰아넣은게 끝이기는 합니다 
## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
- closed #239 
<!-- closed #번호 --> 
