### PR TITLE
메시지 실시간 동기화 기능 추가

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
@@ -51,6 +51,15 @@ class MessageRoomActivity :
         setupMessageRecyclerView()
     }
 
+    override fun onStart() {
+        super.onStart()
+        registerMessageReceiver()
+    }
+
+    private fun registerMessageReceiver() {
+        registerReceiver(messageReceiver, MessageReceiver.getIntentFilter())
+    }
+
     private fun setupViewModel() {
         viewModel.event.observe(this) { handleEvent(it) }
         viewModel.messages.observe(this) {
@@ -124,12 +133,7 @@ class MessageRoomActivity :
 
     override fun onResume() {
         super.onResume()
-        registerMessageReceiver()
         if (viewModel.messageRoomInfo.value != null) viewModel.loadMessages()
-    }
-
-    private fun registerMessageReceiver() {
-        registerReceiver(messageReceiver, MessageReceiver.getIntentFilter())
     }
 
     override fun onStop() {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
@@ -2,7 +2,6 @@ package com.ddangddangddang.android.feature.messageRoom
 
 import android.content.Context
 import android.content.Intent
-import android.content.IntentFilter
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.recyclerview.widget.ConcatAdapter
@@ -66,8 +65,7 @@ class MessageRoomActivity :
     }
 
     private fun setupMessageReceiver() {
-        val filter = IntentFilter().apply { addAction(MessageReceiver.MessageAction) }
-        registerReceiver(messageReceiver, filter)
+        registerReceiver(messageReceiver, MessageReceiver.getIntentFilter())
     }
 
     private fun handleEvent(event: MessageRoomViewModel.MessageRoomEvent) {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
@@ -51,15 +51,6 @@ class MessageRoomActivity :
         setupMessageRecyclerView()
     }
 
-    override fun onStart() {
-        super.onStart()
-        registerMessageReceiver()
-    }
-
-    private fun registerMessageReceiver() {
-        registerReceiver(messageReceiver, MessageReceiver.getIntentFilter())
-    }
-
     private fun setupViewModel() {
         viewModel.event.observe(this) { handleEvent(it) }
         viewModel.messages.observe(this) {
@@ -133,15 +124,12 @@ class MessageRoomActivity :
 
     override fun onResume() {
         super.onResume()
+        registerReceiver(messageReceiver, MessageReceiver.getIntentFilter())
         if (viewModel.messageRoomInfo.value != null) viewModel.loadMessages()
     }
 
-    override fun onStop() {
-        super.onStop()
-        unregisterMessageReceiver()
-    }
-
-    private fun unregisterMessageReceiver() {
+    override fun onPause() {
+        super.onPause()
         unregisterReceiver(messageReceiver)
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
@@ -2,6 +2,7 @@ package com.ddangddangddang.android.feature.messageRoom
 
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.recyclerview.widget.ConcatAdapter
@@ -15,6 +16,7 @@ import com.ddangddangddang.android.feature.report.ReportActivity
 import com.ddangddangddang.android.global.AnalyticsDelegate
 import com.ddangddangddang.android.global.AnalyticsDelegateImpl
 import com.ddangddangddang.android.model.ReportType
+import com.ddangddangddang.android.reciever.MessageReceiver
 import com.ddangddangddang.android.util.binding.BindingActivity
 import com.ddangddangddang.android.util.view.showSnackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -31,6 +33,11 @@ class MessageRoomActivity :
     lateinit var messageAdapter: MessageAdapter
 
     private val adapter by lazy { ConcatAdapter(roomCreatedNotifyAdapter, messageAdapter) }
+
+    private val messageReceiver: MessageReceiver by lazy {
+        MessageReceiver(viewModel::loadMessages)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         registerAnalytics(javaClass.simpleName, lifecycle)
@@ -39,6 +46,7 @@ class MessageRoomActivity :
         if (viewModel.messageRoomInfo.value == null) viewModel.loadMessageRoom(roomId)
         setupViewModel()
         setupMessageRecyclerView()
+        setupMessageReceiver()
     }
 
     private fun setupViewModel() {
@@ -51,6 +59,11 @@ class MessageRoomActivity :
     private fun setupMessageRecyclerView() {
         binding.rvMessageList.adapter = adapter
         (binding.rvMessageList.layoutManager as LinearLayoutManager).stackFromEnd = true
+    }
+
+    private fun setupMessageReceiver() {
+        val filter = IntentFilter().apply { addAction(MessageReceiver.MessageAction) }
+        registerReceiver(messageReceiver, filter)
     }
 
     private fun handleEvent(event: MessageRoomViewModel.MessageRoomEvent) {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
@@ -49,7 +49,6 @@ class MessageRoomActivity :
         if (viewModel.messageRoomInfo.value == null) viewModel.loadMessageRoom(roomId)
         setupViewModel()
         setupMessageRecyclerView()
-        setupMessageReceiver()
     }
 
     private fun setupViewModel() {
@@ -62,10 +61,6 @@ class MessageRoomActivity :
     private fun setupMessageRecyclerView() {
         binding.rvMessageList.adapter = adapter
         (binding.rvMessageList.layoutManager as LinearLayoutManager).stackFromEnd = true
-    }
-
-    private fun setupMessageReceiver() {
-        registerReceiver(messageReceiver, MessageReceiver.getIntentFilter())
     }
 
     private fun handleEvent(event: MessageRoomViewModel.MessageRoomEvent) {
@@ -125,6 +120,25 @@ class MessageRoomActivity :
                 getString(R.string.message_room_send_message_failed)
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        registerMessageReceiver()
+        if (viewModel.messageRoomInfo.value != null) viewModel.loadMessages()
+    }
+
+    private fun registerMessageReceiver() {
+        registerReceiver(messageReceiver, MessageReceiver.getIntentFilter())
+    }
+
+    override fun onStop() {
+        super.onStop()
+        unregisterMessageReceiver()
+    }
+
+    private fun unregisterMessageReceiver() {
+        unregisterReceiver(messageReceiver)
     }
 
     companion object {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
@@ -35,7 +35,11 @@ class MessageRoomActivity :
     private val adapter by lazy { ConcatAdapter(roomCreatedNotifyAdapter, messageAdapter) }
 
     private val messageReceiver: MessageReceiver by lazy {
-        MessageReceiver(viewModel::loadMessages)
+        MessageReceiver { messageRoomId ->
+            if (messageRoomId == viewModel.messageRoomInfo.value?.roomId) {
+                viewModel.loadMessages()
+            }
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
@@ -53,7 +53,12 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
         if (remoteMessage.data.isNotEmpty()) {
             if (checkNotificationPermission()) {
                 val notification = createMessageReceivedNotification(remoteMessage) ?: return
-                val intent = Intent(MessageReceiver.MessageAction)
+                val intent = Intent(MessageReceiver.MessageAction).apply {
+                    putExtra(
+                        MessageReceiver.MessageRoomId,
+                        remoteMessage.data["redirectUrl"]?.split("/")?.last()?.toLong() ?: -1,
+                    )
+                }
                 sendBroadcast(intent)
                 notificationManager.notify(System.currentTimeMillis().toInt(), notification)
             }

--- a/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.app.Notification
 import android.app.PendingIntent
 import android.app.PendingIntent.FLAG_IMMUTABLE
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -14,6 +15,7 @@ import com.bumptech.glide.Glide
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.feature.detail.AuctionDetailActivity
 import com.ddangddangddang.android.feature.messageRoom.MessageRoomActivity
+import com.ddangddangddang.android.reciever.MessageReceiver
 import com.ddangddangddang.data.model.request.UpdateDeviceTokenRequest
 import com.ddangddangddang.data.repository.UserRepository
 import com.google.firebase.messaging.FirebaseMessagingService
@@ -51,6 +53,8 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
         if (remoteMessage.data.isNotEmpty()) {
             if (checkNotificationPermission()) {
                 val notification = createMessageReceivedNotification(remoteMessage) ?: return
+                val intent = Intent(MessageReceiver.MessageAction)
+                sendBroadcast(intent)
                 notificationManager.notify(System.currentTimeMillis().toInt(), notification)
             }
         }
@@ -74,7 +78,7 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
                 NotificationType.MESSAGE -> getMessageRoomPendingIntent(remoteMessage)
                 NotificationType.BID -> getAuctionDetailPendingIntent(remoteMessage)
             }
-            
+
             NotificationCompat.Builder(applicationContext, CHANNEL_ID).apply {
                 setSmallIcon(R.drawable.img_logo)
                 setLargeIcon(image)

--- a/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.app.Notification
 import android.app.PendingIntent
 import android.app.PendingIntent.FLAG_IMMUTABLE
-import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -53,13 +52,9 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
         if (remoteMessage.data.isNotEmpty()) {
             if (checkNotificationPermission()) {
                 val notification = createMessageReceivedNotification(remoteMessage) ?: return
-                val intent = Intent(MessageReceiver.MessageAction).apply {
-                    putExtra(
-                        MessageReceiver.MessageRoomId,
-                        remoteMessage.data["redirectUrl"]?.split("/")?.last()?.toLong() ?: -1,
-                    )
-                }
-                sendBroadcast(intent)
+                sendBroadcastToMessageReceiver(
+                    remoteMessage.data["redirectUrl"]?.split("/")?.last()?.toLong() ?: -1,
+                )
                 notificationManager.notify(System.currentTimeMillis().toInt(), notification)
             }
         }
@@ -127,5 +122,10 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
             intent,
             FLAG_IMMUTABLE,
         )
+    }
+
+    private fun sendBroadcastToMessageReceiver(roomId: Long) {
+        val intent = MessageReceiver.getIntent(roomId)
+        sendBroadcast(intent)
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/reciever/MessageReceiver.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/reciever/MessageReceiver.kt
@@ -3,6 +3,7 @@ package com.ddangddangddang.android.reciever
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 
 class MessageReceiver(private val onReceive: (messageRoomId: Long) -> Unit) : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
@@ -13,7 +14,15 @@ class MessageReceiver(private val onReceive: (messageRoomId: Long) -> Unit) : Br
     }
 
     companion object {
-        const val MessageAction = "com.ddangddangddang.android.message.receive.action"
-        const val MessageRoomId = "message_room_id"
+        private const val MessageAction = "com.ddangddangddang.android.message.receive.action"
+        private const val MessageRoomId = "message_room_id"
+
+        fun getIntent(messageRoomId: Long): Intent {
+            return Intent(MessageAction).apply { putExtra(MessageRoomId, messageRoomId) }
+        }
+
+        fun getIntentFilter(): IntentFilter {
+            return IntentFilter().apply { addAction(MessageAction) }
+        }
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/reciever/MessageReceiver.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/reciever/MessageReceiver.kt
@@ -4,14 +4,16 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 
-class MessageReceiver(private val onReceive: () -> Unit) : BroadcastReceiver() {
+class MessageReceiver(private val onReceive: (messageRoomId: Long) -> Unit) : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
         if (MessageAction == intent?.action) {
-            onReceive()
+            val messageRoomId = intent.getLongExtra(MessageRoomId, -1L)
+            onReceive(messageRoomId)
         }
     }
 
     companion object {
         const val MessageAction = "com.ddangddangddang.android.message.receive.action"
+        const val MessageRoomId = "message_room_id"
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/reciever/MessageReceiver.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/reciever/MessageReceiver.kt
@@ -1,0 +1,17 @@
+package com.ddangddangddang.android.reciever
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class MessageReceiver(private val onReceive: () -> Unit) : BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (MessageAction == intent?.action) {
+            onReceive()
+        }
+    }
+
+    companion object {
+        const val MessageAction = "com.ddangddangddang.android.message.receive.action"
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
브로드 캐스트 리시버를 활용해서, fcm 수신시 해당 메시지 룸 id를 담은 인텐트와 액션을 담아서 방송을 송신함. 
MessageRoomActivity에서는 동적으로 브로드캐스트리시버를 등록해서 이 액티비티가 있는 동안에만 수신해줌.

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
아래처럼, 사용하기 쉽게 만들어놔서, 다른 곳에서도 메시지 수신이 필요하면 사용해볼 수 있을 것 같네요. 일단은 MessageRoomActivity에만 적용했습니다. MessageFragment도 받도록 해서 메시지 오면 메시지 방 리스트 갱신하는 것도 좋을 것 같네요
![image](https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/ed386c1f-bd9a-4f03-9373-253c9787035e)
![image](https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/3bc66cb8-f766-41f5-b111-ace477044dd2)
여기서 빨간 박스 친 부분은 나중에 글로꺼 머지되고 수정하면 좋을 것 같습니다. 이번에 글로쪽 pr에서도 많이 바뀐 것 같아서 현재 구조를 괜히 함수 분리로 건들였다가 머지 할때 충돌 날거 같네요

## 📎 Issue 번호
- close: #528 