### PR TITLE
경매 상세 페이지 이미지 모아보기 기능 작성

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,9 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
+            android:name=".feature.imageDetail.ImageDetailActivity"
+            android:exported="false" />
+        <activity
             android:name=".feature.participateAuction.ParticipateAuctionActivity"
             android:exported="false" />
         <activity

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
@@ -9,6 +9,7 @@ import androidx.viewpager2.widget.MarginPageTransformer
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.ActivityAuctionDetailBinding
 import com.ddangddangddang.android.feature.detail.bid.AuctionBidDialog
+import com.ddangddangddang.android.feature.imageDetail.ImageDetailActivity
 import com.ddangddangddang.android.feature.messageRoom.MessageRoomActivity
 import com.ddangddangddang.android.feature.report.ReportActivity
 import com.ddangddangddang.android.model.RegionModel
@@ -104,7 +105,11 @@ class AuctionDetailActivity :
             clipToPadding = false
             clipChildren = false
             offscreenPageLimit = 1
-            adapter = AuctionImageAdapter(images)
+            adapter = AuctionImageAdapter(images) {
+                viewModel.auctionDetailModel.value?.images?.let {
+                    startActivity(ImageDetailActivity.getIntent(this@AuctionDetailActivity, it))
+                }
+            }
             setPageTransformer(MarginPageTransformer(convertDpToPx(20f)))
             setPadding(200, 0, 200, 0)
         }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
@@ -59,6 +59,10 @@ class AuctionDetailActivity :
             )
 
             is AuctionDetailViewModel.AuctionDetailEvent.ReportAuction -> navigateToReport(event.auctionId)
+            is AuctionDetailViewModel.AuctionDetailEvent.NavigateToImageDetail -> {
+                navigateToImageDetail(event.images, event.focusPosition)
+            }
+
             is AuctionDetailViewModel.AuctionDetailEvent.NotifyAuctionDoesNotExist -> notifyAuctionDoesNotExist()
             AuctionDetailViewModel.AuctionDetailEvent.DeleteAuction -> askDeletion()
             AuctionDetailViewModel.AuctionDetailEvent.NotifyAuctionDeletionComplete -> notifyDeleteComplete()
@@ -77,6 +81,12 @@ class AuctionDetailActivity :
 
     private fun navigateToReport(auctionId: Long) {
         startActivity(ReportActivity.getIntent(this, ReportType.ArticleReport.ordinal, auctionId))
+    }
+
+    private fun navigateToImageDetail(images: List<String>, focusPosition: Int) {
+        startActivity(
+            ImageDetailActivity.getIntent(this@AuctionDetailActivity, images, focusPosition),
+        )
     }
 
     private fun notifyAuctionDoesNotExist() {
@@ -105,11 +115,7 @@ class AuctionDetailActivity :
             clipToPadding = false
             clipChildren = false
             offscreenPageLimit = 1
-            adapter = AuctionImageAdapter(images) {
-                viewModel.auctionDetailModel.value?.images?.let {
-                    startActivity(ImageDetailActivity.getIntent(this@AuctionDetailActivity, it))
-                }
-            }
+            adapter = AuctionImageAdapter(images) { viewModel.navigateToImageDetail(it) }
             setPageTransformer(MarginPageTransformer(convertDpToPx(20f)))
             setPadding(200, 0, 200, 0)
         }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailViewModel.kt
@@ -103,6 +103,13 @@ class AuctionDetailViewModel @Inject constructor(
         }
     }
 
+    fun navigateToImageDetail(image: String) {
+        val images = auctionDetailModel.value?.images ?: return
+        val focusPosition = images.indexOf(image)
+        if (focusPosition == -1) return
+        _event.value = AuctionDetailEvent.NavigateToImageDetail(images, focusPosition)
+    }
+
     fun setExitEvent() {
         _event.value = AuctionDetailEvent.Exit
     }
@@ -126,8 +133,7 @@ class AuctionDetailViewModel @Inject constructor(
             viewModelScope.launch {
                 when (auctionRepository.deleteAuction(it.id)) {
                     is ApiResponse.Success ->
-                        _event.value =
-                            AuctionDetailEvent.NotifyAuctionDeletionComplete
+                        _event.value = AuctionDetailEvent.NotifyAuctionDeletionComplete
 
                     is ApiResponse.Failure -> {}
                     is ApiResponse.NetworkError -> {}
@@ -143,6 +149,9 @@ class AuctionDetailViewModel @Inject constructor(
         object PopupAuctionBid : AuctionDetailEvent()
         data class EnterMessageRoom(val roomId: Long) : AuctionDetailEvent()
         data class ReportAuction(val auctionId: Long) : AuctionDetailEvent()
+        data class NavigateToImageDetail(val images: List<String>, val focusPosition: Int) :
+            AuctionDetailEvent()
+
         object DeleteAuction : AuctionDetailEvent()
         object NotifyAuctionDoesNotExist : AuctionDetailEvent()
         object NotifyAuctionDeletionComplete : AuctionDetailEvent()

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionImageAdapter.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionImageAdapter.kt
@@ -5,9 +5,10 @@ import androidx.recyclerview.widget.RecyclerView
 
 class AuctionImageAdapter(
     private var images: List<String>,
+    private val onImageClick: (image: String) -> Unit = {},
 ) : RecyclerView.Adapter<AuctionImageViewHolder>() {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AuctionImageViewHolder {
-        return AuctionImageViewHolder.create(parent)
+        return AuctionImageViewHolder.create(parent, onImageClick)
     }
 
     override fun onBindViewHolder(holder: AuctionImageViewHolder, position: Int) {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionImageViewHolder.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionImageViewHolder.kt
@@ -5,17 +5,26 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.ddangddangddang.android.databinding.ItemDetailAuctionBinding
 
-class AuctionImageViewHolder private constructor(private val binding: ItemDetailAuctionBinding) :
-    RecyclerView.ViewHolder(binding.root) {
+class AuctionImageViewHolder private constructor(
+    private val binding: ItemDetailAuctionBinding,
+    onClick: (image: String) -> Unit = {},
+) : RecyclerView.ViewHolder(binding.root) {
+    init {
+        binding.onItemClickListener = onClick
+    }
+
     fun bind(imageUrl: String) {
         binding.imageUrl = imageUrl
     }
 
     companion object {
-        fun create(parent: ViewGroup): AuctionImageViewHolder {
+        fun create(
+            parent: ViewGroup,
+            onClick: (image: String) -> Unit = {},
+        ): AuctionImageViewHolder {
             val layoutInflater = LayoutInflater.from(parent.context)
             val binding = ItemDetailAuctionBinding.inflate(layoutInflater, parent, false)
-            return AuctionImageViewHolder(binding)
+            return AuctionImageViewHolder(binding, onClick)
         }
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionImageViewHolder.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionImageViewHolder.kt
@@ -7,10 +7,10 @@ import com.ddangddangddang.android.databinding.ItemDetailAuctionBinding
 
 class AuctionImageViewHolder private constructor(
     private val binding: ItemDetailAuctionBinding,
-    onClick: (image: String) -> Unit = {},
+    onImageClick: (image: String) -> Unit = {},
 ) : RecyclerView.ViewHolder(binding.root) {
     init {
-        binding.onItemClickListener = onClick
+        binding.onImageClickListener = onImageClick
     }
 
     fun bind(imageUrl: String) {
@@ -20,11 +20,11 @@ class AuctionImageViewHolder private constructor(
     companion object {
         fun create(
             parent: ViewGroup,
-            onClick: (image: String) -> Unit = {},
+            onImageClick: (image: String) -> Unit = {},
         ): AuctionImageViewHolder {
             val layoutInflater = LayoutInflater.from(parent.context)
             val binding = ItemDetailAuctionBinding.inflate(layoutInflater, parent, false)
-            return AuctionImageViewHolder(binding, onClick)
+            return AuctionImageViewHolder(binding, onImageClick)
         }
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailActivity.kt
@@ -25,7 +25,14 @@ class ImageDetailActivity :
     private fun setupViewModel() {
         viewModel.images.observe(this) { setupImages(it) }
         viewModel.focusPosition.observe(this) {
-            binding.vpImageList.currentItem = it
+            binding.vpImageList.setCurrentItem(it, false)
+        }
+        viewModel.event.observe(this) { handleEvent(it) }
+    }
+
+    private fun handleEvent(event: ImageDetailViewModel.Event) {
+        when (event) {
+            ImageDetailViewModel.Event.Exit -> finish()
         }
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailActivity.kt
@@ -18,18 +18,25 @@ class ImageDetailActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.viewModel = viewModel
-        if (viewModel.images.value == null) viewModel.setImages(getImageUrls())
+        if (viewModel.images.value == null) viewModel.setImages(getImageUrls(), getImageFocus())
         setupViewModel()
     }
 
     private fun setupViewModel() {
         viewModel.images.observe(this) { setupImages(it) }
+        viewModel.focusPosition.observe(this) {
+            binding.vpImageList.currentItem = it
+        }
     }
 
     private fun getImageUrls(): List<String> {
         val images = intent.getStringArrayExtra(IMAGE_URL_KEY) ?: emptyArray()
         if (images.isEmpty()) notifyNotExistImages()
         return images.toList()
+    }
+
+    private fun getImageFocus(): Int {
+        return intent.getIntExtra(FOCUS_IMAGE_POSITION_KEY, 0)
     }
 
     private fun notifyNotExistImages() {
@@ -48,8 +55,10 @@ class ImageDetailActivity :
 
     companion object {
         private const val IMAGE_URL_KEY = "image_url_key"
-        fun getIntent(context: Context, images: List<String>): Intent {
+        private const val FOCUS_IMAGE_POSITION_KEY = "focus_image_position_key"
+        fun getIntent(context: Context, images: List<String>, focusPosition: Int): Intent {
             return Intent(context, ImageDetailActivity::class.java).apply {
+                putExtra(FOCUS_IMAGE_POSITION_KEY, focusPosition)
                 putExtra(IMAGE_URL_KEY, images.toTypedArray())
             }
         }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailActivity.kt
@@ -1,0 +1,40 @@
+package com.ddangddangddang.android.feature.imageDetail
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.viewModels
+import com.ddangddangddang.android.R
+import com.ddangddangddang.android.databinding.ActivityImageDetailBinding
+import com.ddangddangddang.android.util.binding.BindingActivity
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class ImageDetailActivity :
+    BindingActivity<ActivityImageDetailBinding>(R.layout.activity_image_detail) {
+    private val viewModel: ImageDetailViewModel by viewModels()
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding.viewModel = viewModel
+        if (viewModel.images.value == null) viewModel.setImages(getImageUrls())
+    }
+
+    private fun getImageUrls(): List<String> {
+        val images = intent.getStringArrayExtra(IMAGE_URL_KEY) ?: emptyArray()
+        if (images.isEmpty()) notifyNotExistImages()
+        return images.toList()
+    }
+
+    private fun notifyNotExistImages() {
+        finish()
+    }
+
+    companion object {
+        private const val IMAGE_URL_KEY = "image_url_key"
+        fun getIntent(context: Context, images: List<String>): Intent {
+            return Intent(context, ImageDetailActivity::class.java).apply {
+                putExtra(IMAGE_URL_KEY, images.toTypedArray())
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailActivity.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.ActivityImageDetailBinding
-import com.ddangddangddang.android.feature.detail.AuctionImageAdapter
 import com.ddangddangddang.android.util.binding.BindingActivity
 import com.ddangddangddang.android.util.view.Toaster
 import com.google.android.material.tabs.TabLayoutMediator
@@ -41,7 +40,7 @@ class ImageDetailActivity :
     private fun setupImages(images: List<String>) {
         binding.vpImageList.apply {
             offscreenPageLimit = 1
-            adapter = AuctionImageAdapter(images)
+            adapter = ImageDetailAdapter(images)
         }
 
         TabLayoutMediator(binding.tlIndicator, binding.vpImageList) { _, _ -> }.attach()

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailActivity.kt
@@ -6,7 +6,10 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.ActivityImageDetailBinding
+import com.ddangddangddang.android.feature.detail.AuctionImageAdapter
 import com.ddangddangddang.android.util.binding.BindingActivity
+import com.ddangddangddang.android.util.view.Toaster
+import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -17,6 +20,11 @@ class ImageDetailActivity :
         super.onCreate(savedInstanceState)
         binding.viewModel = viewModel
         if (viewModel.images.value == null) viewModel.setImages(getImageUrls())
+        setupViewModel()
+    }
+
+    private fun setupViewModel() {
+        viewModel.images.observe(this) { setupImages(it) }
     }
 
     private fun getImageUrls(): List<String> {
@@ -26,7 +34,17 @@ class ImageDetailActivity :
     }
 
     private fun notifyNotExistImages() {
+        Toaster.showShort(this, getString(R.string.image_detail_images_not_exist))
         finish()
+    }
+
+    private fun setupImages(images: List<String>) {
+        binding.vpImageList.apply {
+            offscreenPageLimit = 1
+            adapter = AuctionImageAdapter(images)
+        }
+
+        TabLayoutMediator(binding.tlIndicator, binding.vpImageList) { _, _ -> }.attach()
     }
 
     companion object {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailAdapter.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailAdapter.kt
@@ -1,0 +1,18 @@
+package com.ddangddangddang.android.feature.imageDetail
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+
+class ImageDetailAdapter(
+    private var images: List<String>,
+) : RecyclerView.Adapter<ImageDetailViewHolder>() {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ImageDetailViewHolder {
+        return ImageDetailViewHolder.create(parent)
+    }
+
+    override fun onBindViewHolder(holder: ImageDetailViewHolder, position: Int) {
+        holder.bind(images[position])
+    }
+
+    override fun getItemCount(): Int = images.size
+}

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailViewHolder.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailViewHolder.kt
@@ -1,0 +1,25 @@
+package com.ddangddangddang.android.feature.imageDetail
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.ddangddangddang.android.databinding.ItemDetailImageBinding
+
+class ImageDetailViewHolder private constructor(
+    private val binding: ItemDetailImageBinding,
+) : RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(imageUrl: String) {
+        binding.imageUrl = imageUrl
+    }
+
+    companion object {
+        fun create(
+            parent: ViewGroup,
+        ): ImageDetailViewHolder {
+            val layoutInflater = LayoutInflater.from(parent.context)
+            val binding = ItemDetailImageBinding.inflate(layoutInflater, parent, false)
+            return ImageDetailViewHolder(binding)
+        }
+    }
+}

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailViewModel.kt
@@ -9,6 +9,10 @@ import javax.inject.Inject
 
 @HiltViewModel
 class ImageDetailViewModel @Inject constructor() : ViewModel() {
+    private val _event: SingleLiveEvent<Event> = SingleLiveEvent()
+    val event: SingleLiveEvent<Event>
+        get() = _event
+
     private val _images: MutableLiveData<List<String>> = MutableLiveData()
     val images: LiveData<List<String>>
         get() = _images
@@ -23,5 +27,10 @@ class ImageDetailViewModel @Inject constructor() : ViewModel() {
     }
 
     fun setExitEvent() {
+        _event.value = Event.Exit
+    }
+
+    sealed class Event {
+        object Exit : Event()
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailViewModel.kt
@@ -15,4 +15,7 @@ class ImageDetailViewModel @Inject constructor() : ViewModel() {
     fun setImages(images: List<String>) {
         _images.value = images
     }
+
+    fun setExitEvent() {
+    }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.ddangddangddang.android.feature.imageDetail
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.ddangddangddang.android.util.livedata.SingleLiveEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -12,8 +13,13 @@ class ImageDetailViewModel @Inject constructor() : ViewModel() {
     val images: LiveData<List<String>>
         get() = _images
 
-    fun setImages(images: List<String>) {
+    private val _focusPosition: SingleLiveEvent<Int> = SingleLiveEvent()
+    val focusPosition: LiveData<Int>
+        get() = _focusPosition
+
+    fun setImages(images: List<String>, focusPosition: Int) {
         _images.value = images
+        _focusPosition.value = focusPosition
     }
 
     fun setExitEvent() {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/imageDetail/ImageDetailViewModel.kt
@@ -1,0 +1,18 @@
+package com.ddangddangddang.android.feature.imageDetail
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ImageDetailViewModel @Inject constructor() : ViewModel() {
+    private val _images: MutableLiveData<List<String>> = MutableLiveData()
+    val images: LiveData<List<String>>
+        get() = _images
+
+    fun setImages(images: List<String>) {
+        _images.value = images
+    }
+}

--- a/android/app/src/main/res/drawable/bg_detail_gray_normal_dot_to_white_selected_dot.xml
+++ b/android/app/src/main/res/drawable/bg_detail_gray_normal_dot_to_white_selected_dot.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:drawable="@drawable/ic_detail_dot_white_selected" android:state_selected="true" />
+
+    <item android:drawable="@drawable/ic_detail_dot_gray_normal" />
+
+</selector>

--- a/android/app/src/main/res/drawable/ic_detail_dot_gray_normal.xml
+++ b/android/app/src/main/res/drawable/ic_detail_dot_gray_normal.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:innerRadius="0dp"
+    android:shape="ring"
+    android:thickness="4dp"
+    android:useLevel="false">
+    <solid android:color="@color/black_400" />
+</shape>

--- a/android/app/src/main/res/drawable/ic_detail_dot_white_selected.xml
+++ b/android/app/src/main/res/drawable/ic_detail_dot_white_selected.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:innerRadius="0dp"
+    android:shape="ring"
+    android:thickness="4dp"
+    android:useLevel="false">
+    <solid android:color="@color/white" />
+</shape>

--- a/android/app/src/main/res/layout/activity_image_detail.xml
+++ b/android/app/src/main/res/layout/activity_image_detail.xml
@@ -40,14 +40,14 @@
             android:id="@+id/vp_image_list"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/tl_indicator"
             app:layout_constraintTop_toBottomOf="@id/tb_image_detail" />
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tl_indicator"
             style="@style/Widget.Design.TabLayout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="?attr/actionBarSize"
             app:layout_constraintBottom_toBottomOf="parent"
             app:tabBackground="@drawable/bg_detail_gray_normal_dot_to_white_selected_dot"
             app:tabGravity="center"

--- a/android/app/src/main/res/layout/activity_image_detail.xml
+++ b/android/app/src/main/res/layout/activity_image_detail.xml
@@ -32,7 +32,7 @@
                 android:contentDescription="@string/all_app_bar_close_description"
                 android:onClick="@{()->viewModel.setExitEvent()}"
                 android:src="@drawable/ic_close_24"
-                app:tint="@color/black_900" />
+                app:tint="@color/white"/>
 
         </androidx.appcompat.widget.Toolbar>
 

--- a/android/app/src/main/res/layout/activity_image_detail.xml
+++ b/android/app/src/main/res/layout/activity_image_detail.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
@@ -12,7 +13,45 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/black"
         tools:context=".feature.imageDetail.ImageDetailActivity">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/tb_image_detail"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:contentInsetLeft="0dp"
+            app:contentInsetStart="0dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginStart="@dimen/margin_side_layout"
+                android:contentDescription="@string/all_app_bar_close_description"
+                android:onClick="@{()->viewModel.setExitEvent()}"
+                android:src="@drawable/ic_close_24"
+                app:tint="@color/black_900" />
+
+        </androidx.appcompat.widget.Toolbar>
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/vp_image_list"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tb_image_detail" />
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tl_indicator"
+            style="@style/Widget.Design.TabLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:tabBackground="@drawable/bg_detail_gray_normal_dot_to_white_selected_dot"
+            app:tabGravity="center"
+            app:tabIndicatorHeight="0dp" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/android/app/src/main/res/layout/activity_image_detail.xml
+++ b/android/app/src/main/res/layout/activity_image_detail.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.ddangddangddang.android.feature.imageDetail.ImageDetailViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".feature.imageDetail.ImageDetailActivity">
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/android/app/src/main/res/layout/item_detail_auction.xml
+++ b/android/app/src/main/res/layout/item_detail_auction.xml
@@ -8,7 +8,7 @@
             type="String" />
 
         <variable
-            name="onItemClickListener"
+            name="onImageClickListener"
             type="kotlin.jvm.functions.Function1" />
     </data>
 
@@ -17,7 +17,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:contentDescription="@string/app_name"
-        android:onClick="@{()->onItemClickListener.invoke(imageUrl)}"
+        android:onClick="@{()->onImageClickListener.invoke(imageUrl)}"
         android:scaleType="centerCrop" />
 
 </layout>

--- a/android/app/src/main/res/layout/item_detail_image.xml
+++ b/android/app/src/main/res/layout/item_detail_image.xml
@@ -7,9 +7,6 @@
             name="imageUrl"
             type="String" />
 
-        <variable
-            name="onItemClickListener"
-            type="kotlin.jvm.functions.Function1" />
     </data>
 
     <ImageView
@@ -17,7 +14,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:contentDescription="@string/app_name"
-        android:onClick="@{()->onItemClickListener.invoke(imageUrl)}"
-        android:scaleType="centerCrop" />
+        android:scaleType="fitCenter" />
 
 </layout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="all_auction_success">낙찰 완료</string>
     <string name="all_auction_failure">경매 유찰</string>
     <string name="all_app_bar_back_key_description">뒤로가기 버튼</string>
+    <string name="all_app_bar_close_description">닫기 버튼</string>
     <string name="all_dialog_default_negative_button">취소</string>
     <string name="all_dialog_default_positive_button">확인</string>
     <string name="all_snackbar_default_action">확인</string>
@@ -181,4 +182,7 @@
     <string name="my_auction_list_title">나의 경매 목록</string>
     <string name="my_auction_list_not_exist">등록한 경매 상품이 아직 없습니다</string>
     <string name="my_auction_load_failed_title">내 경매 목록을 불러오는데 실패했습니다</string>
+
+    <!-- image_detail -->
+    <string name="image_detail_images_not_exist">이미지 목록이 존재하지 않습니다.</string>
 </resources>


### PR DESCRIPTION
## 📄 작업 내용 요약
경매 상세 페이지 이미지 모아보기 기능입니다.

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<img width="831" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/6a32ee50-8e0c-43f7-b84e-89425cdb5688">
viewModel.setImages 로 이미지 리스트와 처음 포커스 위치를 설정하고 있습니다.
포커스 위치는 한 번만 되어야 하기 때문에, SingleLiveEvent로 구현했습니다.

디자인은 임의로 해놓았는데, 색상 같은 부분 맘에 안드시면, 수정해놓겠습니다.

![image](https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/05c66e1f-73d3-4239-b582-01a22e3e1160)


![image](https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/719d9866-5009-443f-adfe-177161b11fe2)


## 📎 Issue 번호
- close: #444 
