### PR TITLE
알림 태그와 아이디가 같은 알림 쌓는 기능 및 알림 관련 페이지 이동 시 알림 취소 기능 구현

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
@@ -14,6 +14,8 @@ import com.ddangddangddang.android.feature.messageRoom.MessageRoomActivity
 import com.ddangddangddang.android.feature.report.ReportActivity
 import com.ddangddangddang.android.model.RegionModel
 import com.ddangddangddang.android.model.ReportType
+import com.ddangddangddang.android.notification.NotificationType
+import com.ddangddangddang.android.notification.cancelActiveNotification
 import com.ddangddangddang.android.util.binding.BindingActivity
 import com.ddangddangddang.android.util.view.Toaster
 import com.ddangddangddang.android.util.view.observeLoadingWithDialog
@@ -25,11 +27,11 @@ import dagger.hilt.android.AndroidEntryPoint
 class AuctionDetailActivity :
     BindingActivity<ActivityAuctionDetailBinding>(R.layout.activity_auction_detail) {
     private val viewModel: AuctionDetailViewModel by viewModels()
+    private val auctionId: Long by lazy { intent.getLongExtra(AUCTION_ID_KEY, -1L) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.viewModel = viewModel
-        val auctionId = intent.getLongExtra(AUCTION_ID_KEY, -1L)
         setupViewModel()
 
         if (savedInstanceState == null) viewModel.loadAuctionDetail(auctionId)
@@ -130,6 +132,15 @@ class AuctionDetailActivity :
 
     private fun setupDirectRegions(regions: List<RegionModel>) {
         binding.rvDirectExchangeRegions.adapter = AuctionDirectRegionsAdapter(regions)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        cancelNotification()
+    }
+
+    private fun cancelNotification() {
+        cancelActiveNotification(NotificationType.BID.name, auctionId.toInt())
     }
 
     companion object {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/messageRoom/MessageRoomActivity.kt
@@ -14,6 +14,8 @@ import com.ddangddangddang.android.feature.report.ReportActivity
 import com.ddangddangddang.android.global.AnalyticsDelegate
 import com.ddangddangddang.android.global.AnalyticsDelegateImpl
 import com.ddangddangddang.android.model.ReportType
+import com.ddangddangddang.android.notification.NotificationType
+import com.ddangddangddang.android.notification.cancelActiveNotification
 import com.ddangddangddang.android.util.binding.BindingActivity
 import com.ddangddangddang.android.util.view.showSnackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -28,11 +30,12 @@ class MessageRoomActivity :
         MessageAdapter { viewModel.messages.value?.let { binding.rvMessageList.scrollToPosition(it.size) } }
     }
     private val adapter by lazy { ConcatAdapter(roomCreatedNotifyAdapter, messageAdapter) }
+    private val roomId: Long by lazy { intent.getLongExtra(ROOM_ID_KEY, -1L) }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         registerAnalytics(javaClass.simpleName, lifecycle)
         binding.viewModel = viewModel
-        val roomId: Long = intent.getLongExtra(ROOM_ID_KEY, -1L)
         if (viewModel.messageRoomInfo.value == null) viewModel.loadMessageRoom(roomId)
         setupViewModel()
         setupMessageRecyclerView()
@@ -98,6 +101,15 @@ class MessageRoomActivity :
                 getString(R.string.message_room_send_message_failed)
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        cancelNotification()
+    }
+
+    private fun cancelNotification() {
+        cancelActiveNotification(NotificationType.MESSAGE.name, roomId.toInt())
     }
 
     companion object {

--- a/android/app/src/main/java/com/ddangddangddang/android/notification/ActiveNotificationManager.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/notification/ActiveNotificationManager.kt
@@ -1,0 +1,17 @@
+package com.ddangddangddang.android.notification
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
+
+internal fun Context.getActiveNotification(tag: String, id: Int): Notification? {
+    val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    return notificationManager.activeNotifications.firstOrNull {
+        it.tag == tag && it.id == id
+    }?.notification
+}
+
+internal fun Context.cancelActiveNotification(tag: String, id: Int) {
+    val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    notificationManager.cancel(tag, id)
+}

--- a/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
@@ -60,17 +60,14 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
         if (checkNotificationPermission()) {
             val type = NotificationType.of(remoteMessage.data["type"] ?: "") ?: return
             val tag = type.name
+            val id = remoteMessage.data["redirectUrl"]?.split("/")?.last()?.toLong() ?: -1
             when (type) {
                 NotificationType.MESSAGE -> {
-                    val id =
-                        remoteMessage.data["redirectUrl"]?.split("/")?.last()?.toLong() ?: -1
                     val notification = createMessageNotification(tag, id, remoteMessage)
                     notificationManager.notify(tag, id.toInt(), notification)
                 }
 
                 NotificationType.BID -> {
-                    val id =
-                        remoteMessage.data["redirectUrl"]?.split("/")?.last()?.toLong() ?: -1
                     val notification = createBidNotification(id, remoteMessage)
                     notificationManager.notify(tag, id.toInt(), notification)
                 }

--- a/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
@@ -8,6 +8,7 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -137,10 +138,14 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
 
     private fun getMessageRoomPendingIntent(id: Long): PendingIntent? {
         val intent = MessageRoomActivity.getIntent(applicationContext, id)
+        return intent.getPendingIntent(id.toInt())
+    }
+
+    private fun Intent.getPendingIntent(requestCode: Int): PendingIntent? {
         return PendingIntent.getActivity(
             applicationContext,
-            id.toInt(),
-            intent,
+            requestCode,
+            this,
             FLAG_IMMUTABLE,
         )
     }
@@ -165,11 +170,6 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
 
     private fun getAuctionDetailPendingIntent(id: Long): PendingIntent? {
         val intent = AuctionDetailActivity.getIntent(applicationContext, id)
-        return PendingIntent.getActivity(
-            applicationContext,
-            id.toInt(),
-            intent,
-            FLAG_IMMUTABLE,
-        )
+        return intent.getPendingIntent(id.toInt())
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
@@ -93,7 +93,7 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
             val image = runCatching {
                 getBitmapFromUrl(remoteMessage.data["image"] ?: "")
             }.getOrDefault(defaultImage)
-            val activeNotification = getActiveNotification(tag, id)
+            val activeNotification = getActiveNotification(tag, id.toInt())
             val currentLine = remoteMessage.data["body"] ?: ""
             val pendingIntent =
                 activeNotification?.contentIntent ?: getMessageRoomPendingIntent(id)
@@ -109,12 +109,6 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
                 setAutoCancel(true)
             }.build()
         }
-    }
-
-    private fun getActiveNotification(tag: String, id: Long): Notification? {
-        return notificationManager.activeNotifications.firstOrNull {
-            it.tag == tag && it.id == id.toInt()
-        }?.notification
     }
 
     private fun getMessageInboxStyle(

--- a/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
@@ -2,14 +2,16 @@ package com.ddangddangddang.android.notification
 
 import android.Manifest
 import android.app.Notification
+import android.app.Notification.EXTRA_TEXT_LINES
+import android.app.Notification.InboxStyle
+import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.PendingIntent.FLAG_IMMUTABLE
+import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Build
-import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
 import com.bumptech.glide.Glide
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.feature.detail.AuctionDetailActivity
@@ -29,7 +31,7 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
     @Inject
     lateinit var userRepository: UserRepository
 
-    private val notificationManager by lazy { NotificationManagerCompat.from(applicationContext) }
+    private val notificationManager by lazy { getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager }
 
     private val defaultImage: Bitmap by lazy {
         BitmapFactory.decodeResource(
@@ -56,19 +58,20 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
     private fun notifyNotification(remoteMessage: RemoteMessage) {
         if (checkNotificationPermission()) {
             val type = NotificationType.of(remoteMessage.data["type"] ?: "") ?: return
+            val tag = type.name
             when (type) {
                 NotificationType.MESSAGE -> {
                     val id =
                         remoteMessage.data["redirectUrl"]?.split("/")?.last()?.toLong() ?: -1
-                    val notification = createMessageNotification(id, remoteMessage)
-                    notificationManager.notify(type.name, id.toInt(), notification)
+                    val notification = createMessageNotification(tag, id, remoteMessage)
+                    notificationManager.notify(tag, id.toInt(), notification)
                 }
 
                 NotificationType.BID -> {
                     val id =
                         remoteMessage.data["redirectUrl"]?.split("/")?.last()?.toLong() ?: -1
                     val notification = createBidNotification(id, remoteMessage)
-                    notificationManager.notify(type.name, id.toInt(), notification)
+                    notificationManager.notify(tag, id.toInt(), notification)
                 }
             }
         }
@@ -81,39 +84,50 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
         return notificationManager.areNotificationsEnabled()
     }
 
-    private fun createMessageNotification(id: Long, remoteMessage: RemoteMessage): Notification {
+    private fun createMessageNotification(
+        tag: String,
+        id: Long,
+        remoteMessage: RemoteMessage,
+    ): Notification {
         return runBlocking {
             val image = runCatching {
                 getBitmapFromUrl(remoteMessage.data["image"] ?: "")
             }.getOrDefault(defaultImage)
-            val pendingIntent = getMessageRoomPendingIntent(id)
+            val activeNotification = getActiveNotification(tag, id)
+            val currentLine = remoteMessage.data["body"] ?: ""
+            val pendingIntent =
+                activeNotification?.contentIntent ?: getMessageRoomPendingIntent(id)
 
-            NotificationCompat.Builder(applicationContext, CHANNEL_ID).apply {
+            Notification.Builder(applicationContext, CHANNEL_ID).apply {
                 setSmallIcon(R.drawable.img_logo)
                 setLargeIcon(image)
+                setShowWhen(true)
                 setContentTitle(remoteMessage.data["title"])
-                setContentText(remoteMessage.data["body"])
+                setContentText(currentLine)
+                style = getMessageInboxStyle(activeNotification, currentLine)
                 setContentIntent(pendingIntent)
                 setAutoCancel(true)
             }.build()
         }
     }
 
-    private fun createBidNotification(id: Long, remoteMessage: RemoteMessage): Notification {
-        return runBlocking {
-            val image = runCatching {
-                getBitmapFromUrl(remoteMessage.data["image"] ?: "")
-            }.getOrDefault(defaultImage)
-            val pendingIntent = getAuctionDetailPendingIntent(id)
+    private fun getActiveNotification(tag: String, id: Long): Notification? {
+        return notificationManager.activeNotifications.firstOrNull {
+            it.tag == tag && it.id == id.toInt()
+        }?.notification
+    }
 
-            NotificationCompat.Builder(applicationContext, CHANNEL_ID).apply {
-                setSmallIcon(R.drawable.img_logo)
-                setLargeIcon(image)
-                setContentTitle(remoteMessage.data["title"])
-                setContentText(remoteMessage.data["body"])
-                setContentIntent(pendingIntent)
-                setAutoCancel(true)
-            }.build()
+    private fun getMessageInboxStyle(
+        activeNotification: Notification?,
+        currentLine: String,
+    ): InboxStyle {
+        val previousLines =
+            activeNotification?.extras?.getCharSequenceArray(EXTRA_TEXT_LINES) ?: emptyArray()
+        val lines = previousLines.plus(currentLine)
+
+        return InboxStyle().apply {
+            lines.forEach { addLine(it) }
+            setSummaryText("${lines.size}개의 메시지")
         }
     }
 
@@ -135,6 +149,24 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
             intent,
             FLAG_IMMUTABLE,
         )
+    }
+
+    private fun createBidNotification(id: Long, remoteMessage: RemoteMessage): Notification {
+        return runBlocking {
+            val image = runCatching {
+                getBitmapFromUrl(remoteMessage.data["image"] ?: "")
+            }.getOrDefault(defaultImage)
+            val pendingIntent = getAuctionDetailPendingIntent(id)
+
+            Notification.Builder(applicationContext, CHANNEL_ID).apply {
+                setSmallIcon(R.drawable.img_logo)
+                setLargeIcon(image)
+                setContentTitle(remoteMessage.data["title"])
+                setContentText(remoteMessage.data["body"])
+                setContentIntent(pendingIntent)
+                setAutoCancel(true)
+            }.build()
+        }
     }
 
     private fun getAuctionDetailPendingIntent(id: Long): PendingIntent? {


### PR DESCRIPTION
## 📄 작업 내용 요약
- 메시지 알림
  채팅방 아이디가 같은 알림이 이미 존재하는 경우, InboxStyle의 확장형 알림을 구현하였습니다.
  채팅방으로 이동 시, 채팅방과 관련된 활성화 알림을 취소하도록 했습니다.
- 경매 알림
  경매방 아이디가 같은 알림이 이미 존재하는 경우, 기존의 알림을 덮어씌우도록 하였습니다.
  경매 알림의 경우, 사용자가 경매방으로 이동하여 새로 입찰하지 않는 한 새로운 알림이 오지 않기 때문에 위와 같이 구현했습니다.
  경매방으로 이동 시, 경매방과 관련된 활성화 알림을 취소하도록 했습니다. 

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
### 알림 쌓기 기능
```kotlin
internal fun Context.getActiveNotification(tag: String, id: Int): Notification? {
    val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
    return notificationManager.activeNotifications.firstOrNull {
        it.tag == tag && it.id == id
    }?.notification
}
```
=> 활성화된 알림 중 태그와 아이디가 같은 알림이 있다면 가져오는 코드입니다.
```kotlin
val previousLines =
            activeNotification?.extras?.getCharSequenceArray(EXTRA_TEXT_LINES) ?: emptyArray()
```
=> 태그와 아이디가 같은 알림의 InboxStyle에 addLine 함수로 추가된 문자열을 배열로 가져옵니다.
```kotlin
val pendingIntent =
                activeNotification?.contentIntent ?: getMessageRoomPendingIntent(id)
```
=> 태그와 아이디가 같은 알림이 있다면 해당 알림의 contentIntent를 가져오고 아니라면 새로운 pendingIntent를 가져옵니다.
```kotlin
setContentText(currentLine)
```
=> InboxStyle에서 addLine을 해줌에도 setContentText를 설정하는 이유는 알림을 받은 즉시 휴대폰 위에 띄우는 알림의 ContentText를 지정해주기 위함입니다.
```kotlin
setShowWhen(true)
```
=> 알림을 받은 시각을 시스템 시간으로 표시해줍니다.

### 알림 취소 기능
- ActiveNotificationManager에는 ActiveNotification을 가져오고 취소하는 함수를 정의해 두었습니다.
- 채팅방과 경매방 이동 시 onResume에서 활성화된 알림을 취소하고 있습니다. 활성화된 알림 취소를 위해 roomId와 auctionId가 필요하기 때문에 각 화면의 프로퍼티로 선언하고 by lazy를 이용했습니다.

## 📎 Issue 번호
- close: #527 
