### PR TITLE
탈퇴 시 다이얼로그 띄우기

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/mypage/MyPageFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/mypage/MyPageFragment.kt
@@ -24,6 +24,7 @@ import com.ddangddangddang.android.model.ProfileModel
 import com.ddangddangddang.android.util.binding.BindingFragment
 import com.ddangddangddang.android.util.view.Toaster
 import com.ddangddangddang.android.util.view.observeLoadingWithDialog
+import com.ddangddangddang.android.util.view.showDialog
 import com.ddangddangddang.android.util.view.showSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -94,6 +95,8 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
                 notifyRequestFailed(event.type, defaultMessage)
             }
 
+            MyPageViewModel.MyPageEvent.AskWithdrawal -> askWithdrawal()
+
             MyPageViewModel.MyPageEvent.WithdrawalSuccessfully -> {
                 notifyWithdrawalSuccessfully()
                 navigateToLogin()
@@ -145,6 +148,16 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
     private fun showPrivacyPolicy() {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(BuildConfig.PRIVACY_POLICY_URL))
         startActivity(intent)
+    }
+
+    private fun askWithdrawal() {
+        showDialog(
+            titleId = R.string.mypage_dialog_withdrawal_title,
+            messageId = R.string.mypage_dialog_withdrawal_message,
+            negativeStringId = R.string.all_dialog_default_negative_button,
+            positiveStringId = R.string.mypage_dialog_withdrawal_positive_button,
+            actionPositive = viewModel::withdrawal,
+        )
     }
 
     private fun notifyWithdrawalSuccessfully() {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/mypage/MyPageViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/mypage/MyPageViewModel.kt
@@ -103,6 +103,10 @@ class MyPageViewModel @Inject constructor(
         }
     }
 
+    fun askWithdrawal() {
+        _event.value = MyPageEvent.AskWithdrawal
+    }
+
     fun withdrawal() {
         viewModelScope.launch {
             when (val response = authRepository.withdrawal()) {
@@ -135,6 +139,7 @@ class MyPageViewModel @Inject constructor(
         object NavigateToPrivacyPolicy : MyPageEvent()
         object LogoutSuccessfully : MyPageEvent()
         data class LogoutFailed(val type: ErrorType) : MyPageEvent()
+        object AskWithdrawal : MyPageEvent()
         object WithdrawalSuccessfully : MyPageEvent()
         data class WithdrawalFailed(val type: ErrorType) : MyPageEvent()
     }

--- a/android/app/src/main/java/com/ddangddangddang/android/util/view/DialogFactory.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/util/view/DialogFactory.kt
@@ -10,7 +10,7 @@ fun Activity.showDialog(
     @StringRes
     titleId: Int? = null,
     @StringRes
-    messageId: Int,
+    messageId: Int? = null,
     @StringRes
     negativeStringId: Int? = null,
     @StringRes
@@ -21,7 +21,7 @@ fun Activity.showDialog(
 ) {
     AlertDialog.Builder(this).apply {
         titleId?.let { setTitle(getString(it)) }
-        setMessage(getString(messageId))
+        messageId?.let { setMessage(getString(messageId)) }
         negativeStringId?.let {
             setNegativeButton(negativeStringId) { _, _ ->
                 actionNegative()
@@ -36,24 +36,28 @@ fun Activity.showDialog(
 
 fun Fragment.showDialog(
     @StringRes
-    titleId: Int,
+    titleId: Int? = null,
     @StringRes
-    messageId: Int,
+    messageId: Int? = null,
     @StringRes
-    negativeStringId: Int,
+    negativeStringId: Int? = null,
     @StringRes
-    positiveStringId: Int,
+    positiveStringId: Int = R.string.all_dialog_default_positive_button,
     actionNegative: () -> Unit = {},
     actionPositive: () -> Unit = {},
+    isCancelable: Boolean = true,
 ) {
-    AlertDialog.Builder(requireContext())
-        .setTitle(getString(titleId))
-        .setMessage(getString(messageId))
-        .setNegativeButton(negativeStringId) { _, _ ->
-            actionNegative()
+    AlertDialog.Builder(requireContext()).apply {
+        titleId?.let { setTitle(getString(titleId)) }
+        messageId?.let { setMessage(getString(messageId)) }
+        negativeStringId?.let {
+            setNegativeButton(negativeStringId) { _, _ ->
+                actionNegative()
+            }
         }
-        .setPositiveButton(positiveStringId) { _, _ ->
+        setPositiveButton(positiveStringId) { _, _ ->
             actionPositive()
         }
-        .show()
+        setCancelable(isCancelable)
+    }.show()
 }

--- a/android/app/src/main/res/layout/fragment_my_page.xml
+++ b/android/app/src/main/res/layout/fragment_my_page.xml
@@ -150,7 +150,7 @@
                     android:textSize="14sp"
                     app:layout_constraintEnd_toEndOf="@id/gl_end"
                     app:layout_constraintTop_toBottomOf="@id/tv_logout_button"
-                    android:onClick="@{() -> viewModel.withdrawal()}" />
+                    android:onClick="@{() -> viewModel.askWithdrawal()}" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -139,6 +139,9 @@
     <string name="mypage_delete_account_button">탈퇴하기</string>
     <string name="mypage_toast_logout_successfully_message">성공적으로 로그아웃 되었습니다</string>
     <string name="mypage_snackbar_logout_failed_title">로그아웃에 실패했습니다</string>
+    <string name="mypage_dialog_withdrawal_title">정말 탈퇴하시겠습니까?</string>
+    <string name="mypage_dialog_withdrawal_message">탈퇴 시 유저 정보는 모두 삭제되며, 복구가 불가능합니다.</string>
+    <string name="mypage_dialog_withdrawal_positive_button">탈퇴</string>
     <string name="mypage_toast_withdrawal_successfully_message">성공적으로 탈퇴 되었습니다</string>
     <string name="mypage_snackbar_withdrawal_failed_title">탈퇴에 실패했습니다</string>
     <string name="mypage_snackbar_load_profile_failed_title">프로필 정보를 불러오는데 실패했습니다</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -140,7 +140,7 @@
     <string name="mypage_toast_logout_successfully_message">성공적으로 로그아웃 되었습니다</string>
     <string name="mypage_snackbar_logout_failed_title">로그아웃에 실패했습니다</string>
     <string name="mypage_dialog_withdrawal_title">정말 탈퇴하시겠습니까?</string>
-    <string name="mypage_dialog_withdrawal_message">탈퇴 시 유저 정보는 모두 삭제되며, 복구가 불가능합니다.</string>
+    <string name="mypage_dialog_withdrawal_message">탈퇴 시 개인정보는 모두 삭제되며, 복구가 불가능합니다.</string>
     <string name="mypage_dialog_withdrawal_positive_button">탈퇴</string>
     <string name="mypage_toast_withdrawal_successfully_message">성공적으로 탈퇴 되었습니다</string>
     <string name="mypage_snackbar_withdrawal_failed_title">탈퇴에 실패했습니다</string>


### PR DESCRIPTION
## 📄 작업 내용 요약
탈퇴 시 다이얼로그를 띄우고 탈퇴했을 때 유저 정보가 어떻게 되는지 (바로 삭제 or 몇 일동안은 보류) 유저에게 알려주도록 했습니다! 

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
화면구성에 대응하지는 않았습니다!
탈퇴 다이얼로그의 경우, 화면구성이 변경되었을 때 유지되어야 할 만큼 중요하지 않다고 생각했어요!
(사실 화면구성 변경되어서 다이얼로그 사라지고 유저가 탈퇴할 마음도 함께 사라진다면 오히려 좋을지도...? 라는 못된 생각도 했습니다 😆)

## 📎 Issue 번호
- close: #517 
