### PR TITLE
warn, error 레벨 로그 포맷 변경

### DIFF
--- a/backend/ddang/src/main/java/com/ddang/ddang/exception/GlobalExceptionHandler.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/exception/GlobalExceptionHandler.java
@@ -30,6 +30,7 @@ import com.ddang.ddang.report.application.exception.InvalidChatRoomReportExcepti
 import com.ddang.ddang.report.application.exception.InvalidReportAuctionException;
 import com.ddang.ddang.report.application.exception.InvalidReporterToAuctionException;
 import com.ddang.ddang.user.application.exception.UserNotFoundException;
+import java.net.MalformedURLException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -40,12 +41,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import java.net.MalformedURLException;
-
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
-    private static final String EXCEPTION_FORMAT = "%s : ";
+    private static final String LOG_MESSAGE_FORMAT = "%s : %s";
 
     @Override
     protected ResponseEntity<Object> handleExceptionInternal(
@@ -55,15 +54,22 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             final HttpStatusCode statusCode,
             final WebRequest request
     ) {
-        logger.error(String.format(EXCEPTION_FORMAT, ex.getClass()
-                                                       .getSimpleName()), ex);
+        logger.error(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()), ex);
 
         return super.handleExceptionInternal(ex, body, headers, statusCode, request);
     }
 
+    @ExceptionHandler(MalformedURLException.class)
+    public ResponseEntity<ExceptionResponse> handleMalformedURLException(final MalformedURLException ex) {
+        logger.error(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()), ex);
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                             .body(new ExceptionResponse("이미지 조회에 실패했습니다."));
+    }
+
     @ExceptionHandler(CategoryNotFoundException.class)
     public ResponseEntity<ExceptionResponse> handleCategoryNotFoundException(final CategoryNotFoundException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, CategoryNotFoundException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -71,7 +77,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(RegionNotFoundException.class)
     public ResponseEntity<ExceptionResponse> handleRegionNotFoundException(final RegionNotFoundException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, RegionNotFoundException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -79,7 +85,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(ChatRoomNotFoundException.class)
     public ResponseEntity<ExceptionResponse> handleChatRoomNotFoundException(final ChatRoomNotFoundException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, ChatRoomNotFoundException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -87,7 +93,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(MessageNotFoundException.class)
     public ResponseEntity<ExceptionResponse> handleMessageNotFoundException(final MessageNotFoundException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, MessageNotFoundException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -95,7 +101,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(UnableToChatException.class)
     public ResponseEntity<ExceptionResponse> handleUnableToChatException(final UnableToChatException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, UnableToChatException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -103,7 +109,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ExceptionResponse> handleUserNotFoundException(final UserNotFoundException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, UserNotFoundException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -111,7 +117,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(AuctionNotFoundException.class)
     public ResponseEntity<ExceptionResponse> handleAuctionNotFoundException(final AuctionNotFoundException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, AuctionNotFoundException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -119,7 +125,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(InvalidBidException.class)
     public ResponseEntity<ExceptionResponse> handleInvalidBidException(final InvalidBidException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, InvalidBidException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -129,7 +135,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<ExceptionResponse> handleUserNotAuthorizationException(
             final UserForbiddenException ex
     ) {
-        logger.warn(String.format(EXCEPTION_FORMAT, UserForbiddenException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -139,7 +145,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<ExceptionResponse> handleInaccessibleWithdrawalException(
             final InvalidWithdrawalException ex
     ) {
-        logger.warn(String.format(EXCEPTION_FORMAT, InvalidWithdrawalException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -149,7 +155,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<ExceptionResponse> handleInvalidPriceValueException(
             final InvalidPriceValueException ex
     ) {
-        logger.warn(String.format(EXCEPTION_FORMAT, InvalidPriceValueException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -157,7 +163,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(EmptyImageException.class)
     public ResponseEntity<ExceptionResponse> handleEmptyImageException(final EmptyImageException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, EmptyImageException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -167,7 +173,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<ExceptionResponse> handleStoreImageFailureException(
             final StoreImageFailureException ex
     ) {
-        logger.error(String.format(EXCEPTION_FORMAT, StoreImageFailureException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -177,7 +183,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<ExceptionResponse> handleUnsupportedImageFileExtensionException(
             final UnsupportedImageFileExtensionException ex
     ) {
-        logger.warn(String.format(EXCEPTION_FORMAT, UnsupportedImageFileExtensionException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -185,25 +191,17 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(ImageNotFoundException.class)
     public ResponseEntity<ExceptionResponse> handleImageNotFoundException(final ImageNotFoundException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, ImageNotFoundException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                              .body(new ExceptionResponse(ex.getMessage()));
-    }
-
-    @ExceptionHandler(MalformedURLException.class)
-    public ResponseEntity<ExceptionResponse> handleMalformedURLException(final MalformedURLException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, MalformedURLException.class), ex);
-
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                             .body(new ExceptionResponse("이미지 조회에 실패했습니다."));
     }
 
     @ExceptionHandler(InvalidUserToChat.class)
     public ResponseEntity<ExceptionResponse> handleUserNotAccessibleException(
             final InvalidUserToChat ex
     ) {
-        logger.warn(String.format(EXCEPTION_FORMAT, InvalidUserToChat.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -213,7 +211,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<ExceptionResponse> handleWinnerNotFoundException(
             final WinnerNotFoundException ex
     ) {
-        logger.warn(String.format(EXCEPTION_FORMAT, WinnerNotFoundException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -223,7 +221,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<ExceptionResponse> handleInvalidAuctionToChatException(
             final InvalidAuctionToChatException ex
     ) {
-        logger.warn(String.format(EXCEPTION_FORMAT, InvalidAuctionToChatException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -232,7 +230,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(InvalidReporterToAuctionException.class)
     public ResponseEntity<ExceptionResponse> handleInvalidReporterToAuctionException(
             final InvalidReporterToAuctionException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, InvalidReporterToAuctionException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -241,7 +239,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(InvalidReportAuctionException.class)
     public ResponseEntity<ExceptionResponse> handleInvalidReportAuctionException(
             final InvalidReportAuctionException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, InvalidReportAuctionException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -250,7 +248,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(AlreadyReportAuctionException.class)
     public ResponseEntity<ExceptionResponse> handleAlreadyReportAuctionException(
             final AlreadyReportAuctionException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, AlreadyReportAuctionException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -259,7 +257,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(InvalidChatRoomReportException.class)
     public ResponseEntity<ExceptionResponse> handleChatRoomReportNotAccessibleExceptionException(
             final InvalidChatRoomReportException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, InvalidChatRoomReportException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -268,7 +266,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(AlreadyReportChatRoomException.class)
     public ResponseEntity<ExceptionResponse> handleAlreadyReportChatRoomException(
             final AlreadyReportChatRoomException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, AlreadyReportChatRoomException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -276,7 +274,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(InvalidTokenException.class)
     public ResponseEntity<ExceptionResponse> handleInvalidTokenException(final InvalidTokenException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, InvalidTokenException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -286,7 +284,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<ExceptionResponse> handleUnsupportedSocialLoginException(
             final UnsupportedSocialLoginException ex
     ) {
-        logger.warn(String.format(EXCEPTION_FORMAT, UnsupportedSocialLoginException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -294,7 +292,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(UserUnauthorizedException.class)
     public ResponseEntity<ExceptionResponse> handleUserUnauthorizedException(final UserUnauthorizedException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, UserUnauthorizedException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -303,7 +301,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(InvalidSearchConditionException.class)
     public ResponseEntity<ExceptionResponse> handleInvalidSearchConditionException(
             final InvalidSearchConditionException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, UserUnauthorizedException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -311,7 +309,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(NotificationFailedException.class)
     public ResponseEntity<ExceptionResponse> handleNotificationFailedException(final NotificationFailedException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, NotificationFailedException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -319,7 +317,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(DeviceTokenNotFoundException.class)
     public ResponseEntity<ExceptionResponse> handleDeviceTokenNotFoundException(final DeviceTokenNotFoundException ex) {
-        logger.warn(String.format(EXCEPTION_FORMAT, DeviceTokenNotFoundException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                              .body(new ExceptionResponse(ex.getMessage()));
@@ -328,11 +326,11 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(
             final MethodArgumentNotValidException ex,
-            final HttpHeaders headers,
-            final HttpStatusCode status,
-            final WebRequest request
+            final HttpHeaders ignoredHeaders,
+            final HttpStatusCode ignoredStatus,
+            final WebRequest ignoredRequest
     ) {
-        logger.info(String.format(EXCEPTION_FORMAT, MethodArgumentNotValidException.class), ex);
+        logger.warn(String.format(LOG_MESSAGE_FORMAT, ex.getClass().getSimpleName(), ex.getMessage()));
 
         final String message = ex.getFieldErrors().get(0).getDefaultMessage();
 

--- a/backend/ddang/src/main/resources/application.yml
+++ b/backend/ddang/src/main/resources/application.yml
@@ -9,9 +9,9 @@ spring:
         - file-warn-logging
         - file-error-logging
         - slack-error-logging
-        - file-info-request-trace
+        - file-info-request-logging
       prod:
         - file-warn-logging
         - file-error-logging
         - slack-error-logging
-        - file-info-request-trace
+        - file-info-request-logging

--- a/backend/ddang/src/main/resources/log/console-logging.xml
+++ b/backend/ddang/src/main/resources/log/console-logging.xml
@@ -1,0 +1,16 @@
+<included>
+  <springProfile name="console-logging">
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>INFO</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <root level="info">
+      <appender-ref ref="CONSOLE"/>
+    </root>
+  </springProfile>
+</included>

--- a/backend/ddang/src/main/resources/log/file-error-logging.xml
+++ b/backend/ddang/src/main/resources/log/file-error-logging.xml
@@ -1,0 +1,42 @@
+<included>
+  <springProfile name="file-error-logging">
+    <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>${LOG_DIR}/error/error-${BY_DATE}.log</file>
+
+      <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+        <level>ERROR</level>
+      </filter>
+
+      <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+        <providers>
+          <timestamp>
+            <fieldName>timeStamp</fieldName>
+            <pattern>yyyy-MM-dd HH:mm:ss</pattern>
+          </timestamp>
+          <mdc/>
+          <pattern>
+            <pattern>
+              {
+              "message": "%message",
+              "stacktrace": "%rEx"
+              }
+            </pattern>
+          </pattern>
+        </providers>
+        <charset>utf-8</charset>
+      </encoder>
+
+      <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+        <fileNamePattern>${LOG_DIR}/backup/error/error-%d{yyyy-MM-dd}.%i.log
+        </fileNamePattern>
+        <maxFileSize>100MB</maxFileSize>
+        <maxHistory>30</maxHistory>
+        <totalSizeCap>3GB</totalSizeCap>
+      </rollingPolicy>
+    </appender>
+
+    <root level="info">
+      <appender-ref ref="FILE-ERROR"/>
+    </root>
+  </springProfile>
+</included>

--- a/backend/ddang/src/main/resources/log/file-info-request-logging.xml
+++ b/backend/ddang/src/main/resources/log/file-info-request-logging.xml
@@ -1,0 +1,34 @@
+<included>
+  <springProfile name="file-info-request-logging">
+    <appender name="FILE-INFO_REQUEST-TRACE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>${LOG_DIR}/request-trace/trace-${BY_DATE}.log</file>
+
+      <filter class="ch.qos.logback.classic.filter.LevelFilter">
+        <level>INFO</level>
+        <onMatch>ACCEPT</onMatch>
+        <onMismatch>DENY</onMismatch>
+      </filter>
+
+      <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+        <providers>
+          <timestamp/>
+          <mdc/>
+          <message/>
+        </providers>
+        <timestampPattern>yyyy-MM-dd HH:mm:ss.SSSSSS</timestampPattern>
+        <charset>utf8</charset>
+      </encoder>
+
+      <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+        <fileNamePattern>${LOG_DIR}/backup/request-trace/trace-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+        <maxFileSize>100MB</maxFileSize>
+        <maxHistory>30</maxHistory>
+        <totalSizeCap>3GB</totalSizeCap>
+      </rollingPolicy>
+    </appender>
+
+    <root level="info">
+      <appender-ref ref="FILE-INFO_REQUEST-TRACE"/>
+    </root>
+  </springProfile>
+</included>

--- a/backend/ddang/src/main/resources/log/file-warn-logging.xml
+++ b/backend/ddang/src/main/resources/log/file-warn-logging.xml
@@ -1,0 +1,36 @@
+<included>
+  <springProfile name="file-warn-logging">
+    <appender name="FILE-WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>${LOG_DIR}/warn/warn-${BY_DATE}.log</file>
+
+      <filter class="ch.qos.logback.classic.filter.LevelFilter">
+        <level>WARN</level>
+        <onMatch>ACCEPT</onMatch>
+        <onMismatch>DENY</onMismatch>
+      </filter>
+
+      <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+        <providers>
+          <timestamp>
+            <fieldName>timeStamp</fieldName>
+            <pattern>yyyy-MM-dd HH:mm:ss</pattern>
+          </timestamp>
+          <mdc/>
+          <message/>
+        </providers>
+        <charset>utf-8</charset>
+      </encoder>
+
+      <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+        <fileNamePattern>${LOG_DIR}/backup/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+        <maxFileSize>100MB</maxFileSize>
+        <maxHistory>30</maxHistory>
+        <totalSizeCap>3GB</totalSizeCap>
+      </rollingPolicy>
+    </appender>
+
+    <root level="info">
+      <appender-ref ref="FILE-WARN"/>
+    </root>
+  </springProfile>
+</included>

--- a/backend/ddang/src/main/resources/log/slack-error-logging.xml
+++ b/backend/ddang/src/main/resources/log/slack-error-logging.xml
@@ -1,0 +1,17 @@
+<included>
+  <springProfile name="slack-error-logging">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>ERROR</level>
+    </filter>
+
+    <appender name="SLACK_APPENDER" class="com.ddang.ddang.configuration.log.SlackAppender" />
+
+    <appender name="ASYNC_SLACK_APPENDER" class="ch.qos.logback.classic.AsyncAppender">
+      <appender-ref ref="SLACK_APPENDER"/>
+    </appender>
+
+    <root level="info">
+      <appender-ref ref="ASYNC_SLACK_APPENDER"/>
+    </root>
+  </springProfile>
+</included>

--- a/backend/ddang/src/main/resources/logback-spring.xml
+++ b/backend/ddang/src/main/resources/logback-spring.xml
@@ -1,117 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <configuration scan="true">
-
     <springProperty scope="context" name="LOG_DIR" source="log.directory"/>
     <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
-    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
 
-    <springProfile name="console-logging">
-        <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
-        <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+    <include resource="./log/console-logging.xml" />
+    <include resource="./log/file-error-logging.xml" />
+    <include resource="./log/file-info-request-logging.xml"/>
+    <include resource="./log/file-warn-logging.xml"/>
+    <include resource="./log/slack-error-logging.xml"/>
 
-        <root level="info">
-            <appender-ref ref="CONSOLE"/>
-        </root>
-    </springProfile>
-
-    <springProfile name="file-info-request-trace">
-        <appender name="FILE-INFO_REQUEST-TRACE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>${LOG_DIR}/request-trace/trace-${BY_DATE}.log</file>
-            <filter class="ch.qos.logback.classic.filter.LevelFilter">
-                <level>INFO</level>
-                <onMatch>ACCEPT</onMatch>
-                <onMismatch>DENY</onMismatch>
-            </filter>
-
-            <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-                <providers>
-                    <timestamp/>
-                    <mdc/>
-                    <message/>
-                </providers>
-                <timestampPattern>yyyy-MM-dd HH:mm:ss.SSSSSS</timestampPattern>
-                <charset>utf8</charset>
-                <jsonGeneratorDecorator class="net.logstash.logback.decorate.CompositeJsonGeneratorDecorator">
-                    <decorator class="net.logstash.logback.decorate.PrettyPrintingJsonGeneratorDecorator"/>
-                </jsonGeneratorDecorator>
-            </encoder>
-
-            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-                <fileNamePattern>${LOG_DIR}/backup/request-trace/trace-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-                <maxFileSize>100MB</maxFileSize>
-                <maxHistory>30</maxHistory>
-                <totalSizeCap>3GB</totalSizeCap>
-            </rollingPolicy>
-        </appender>
-
-        <root>
-            <appender-ref ref="FILE-INFO_REQUEST-TRACE"/>
-        </root>
-    </springProfile>
-
-    <springProfile name="file-warn-logging">
-        <appender name="FILE-WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>${LOG_DIR}/warn/warn-${BY_DATE}.log</file>
-            <filter class="ch.qos.logback.classic.filter.LevelFilter">
-                <level>WARN</level>
-                <onMatch>ACCEPT</onMatch>
-                <onMismatch>DENY</onMismatch>
-            </filter>
-            <encoder>
-                <pattern>${LOG_PATTERN}</pattern>
-                <charset>utf8</charset>
-            </encoder>
-            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-                <fileNamePattern>${LOG_DIR}/backup/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-                <maxFileSize>100MB</maxFileSize>
-                <maxHistory>30</maxHistory>
-                <totalSizeCap>3GB</totalSizeCap>
-            </rollingPolicy>
-        </appender>
-
-        <root>
-            <appender-ref ref="FILE-WARN"/>
-        </root>
-    </springProfile>
-
-    <springProfile name="file-error-logging">
-        <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>${LOG_DIR}/error/error-${BY_DATE}.log</file>
-            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                <level>ERROR</level>
-            </filter>
-            <encoder>
-                <pattern>${LOG_PATTERN}</pattern>
-                <charset>utf8</charset>
-            </encoder>
-            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-                <fileNamePattern>${LOG_DIR}/backup/error/error-%d{yyyy-MM-dd}.%i.log
-                </fileNamePattern>
-                <maxFileSize>100MB</maxFileSize>
-                <maxHistory>30</maxHistory>
-                <totalSizeCap>3GB</totalSizeCap>
-            </rollingPolicy>
-        </appender>
-
-        <root>
-            <appender-ref ref="FILE-ERROR"/>
-        </root>
-    </springProfile>
-
-    <springProfile name="slack-error-logging">
-        <appender name="SLACK_APPENDER" class="com.ddang.ddang.configuration.log.SlackAppender">
-        </appender>
-
-        <appender name="ASYNC_SLACK_APPENDER" class="ch.qos.logback.classic.AsyncAppender">
-            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                <level>ERROR</level>
-            </filter>
-            <appender-ref ref="SLACK_APPENDER"/>
-        </appender>
-
-        <root>
-            <appender-ref ref="ASYNC_SLACK_APPENDER"/>
-        </root>
-    </springProfile>
 </configuration>


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->
- warn, error 레벨 로그 포맷 변경
  - warn, error 레벨 모두 json 형태로 출력하도록 변경했습니다
  - MDC를 통해 어떠한 요청에서 예외가 발생했는지 추적할 수 있도록 설정했습니다 
  - warn은 예외의 stack trace를 출력하지 않도록 했으며 error만 출력하도록 했습니다 
  - GlobalExceptionHandler에서 잘못된 레벨로 로그를 출력하던 내용을 변경했습니다
    - 상태코드 500이었으나 warn 레벨이던걸 error로 변경했습니다
  - logback-spring.xml에서 profile 별로 xml을 분리했습니다 
  - 잘못된 설정값을 수정했습니다
    - timestamp 포맷 설정 방식 변경 
    - json pretty 설정 삭제(\n이 추가되므로 그라파나에서 확인할 때 매우 지저분해짐) 
## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
- closed #530 
<!-- closed #번호 --> 
