### PR TITLE
하위 버전에서 상세 페이지의 제목 글자 흐르지 않던 문제 해결

### DIFF
--- a/android/app/src/main/res/layout/activity_auction_detail.xml
+++ b/android/app/src/main/res/layout/activity_auction_detail.xml
@@ -60,7 +60,6 @@
                     android:selected="@{true}"
                     android:singleLine="true"
                     android:text="@{viewModel.auctionDetailModel.title}"
-                    android:textIsSelectable="true"
                     tools:text="M1 맥북 에어" />
 
                 <ImageView
@@ -220,11 +219,11 @@
                     android:id="@+id/iv_auctioneer_count_icon"
                     android:layout_width="16dp"
                     android:layout_height="16dp"
+                    android:layout_marginTop="12dp"
                     android:contentDescription="@string/detail_auctioneer_count_icon_description"
                     android:src="@drawable/ic_people_alt_24"
                     app:layout_constraintStart_toStartOf="@id/gl_begin"
                     app:layout_constraintTop_toBottomOf="@id/tv_start_price"
-                    android:layout_marginTop="12dp"
                     app:tint="@color/grey_700" />
 
                 <TextView


### PR DESCRIPTION
## 📄 작업 내용 요약
하위 버전에서 상세 페이지의 제목 글자 흐르지 않던 문제 해결을 위해 찾아본 결과, 글자 흐름과 글자 복사 가능 기능을 같이 넣기 위해서는 핸들러를 사용해서 액티비티가 재개되고 잠시후에 동적으로 수정해야 한다는 자료를 발견했습니다. 하지만, 애초에 상세 페이지에서 제목 복사 기능은 혹시 있으면 좋을 것 같아서 넣었던 코드입니다. 굳이 필수도 아닌데 불안정한 것에 대응하는 코드를 넣을 필요는 없을 것 같다고 느껴져서 복사 기능을 제거했습니다.
https://stackoverflow.com/questions/33872104/setting-textisselectable-on-textview-with-marquee-ellipsize-adds-ellipse

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
없음

## 📎 Issue 번호
- close: #576 
