### PR TITLE
홈 화면에서 홈 버튼 클릭 시 맨 위로 스크롤하는 기능 추가

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/home/HomeFragment.kt
@@ -109,4 +109,8 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
             binding.srlReloadAuctions.isRefreshing = false
         }
     }
+
+    fun scrollToTop() {
+        binding.rvAuction.smoothScrollToPosition(0)
+    }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainActivity.kt
@@ -66,10 +66,22 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     }
 
     private fun setupViewModel() {
+        viewModel.event.observe(this) { handleEvent(it) }
         viewModel.currentFragmentType.observe(this) {
             changeFragment(it)
             screenViewLogEvent(it.name)
         }
+    }
+
+    private fun handleEvent(event: MainViewModel.MainEvent) {
+        when (event) {
+            MainViewModel.MainEvent.HomeToTop -> scrollHomeToTop()
+        }
+    }
+
+    private fun scrollHomeToTop() {
+        val homeFragment = supportFragmentManager.findFragmentByTag(FragmentType.HOME.tag) as? HomeFragment
+        homeFragment?.scrollToTop()
     }
 
     private fun changeFragment(type: FragmentType) {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.ddangddangddang.android.R
+import com.ddangddangddang.android.util.livedata.SingleLiveEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -14,6 +15,9 @@ class MainViewModel @Inject constructor() : ViewModel() {
         MutableLiveData(FragmentType.HOME)
     val currentFragmentType: LiveData<FragmentType>
         get() = _currentFragmentType
+    private val _event: SingleLiveEvent<MainEvent> = SingleLiveEvent()
+    val event: LiveData<MainEvent>
+        get() = _event
 
     fun setCurrentFragment(item: MenuItem): Boolean {
         val menuItemId = item.itemId
@@ -34,8 +38,16 @@ class MainViewModel @Inject constructor() : ViewModel() {
     }
 
     private fun changeCurrentFragmentType(fragmentType: FragmentType) {
-        if (currentFragmentType.value == fragmentType) return
+        if (currentFragmentType.value == fragmentType) {
+            if (fragmentType == FragmentType.HOME) {
+                _event.value = MainEvent.HomeToTop
+            }
+        }
 
         _currentFragmentType.value = fragmentType
+    }
+
+    sealed class MainEvent {
+        object HomeToTop : MainEvent()
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
홈 화면에서 맨 위로 스크롤하는 기능이 없어서 불편하다고 생각했습니다.
그래서 예전 배달의 민족 앱처럼 홈 화면에서 홈 버튼을 누르면 맨 위로 스크롤하도록 기능을 추가했습니다!

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
홈 화면에서 홈 버튼을 클릭하면 이벤트를 설정하고 MainActivity에서 이벤트를 옵저빙하게 했습니다.
이벤트가 옵저빙되면 supportFragmentManager로부터 HomeFragment를 가져와서 HomeFragment에 정의된 함수를 호출하게 하였습니다!
해당 함수는 경매 목록 리사이클러뷰의 스크롤을 스무스하게 맨 위로 스크롤합니다!

## 📎 Issue 번호
- close: #522 
