### PR TITLE
경매 이미지가 경매 id와 동일한 값으로 전달되는 버그 수정

### DIFF
--- a/backend/ddang/src/main/java/com/ddang/ddang/user/presentation/dto/response/ReadAuctionResponse.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/presentation/dto/response/ReadAuctionResponse.java
@@ -17,11 +17,17 @@ public record ReadAuctionResponse(
         return new ReadAuctionResponse(
                 dto.id(),
                 dto.title(),
-                ImageUrlCalculator.calculateBy(ImageRelativeUrl.AUCTION, dto.id()),
+                calculateThumbnailImageUrl(dto),
                 processAuctionPrice(dto.startPrice(), dto.lastBidPrice()),
                 dto.auctionStatus().name(),
                 dto.auctioneerCount()
         );
+    }
+
+    private static String calculateThumbnailImageUrl(final ReadAuctionDto dto) {
+        final Long thumbnailAuctionImage = dto.auctionImageIds().get(0);
+
+        return ImageUrlCalculator.calculateBy(ImageRelativeUrl.AUCTION, thumbnailAuctionImage);
     }
 
     private static int processAuctionPrice(final Integer startPrice, final Integer lastBidPrice) {


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->
경매 이미지가 경매 id와 동일한 값으로 전달되는 버그
## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
- ReadAuctionResponse에서 발생한 이슈입니다 
- `ImageUrlCalculator.calculateBy(ImageRelativeUrl.AUCTION, dto.id())`처럼 경매 id를 넣어주고 있어서 발생한 이슈였습니다
- 이 부분만 수정했습니다 
## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
- closed #574 
<!-- closed #번호 --> 
