### PR TITLE
각 날짜별로 첫번째 메시지의 상단에 날짜가 표시되도록 수정

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/di/Annotations.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/di/Annotations.kt
@@ -9,3 +9,11 @@ annotation class AuthRetrofitQualifier
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class AuctionRetrofitQualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DateFormatter
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class TimeFormatter

--- a/android/app/src/main/java/com/ddangddangddang/android/di/FormatterModule.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/di/FormatterModule.kt
@@ -9,11 +9,13 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object FormatterModule {
     @DateFormatter
+    @Singleton
     @Provides
     fun provideDateFormatter(@ApplicationContext context: Context): DateTimeFormatter {
         return DateTimeFormatter.ofPattern(
@@ -23,6 +25,7 @@ object FormatterModule {
     }
 
     @TimeFormatter
+    @Singleton
     @Provides
     fun provideTimeFormatter(@ApplicationContext context: Context): DateTimeFormatter {
         return DateTimeFormatter.ofPattern(

--- a/android/app/src/main/java/com/ddangddangddang/android/di/FormatterModule.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/di/FormatterModule.kt
@@ -19,7 +19,7 @@ object FormatterModule {
     @Provides
     fun provideDateFormatter(@ApplicationContext context: Context): DateTimeFormatter {
         return DateTimeFormatter.ofPattern(
-            context.getString(R.string.message_room_item_date_format),
+            context.getString(R.string.all_date_format),
             Locale.KOREAN,
         )
     }
@@ -29,7 +29,7 @@ object FormatterModule {
     @Provides
     fun provideTimeFormatter(@ApplicationContext context: Context): DateTimeFormatter {
         return DateTimeFormatter.ofPattern(
-            context.getString(R.string.message_room_item_time_format),
+            context.getString(R.string.all_time_format),
             Locale.KOREAN,
         )
     }

--- a/android/app/src/main/java/com/ddangddangddang/android/di/FormatterModule.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/di/FormatterModule.kt
@@ -1,0 +1,33 @@
+package com.ddangddangddang.android.di
+
+import android.content.Context
+import com.ddangddangddang.android.R
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+@Module
+@InstallIn(SingletonComponent::class)
+object FormatterModule {
+    @DateFormatter
+    @Provides
+    fun provideDateFormatter(@ApplicationContext context: Context): DateTimeFormatter {
+        return DateTimeFormatter.ofPattern(
+            context.getString(R.string.message_room_item_date_format),
+            Locale.KOREAN,
+        )
+    }
+
+    @TimeFormatter
+    @Provides
+    fun provideTimeFormatter(@ApplicationContext context: Context): DateTimeFormatter {
+        return DateTimeFormatter.ofPattern(
+            context.getString(R.string.message_room_item_time_format),
+            Locale.KOREAN,
+        )
+    }
+}

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageAdapter.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageAdapter.kt
@@ -8,7 +8,6 @@ import java.time.format.DateTimeFormatter
 class MessageAdapter(
     private val dateFormatter: DateTimeFormatter,
     private val timeFormatter: DateTimeFormatter,
-    private val diffUtilCommitCallback: Runnable,
 ) : ListAdapter<MessageViewItem, MessageViewHolder>(MessageDiffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MessageViewHolder {
@@ -31,7 +30,7 @@ class MessageAdapter(
         return currentList[position].type.ordinal
     }
 
-    fun setMessages(list: List<MessageViewItem>) {
+    fun setMessages(list: List<MessageViewItem>, diffUtilCommitCallback: Runnable? = null) {
         submitList(list, diffUtilCommitCallback)
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageAdapter.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageAdapter.kt
@@ -3,13 +3,17 @@ package com.ddangddangddang.android.feature.messageRoom
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
+import com.ddangddangddang.android.di.DateFormatter
+import com.ddangddangddang.android.di.TimeFormatter
+import dagger.hilt.android.scopes.ActivityRetainedScoped
 import java.time.format.DateTimeFormatter
+import javax.inject.Inject
 
-class MessageAdapter(
-    private val dateFormatter: DateTimeFormatter,
-    private val timeFormatter: DateTimeFormatter,
+@ActivityRetainedScoped
+class MessageAdapter @Inject constructor(
+    @DateFormatter private val dateFormatter: DateTimeFormatter,
+    @TimeFormatter private val timeFormatter: DateTimeFormatter,
 ) : ListAdapter<MessageViewItem, MessageViewHolder>(MessageDiffUtil) {
-
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MessageViewHolder {
         return MessageViewHolder.of(
             parent,

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageAdapter.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageAdapter.kt
@@ -12,7 +12,12 @@ class MessageAdapter(
 ) : ListAdapter<MessageViewItem, MessageViewHolder>(MessageDiffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MessageViewHolder {
-        return MessageViewHolder.of(parent, MessageViewType.values()[viewType], dateFormatter, timeFormatter)
+        return MessageViewHolder.of(
+            parent,
+            MessageViewType.values()[viewType],
+            dateFormatter,
+            timeFormatter,
+        )
     }
 
     override fun onBindViewHolder(holder: MessageViewHolder, position: Int) {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageAdapter.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageAdapter.kt
@@ -3,13 +3,16 @@ package com.ddangddangddang.android.feature.messageRoom
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
+import java.time.format.DateTimeFormatter
 
 class MessageAdapter(
+    private val dateFormatter: DateTimeFormatter,
+    private val timeFormatter: DateTimeFormatter,
     private val diffUtilCommitCallback: Runnable,
 ) : ListAdapter<MessageViewItem, MessageViewHolder>(MessageDiffUtil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MessageViewHolder {
-        return MessageViewHolder.of(parent, MessageViewType.values()[viewType])
+        return MessageViewHolder.of(parent, MessageViewType.values()[viewType], dateFormatter, timeFormatter)
     }
 
     override fun onBindViewHolder(holder: MessageViewHolder, position: Int) {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
@@ -17,8 +17,7 @@ import com.ddangddangddang.android.model.ReportType
 import com.ddangddangddang.android.util.binding.BindingActivity
 import com.ddangddangddang.android.util.view.showSnackbar
 import dagger.hilt.android.AndroidEntryPoint
-import java.time.format.DateTimeFormatter
-import java.util.Locale
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MessageRoomActivity :
@@ -26,18 +25,10 @@ class MessageRoomActivity :
     AnalyticsDelegate by AnalyticsDelegateImpl() {
     private val viewModel: MessageRoomViewModel by viewModels()
     private val roomCreatedNotifyAdapter by lazy { RoomCreatedNotifyAdapter() }
-    private val messageAdapter by lazy {
-        MessageAdapter(
-            DateTimeFormatter.ofPattern(
-                getString(R.string.message_room_item_date_format),
-                Locale.KOREAN,
-            ),
-            DateTimeFormatter.ofPattern(
-                getString(R.string.message_room_item_time_format),
-                Locale.KOREAN,
-            ),
-        )
-    }
+
+    @Inject
+    lateinit var messageAdapter: MessageAdapter
+
     private val adapter by lazy { ConcatAdapter(roomCreatedNotifyAdapter, messageAdapter) }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
@@ -17,6 +17,8 @@ import com.ddangddangddang.android.model.ReportType
 import com.ddangddangddang.android.util.binding.BindingActivity
 import com.ddangddangddang.android.util.view.showSnackbar
 import dagger.hilt.android.AndroidEntryPoint
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 @AndroidEntryPoint
 class MessageRoomActivity :
@@ -25,7 +27,18 @@ class MessageRoomActivity :
     private val viewModel: MessageRoomViewModel by viewModels()
     private val roomCreatedNotifyAdapter by lazy { RoomCreatedNotifyAdapter() }
     private val messageAdapter by lazy {
-        MessageAdapter { viewModel.messages.value?.let { binding.rvMessageList.scrollToPosition(it.size) } }
+        MessageAdapter(
+            DateTimeFormatter.ofPattern(
+                getString(R.string.message_room_item_date_format),
+                Locale.KOREAN,
+            ),
+            DateTimeFormatter.ofPattern(
+                getString(R.string.message_room_item_time_format),
+                Locale.KOREAN,
+            ),
+        ) {
+            viewModel.messages.value?.let { binding.rvMessageList.scrollToPosition(it.size) }
+        }
     }
     private val adapter by lazy { ConcatAdapter(roomCreatedNotifyAdapter, messageAdapter) }
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
@@ -36,9 +36,7 @@ class MessageRoomActivity :
                 getString(R.string.message_room_item_time_format),
                 Locale.KOREAN,
             ),
-        ) {
-            viewModel.messages.value?.let { binding.rvMessageList.scrollToPosition(it.size) }
-        }
+        )
     }
     private val adapter by lazy { ConcatAdapter(roomCreatedNotifyAdapter, messageAdapter) }
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -54,7 +52,7 @@ class MessageRoomActivity :
     private fun setupViewModel() {
         viewModel.event.observe(this) { handleEvent(it) }
         viewModel.messages.observe(this) {
-            messageAdapter.setMessages(it)
+            messageAdapter.setMessages(it) { scrollToDown() }
         }
     }
 
@@ -73,6 +71,10 @@ class MessageRoomActivity :
 
             is MessageRoomViewModel.MessageRoomEvent.FailureEvent -> handleFailureEvent(event)
         }
+    }
+
+    private fun scrollToDown() {
+        viewModel.messages.value?.let { binding.rvMessageList.scrollToPosition(it.size) }
     }
 
     private fun navigateToReport(roomId: Long) {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomViewModel.kt
@@ -103,16 +103,15 @@ class MessageRoomViewModel @Inject constructor(
     private fun List<MessageModel>.toViewItems(): List<MessageViewItem> {
         return mapIndexed { index, messageModel ->
             val sendDateTime = LocalDateTime.parse(messageModel.createdAt)
-            if (index == 0) return@mapIndexed messageModel.toViewItem(sendDateTime, true)
-
             val sendDate = sendDateTime.toLocalDate()
-            val previousSendDateTime = LocalDateTime.parse(this[index - 1].createdAt)
-            val previousSendDate = previousSendDateTime.toLocalDate()
-            return@mapIndexed if (sendDate == previousSendDate) {
-                messageModel.toViewItem(sendDateTime, false)
+
+            val previousSendDate = if (index == 0) {
+                _messages.value?.lastOrNull()?.createdDateTime?.toLocalDate()
             } else {
-                messageModel.toViewItem(sendDateTime, true)
+                LocalDateTime.parse(this[index - 1].createdAt).toLocalDate()
             }
+
+            messageModel.toViewItem(sendDateTime, (sendDate == previousSendDate).not())
         }
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomViewModel.kt
@@ -101,17 +101,13 @@ class MessageRoomViewModel @Inject constructor(
     }
 
     private fun List<MessageModel>.toViewItems(): List<MessageViewItem> {
+        var previousSendDate = _messages.value?.lastOrNull()?.createdDateTime?.toLocalDate()
         return mapIndexed { index, messageModel ->
             val sendDateTime = LocalDateTime.parse(messageModel.createdAt)
             val sendDate = sendDateTime.toLocalDate()
-
-            val previousSendDate = if (index == 0) {
-                _messages.value?.lastOrNull()?.createdDateTime?.toLocalDate()
-            } else {
-                LocalDateTime.parse(this[index - 1].createdAt).toLocalDate()
-            }
-
-            messageModel.toViewItem(sendDateTime, (sendDate == previousSendDate).not())
+            val isFirstAtDate = (sendDate == previousSendDate).not()
+            previousSendDate = sendDate
+            messageModel.toViewItem(sendDateTime, isFirstAtDate)
         }
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomViewModel.kt
@@ -16,7 +16,6 @@ import com.ddangddangddang.data.repository.ChatRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 @HiltViewModel
@@ -40,8 +39,6 @@ class MessageRoomViewModel @Inject constructor(
         get() = _messages.value?.lastOrNull()?.id
 
     private var isMessageLoading: Boolean = false
-
-    private val formatter = DateTimeFormatter.ofPattern("h:mm a")
 
     fun loadMessageRoom(roomId: Long) {
         viewModelScope.launch {
@@ -106,25 +103,27 @@ class MessageRoomViewModel @Inject constructor(
     private fun List<MessageModel>.toViewItems(): List<MessageViewItem> {
         return mapIndexed { index, messageModel ->
             val sendDateTime = LocalDateTime.parse(messageModel.createdAt)
-            val sendTime = sendDateTime.format(formatter)
-            if (index == 0) return@mapIndexed messageModel.toViewItem(sendTime, true)
+            if (index == 0) return@mapIndexed messageModel.toViewItem(sendDateTime, true)
 
             val sendDate = sendDateTime.toLocalDate()
             val previousSendDateTime = LocalDateTime.parse(this[index - 1].createdAt)
             val previousSendDate = previousSendDateTime.toLocalDate()
             return@mapIndexed if (sendDate == previousSendDate) {
-                messageModel.toViewItem(sendTime, false)
+                messageModel.toViewItem(sendDateTime, false)
             } else {
-                messageModel.toViewItem(sendTime, true)
+                messageModel.toViewItem(sendDateTime, true)
             }
         }
     }
 
-    private fun MessageModel.toViewItem(sendTime: String, isFirstAtDate: Boolean): MessageViewItem {
+    private fun MessageModel.toViewItem(
+        sendDateTime: LocalDateTime,
+        isFirstAtDate: Boolean,
+    ): MessageViewItem {
         return if (isMyMessage) {
-            MessageViewItem.MyMessageViewItem(id, sendTime, contents, isFirstAtDate)
+            MessageViewItem.MyMessageViewItem(id, sendDateTime, contents, isFirstAtDate)
         } else {
-            MessageViewItem.PartnerMessageViewItem(id, sendTime, contents, isFirstAtDate)
+            MessageViewItem.PartnerMessageViewItem(id, sendDateTime, contents, isFirstAtDate)
         }
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomViewModel.kt
@@ -101,9 +101,9 @@ class MessageRoomViewModel @Inject constructor(
 
     private fun MessageModel.toViewItem(): MessageViewItem {
         return if (isMyMessage) {
-            MessageViewItem.MyMessageViewItem(id, createdDateTime, contents)
+            MessageViewItem.MyMessageViewItem(id, createdDateTime, contents, false)
         } else {
-            MessageViewItem.PartnerMessageViewItem(id, createdDateTime, contents)
+            MessageViewItem.PartnerMessageViewItem(id, createdDateTime, contents, false)
         }
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomViewModel.kt
@@ -15,7 +15,6 @@ import com.ddangddangddang.data.remote.ApiResponse
 import com.ddangddangddang.data.repository.ChatRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import java.time.LocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
@@ -103,22 +102,20 @@ class MessageRoomViewModel @Inject constructor(
     private fun List<MessageModel>.toViewItems(): List<MessageViewItem> {
         var previousSendDate = _messages.value?.lastOrNull()?.createdDateTime?.toLocalDate()
         return map { messageModel ->
-            val sendDateTime = LocalDateTime.parse(messageModel.createdAt)
-            val sendDate = sendDateTime.toLocalDate()
+            val sendDate = messageModel.createdDateTime.toLocalDate()
             val isFirstAtDate = (sendDate == previousSendDate).not()
             previousSendDate = sendDate
-            messageModel.toViewItem(sendDateTime, isFirstAtDate)
+            messageModel.toViewItem(isFirstAtDate)
         }
     }
 
     private fun MessageModel.toViewItem(
-        sendDateTime: LocalDateTime,
         isFirstAtDate: Boolean,
     ): MessageViewItem {
         return if (isMyMessage) {
-            MessageViewItem.MyMessageViewItem(id, sendDateTime, contents, isFirstAtDate)
+            MessageViewItem.MyMessageViewItem(id, createdDateTime, contents, isFirstAtDate)
         } else {
-            MessageViewItem.PartnerMessageViewItem(id, sendDateTime, contents, isFirstAtDate)
+            MessageViewItem.PartnerMessageViewItem(id, createdDateTime, contents, isFirstAtDate)
         }
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomViewModel.kt
@@ -102,7 +102,7 @@ class MessageRoomViewModel @Inject constructor(
 
     private fun List<MessageModel>.toViewItems(): List<MessageViewItem> {
         var previousSendDate = _messages.value?.lastOrNull()?.createdDateTime?.toLocalDate()
-        return mapIndexed { index, messageModel ->
+        return map { messageModel ->
             val sendDateTime = LocalDateTime.parse(messageModel.createdAt)
             val sendDate = sendDateTime.toLocalDate()
             val isFirstAtDate = (sendDate == previousSendDate).not()

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageViewHolder.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageViewHolder.kt
@@ -6,11 +6,19 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.ddangddangddang.android.databinding.ItemMyMessageBinding
 import com.ddangddangddang.android.databinding.ItemPartnerMessageBinding
+import java.time.format.DateTimeFormatter
 
 sealed class MessageViewHolder(view: View) : RecyclerView.ViewHolder(view) {
     class MyMessageViewHolder(
         private val binding: ItemMyMessageBinding,
+        dateFormatter: DateTimeFormatter,
+        timeFormatter: DateTimeFormatter,
     ) : MessageViewHolder(binding.root) {
+        init {
+            binding.dateFormatter = dateFormatter
+            binding.timeFormatter = timeFormatter
+        }
+
         fun bind(item: MessageViewItem.MyMessageViewItem) {
             binding.item = item
         }
@@ -18,7 +26,14 @@ sealed class MessageViewHolder(view: View) : RecyclerView.ViewHolder(view) {
 
     class PartnerMessageViewHolder(
         private val binding: ItemPartnerMessageBinding,
+        dateFormatter: DateTimeFormatter,
+        timeFormatter: DateTimeFormatter,
     ) : MessageViewHolder(binding.root) {
+        init {
+            binding.dateFormatter = dateFormatter
+            binding.timeFormatter = timeFormatter
+        }
+
         fun bind(item: MessageViewItem.PartnerMessageViewItem) {
             binding.item = item
         }
@@ -28,15 +43,21 @@ sealed class MessageViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         fun of(
             parent: ViewGroup,
             type: MessageViewType,
+            dateFormatter: DateTimeFormatter,
+            timeFormatter: DateTimeFormatter,
         ): MessageViewHolder {
             val view = LayoutInflater.from(parent.context).inflate(type.id, parent, false)
             return when (type) {
                 MessageViewType.MY_MESSAGE -> MyMessageViewHolder(
                     ItemMyMessageBinding.bind(view),
+                    dateFormatter,
+                    timeFormatter,
                 )
 
                 MessageViewType.PARTNER_MESSAGE -> PartnerMessageViewHolder(
                     ItemPartnerMessageBinding.bind(view),
+                    dateFormatter,
+                    timeFormatter,
                 )
             }
         }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageViewItem.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageViewItem.kt
@@ -5,11 +5,13 @@ sealed interface MessageViewItem {
     val type: MessageViewType
     val createdDateTime: String
     val contents: String
+    val isFirstAtDate: Boolean
 
     data class MyMessageViewItem(
         override val id: Long,
         override val createdDateTime: String,
         override val contents: String,
+        override val isFirstAtDate: Boolean,
     ) : MessageViewItem {
         override val type: MessageViewType = MessageViewType.MY_MESSAGE
     }
@@ -18,6 +20,7 @@ sealed interface MessageViewItem {
         override val id: Long,
         override val createdDateTime: String,
         override val contents: String,
+        override val isFirstAtDate: Boolean,
     ) : MessageViewItem {
         override val type: MessageViewType = MessageViewType.PARTNER_MESSAGE
     }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageViewItem.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageViewItem.kt
@@ -1,15 +1,17 @@
 package com.ddangddangddang.android.feature.messageRoom
 
+import java.time.LocalDateTime
+
 sealed interface MessageViewItem {
     val id: Long
     val type: MessageViewType
-    val createdDateTime: String
+    val createdDateTime: LocalDateTime
     val contents: String
     val isFirstAtDate: Boolean
 
     data class MyMessageViewItem(
         override val id: Long,
-        override val createdDateTime: String,
+        override val createdDateTime: LocalDateTime,
         override val contents: String,
         override val isFirstAtDate: Boolean,
     ) : MessageViewItem {
@@ -18,7 +20,7 @@ sealed interface MessageViewItem {
 
     data class PartnerMessageViewItem(
         override val id: Long,
-        override val createdDateTime: String,
+        override val createdDateTime: LocalDateTime,
         override val contents: String,
         override val isFirstAtDate: Boolean,
     ) : MessageViewItem {

--- a/android/app/src/main/java/com/ddangddangddang/android/model/MessageModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/model/MessageModel.kt
@@ -2,7 +2,7 @@ package com.ddangddangddang.android.model
 
 data class MessageModel(
     val id: Long,
-    val createdDateTime: String,
+    val createdAt: String,
     val isMyMessage: Boolean,
     val contents: String,
 )

--- a/android/app/src/main/java/com/ddangddangddang/android/model/MessageModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/model/MessageModel.kt
@@ -1,8 +1,10 @@
 package com.ddangddangddang.android.model
 
+import java.time.LocalDateTime
+
 data class MessageModel(
     val id: Long,
-    val createdAt: String,
+    val createdDateTime: LocalDateTime,
     val isMyMessage: Boolean,
     val contents: String,
 )

--- a/android/app/src/main/java/com/ddangddangddang/android/model/mapper/MessageModelMapper.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/model/mapper/MessageModelMapper.kt
@@ -2,15 +2,12 @@ package com.ddangddangddang.android.model.mapper
 
 import com.ddangddangddang.android.model.MessageModel
 import com.ddangddangddang.data.model.response.ChatMessageResponse
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 object MessageModelMapper : Mapper<MessageModel, ChatMessageResponse> {
-    private val formatter = DateTimeFormatter.ofPattern("h:mm a")
     override fun ChatMessageResponse.toPresentation(): MessageModel {
         return MessageModel(
             id,
-            LocalDateTime.parse(createdAt).format(formatter),
+            createdAt,
             isMyMessage,
             contents,
         )

--- a/android/app/src/main/java/com/ddangddangddang/android/model/mapper/MessageModelMapper.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/model/mapper/MessageModelMapper.kt
@@ -2,12 +2,13 @@ package com.ddangddangddang.android.model.mapper
 
 import com.ddangddangddang.android.model.MessageModel
 import com.ddangddangddang.data.model.response.ChatMessageResponse
+import java.time.LocalDateTime
 
 object MessageModelMapper : Mapper<MessageModel, ChatMessageResponse> {
     override fun ChatMessageResponse.toPresentation(): MessageModel {
         return MessageModel(
             id,
-            createdAt,
+            LocalDateTime.parse(createdAt),
             isMyMessage,
             contents,
         )

--- a/android/app/src/main/res/layout/item_message_room_created_notify.xml
+++ b/android/app/src/main/res/layout/item_message_room_created_notify.xml
@@ -8,15 +8,16 @@
         android:paddingVertical="20dp">
 
         <TextView
+            style="@style/Caption"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:background="#F8F8FB"
+            android:background="@drawable/bg_stroke_gray_radius_1dp"
+            android:backgroundTint="@color/grey_100"
             android:paddingHorizontal="12dp"
             android:paddingVertical="4dp"
             android:text="@string/message_room_created_introduce_text"
-            android:textColor="#686868"
-            android:textSize="12sp" />
+            android:textColor="@color/grey_700" />
     </LinearLayout>
 
 </layout>

--- a/android/app/src/main/res/layout/item_my_message.xml
+++ b/android/app/src/main/res/layout/item_my_message.xml
@@ -6,20 +6,45 @@
     <data>
 
         <variable
+            name="dateFormatter"
+            type="java.time.format.DateTimeFormatter" />
+
+        <variable
+            name="timeFormatter"
+            type="java.time.format.DateTimeFormatter" />
+
+        <variable
             name="item"
             type="com.ddangddangddang.android.feature.messageRoom.MessageViewItem.MyMessageViewItem" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="16dp">
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/tv_date"
+            style="@style/Caption"
+            isVisible="@{item.isFirstAtDate}"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/padding_vertical_filter_chips"
+            android:background="@drawable/bg_stroke_gray_radius_1dp"
+            android:backgroundTint="@color/grey_100"
+            android:paddingHorizontal="8dp"
+            android:paddingVertical="4dp"
+            android:text="@{item.createdDateTime.format(dateFormatter)}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="2023년 10월 3일" />
 
         <TextView
             android:id="@+id/tv_message_contents"
             style="@style/Body"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/padding_vertical_filter_chips"
             android:background="@drawable/bg_stroke_gray_radius_1dp"
             android:backgroundTint="@color/primary"
             android:maxWidth="310dp"
@@ -27,7 +52,7 @@
             android:text="@{item.contents}"
             android:textColor="@color/text_active_fixed"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_date"
             tools:text="안녕하세요, 이번 방탄 진 포카 낙찰자입니다!ㅎㅎ
 서울 사시던데 강남에서 직거래 어떠세요?" />
 
@@ -37,7 +62,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/padding_vertical_filter_chips"
             android:paddingHorizontal="4dp"
-            android:text="@{item.createdDateTime}"
+            android:text="@{item.createdDateTime.format(timeFormatter)}"
             android:textColor="@color/grey_500"
             android:textStyle="italic"
             app:layout_constraintEnd_toEndOf="@id/tv_message_contents"

--- a/android/app/src/main/res/layout/item_my_message.xml
+++ b/android/app/src/main/res/layout/item_my_message.xml
@@ -31,7 +31,7 @@
             android:layout_marginTop="@dimen/padding_vertical_filter_chips"
             android:background="@drawable/bg_stroke_gray_radius_1dp"
             android:backgroundTint="@color/grey_100"
-            android:paddingHorizontal="8dp"
+            android:paddingHorizontal="12dp"
             android:paddingVertical="4dp"
             android:text="@{item.createdDateTime.format(dateFormatter)}"
             app:layout_constraintEnd_toEndOf="parent"

--- a/android/app/src/main/res/layout/item_my_message.xml
+++ b/android/app/src/main/res/layout/item_my_message.xml
@@ -51,6 +51,7 @@
             android:padding="14dp"
             android:text="@{item.contents}"
             android:textColor="@color/text_active_fixed"
+            android:textIsSelectable="true"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_date"
             tools:text="안녕하세요, 이번 방탄 진 포카 낙찰자입니다!ㅎㅎ

--- a/android/app/src/main/res/layout/item_partner_message.xml
+++ b/android/app/src/main/res/layout/item_partner_message.xml
@@ -51,6 +51,7 @@
             android:padding="14dp"
             android:text="@{item.contents}"
             android:textColor="@color/grey_700"
+            android:textIsSelectable="true"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_date"
             tools:text="안녕하세요, 이번 방탄 진 포카 낙찰자입니다!ㅎㅎ

--- a/android/app/src/main/res/layout/item_partner_message.xml
+++ b/android/app/src/main/res/layout/item_partner_message.xml
@@ -31,7 +31,7 @@
             android:layout_marginTop="@dimen/padding_vertical_filter_chips"
             android:background="@drawable/bg_stroke_gray_radius_1dp"
             android:backgroundTint="@color/grey_100"
-            android:paddingHorizontal="8dp"
+            android:paddingHorizontal="12dp"
             android:paddingVertical="4dp"
             android:text="@{item.createdDateTime.format(dateFormatter)}"
             app:layout_constraintEnd_toEndOf="parent"

--- a/android/app/src/main/res/layout/item_partner_message.xml
+++ b/android/app/src/main/res/layout/item_partner_message.xml
@@ -6,20 +6,45 @@
     <data>
 
         <variable
+            name="dateFormatter"
+            type="java.time.format.DateTimeFormatter" />
+
+        <variable
+            name="timeFormatter"
+            type="java.time.format.DateTimeFormatter" />
+
+        <variable
             name="item"
             type="com.ddangddangddang.android.feature.messageRoom.MessageViewItem.PartnerMessageViewItem" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="16dp">
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/tv_date"
+            style="@style/Caption"
+            isVisible="@{item.isFirstAtDate}"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/padding_vertical_filter_chips"
+            android:background="@drawable/bg_stroke_gray_radius_1dp"
+            android:backgroundTint="@color/grey_100"
+            android:paddingHorizontal="8dp"
+            android:paddingVertical="4dp"
+            android:text="@{item.createdDateTime.format(dateFormatter)}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="2023년 10월 3일" />
 
         <TextView
             android:id="@+id/tv_message_contents"
             style="@style/Body"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/padding_vertical_filter_chips"
             android:background="@drawable/bg_stroke_gray_radius_1dp"
             android:backgroundTint="@color/grey_100"
             android:maxWidth="310dp"
@@ -27,7 +52,7 @@
             android:text="@{item.contents}"
             android:textColor="@color/grey_700"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_date"
             tools:text="안녕하세요, 이번 방탄 진 포카 낙찰자입니다!ㅎㅎ
 서울 사시던데 강남에서 직거래 어떠세요?" />
 
@@ -36,7 +61,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/padding_vertical_filter_chips"
-            android:text="@{item.createdDateTime}"
+            android:paddingHorizontal="4dp"
+            android:text="@{item.createdDateTime.format(timeFormatter)}"
             android:textColor="@color/grey_500"
             android:textStyle="italic"
             app:layout_constraintStart_toStartOf="@id/tv_message_contents"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -26,6 +26,8 @@
     <string name="all_network_error_message">인터넷이 연결되어 있는지 확인해주세요.</string>
     <string name="all_unexpected_error_message">예기치 못한 오류가 발생했습니다. 다시 시도해주세요.</string>
     <string name="all_must_update_to_latest_version">최신 버전으로 업데이트가 필요합니다.</string>
+    <string name="all_date_format">yyyy년 M월 d일</string>
+    <string name="all_time_format">h:mm a</string>
 
     <!-- splash -->
     <string name="splash_app_update_request_dialog_title">업데이트 알림</string>
@@ -126,8 +128,6 @@
     <string name="message_room_send_message_failed">메시지 전송에 실패했습니다\n잠시 후에 다시 시도해주세요</string>
     <string name="message_room_created_introduce_text">쪽지방이 생성됐습니다.</string>
     <string name="message_room_auction_bid_price">%,d원</string>
-    <string name="message_room_item_date_format">yyyy년 M월 d일</string>
-    <string name="message_room_item_time_format">h:mm a</string>
 
     <!-- mypage -->
     <string name="mypage">마이페이지</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -126,6 +126,8 @@
     <string name="message_room_send_message_failed">메시지 전송에 실패했습니다\n잠시 후에 다시 시도해주세요</string>
     <string name="message_room_created_introduce_text">쪽지방이 생성됐습니다.</string>
     <string name="message_room_auction_bid_price">%,d원</string>
+    <string name="message_room_item_date_format">yyyy년 M월 d일</string>
+    <string name="message_room_item_time_format">h:mm a</string>
 
     <!-- mypage -->
     <string name="mypage">마이페이지</string>


### PR DESCRIPTION
## 📄 작업 내용 요약
각 날짜별로 첫번째 메시지의 상단에 날짜가 표시되도록 수정 및 메시지에 텍스트 복사 기능만 추가했습니다.

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
![image](https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/d036e463-de63-41ea-b270-d06cdee4392e)
저번 di미션때 레아가 짜주셨던 방법과 유사하게 하려고 포매터를 어댑터의 생성자에서 받도록 수정했습니다.

기존에는 toViewItem을 호출해서 내 메시지와 상대 메시지타입을 나눴었는데, 그 전에 먼저 합쳐진 상태에서 이번에 뒤에 더 추가하려는 메시지들에 대해서 toViewItems()를 호출하는 방식으로 수정했습니다. 
추가하려는 메시지들 중 가장 앞에 있는(인덱스가 0인) 메시지는 기존의 메시지 중 가장 뒤에 있는 메시지의 LocalDate와 비교합니다. 
아래 보이시는 것처럼, 효율적인 비교를 위해 내 바로 앞에 있는 메시지의 LocalDate하고만 비교하며, map문의 순회 한번이 끝날때마다 sendTime을 previousSendDate에 할당해줘서 다음번 순회에서 중복으로 불필요하게 이전 아이템의 LocalDate구하는 과정을 없앴습니다.
![image](https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/9f927afd-d2c9-493c-8a5b-542c2d885bd9)


## 📎 Issue 번호
- close: #516 