### PR TITLE
메인 화면에서 백키 핸들러 추가

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainActivity.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.Settings.ACTION_APP_NOTIFICATION_SETTINGS
 import android.provider.Settings.EXTRA_APP_PACKAGE
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.annotation.RequiresApi
@@ -21,6 +22,7 @@ import com.ddangddangddang.android.feature.mypage.MyPageFragment
 import com.ddangddangddang.android.feature.search.SearchFragment
 import com.ddangddangddang.android.global.screenViewLogEvent
 import com.ddangddangddang.android.util.binding.BindingActivity
+import com.ddangddangddang.android.util.view.BackKeyHandler
 import com.ddangddangddang.android.util.view.showDialog
 import com.ddangddangddang.android.util.view.showSnackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -29,6 +31,14 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main) {
     private val viewModel: MainViewModel by viewModels()
     private var isInitialized = false
+    private val backKeyHandler = BackKeyHandler(this)
+
+    private val callback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            if (viewModel.currentFragmentType.value == FragmentType.HOME) return backKeyHandler.onBackPressed()
+            binding.bnvNavigation.selectedItemId = R.id.menu_item_home
+        }
+    }
 
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     private val requestNotificationPermissionLauncher = registerForActivityResult(
@@ -52,8 +62,8 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         binding.viewModel = viewModel
 
         setupViewModel()
-
         askNotificationPermission()
+        onBackPressedDispatcher.addCallback(this, callback)
     }
 
     override fun onResume() {
@@ -80,7 +90,8 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     }
 
     private fun scrollHomeToTop() {
-        val homeFragment = supportFragmentManager.findFragmentByTag(FragmentType.HOME.tag) as? HomeFragment
+        val homeFragment =
+            supportFragmentManager.findFragmentByTag(FragmentType.HOME.tag) as? HomeFragment
         homeFragment?.scrollToTop()
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainActivity.kt
@@ -35,8 +35,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
     private val callback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
-            if (viewModel.currentFragmentType.value == FragmentType.HOME) return backKeyHandler.onBackPressed()
-            binding.bnvNavigation.selectedItemId = R.id.menu_item_home
+            backKeyHandler.onBackPressed()
         }
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainBindingAdapter.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainBindingAdapter.kt
@@ -1,12 +1,24 @@
 package com.ddangddangddang.android.feature.main
 
+import android.util.Log
 import androidx.databinding.BindingAdapter
+import com.ddangddangddang.android.R
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import com.google.android.material.navigation.NavigationBarView
 
 @BindingAdapter("onNavigationItemSelected")
 fun BottomNavigationView.bindOnNavigationItemSelectedListener(
-    listener: NavigationBarView.OnItemSelectedListener,
+    onFragmentChange: (FragmentType) -> Unit,
 ) {
-    this.setOnItemSelectedListener(listener)
+    this.setOnItemSelectedListener { menuItem ->
+        Log.d("mendel", "clickItem: $menuItem")
+        val fragmentType = when (menuItem.itemId) {
+            R.id.menu_item_home -> FragmentType.HOME
+            R.id.menu_item_search -> FragmentType.SEARCH
+            R.id.menu_item_message -> FragmentType.MESSAGE
+            R.id.menu_item_my_page -> FragmentType.MY_PAGE
+            else -> throw IllegalArgumentException("Not found menu item")
+        }
+        onFragmentChange(fragmentType)
+        true
+    }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainBindingAdapter.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainBindingAdapter.kt
@@ -1,6 +1,5 @@
 package com.ddangddangddang.android.feature.main
 
-import android.util.Log
 import androidx.databinding.BindingAdapter
 import com.ddangddangddang.android.R
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -10,7 +9,6 @@ fun BottomNavigationView.bindOnNavigationItemSelectedListener(
     onFragmentChange: (FragmentType) -> Unit,
 ) {
     this.setOnItemSelectedListener { menuItem ->
-        Log.d("mendel", "clickItem: $menuItem")
         val fragmentType = when (menuItem.itemId) {
             R.id.menu_item_home -> FragmentType.HOME
             R.id.menu_item_search -> FragmentType.SEARCH

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainViewModel.kt
@@ -1,10 +1,8 @@
 package com.ddangddangddang.android.feature.main
 
-import android.view.MenuItem
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import com.ddangddangddang.android.R
 import com.ddangddangddang.android.util.livedata.SingleLiveEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -19,22 +17,8 @@ class MainViewModel @Inject constructor() : ViewModel() {
     val event: LiveData<MainEvent>
         get() = _event
 
-    fun setCurrentFragment(item: MenuItem): Boolean {
-        val menuItemId = item.itemId
-        val pageType = getPageType(menuItemId)
-        changeCurrentFragmentType(pageType)
-
-        return true
-    }
-
-    private fun getPageType(menuItemId: Int): FragmentType {
-        return when (menuItemId) {
-            R.id.menu_item_home -> FragmentType.HOME
-            R.id.menu_item_search -> FragmentType.SEARCH
-            R.id.menu_item_message -> FragmentType.MESSAGE
-            R.id.menu_item_my_page -> FragmentType.MY_PAGE
-            else -> throw IllegalArgumentException("Not found menu item")
-        }
+    val fragmentChange = { fragmentType: FragmentType ->
+        changeCurrentFragmentType(fragmentType)
     }
 
     private fun changeCurrentFragmentType(fragmentType: FragmentType) {

--- a/android/app/src/main/java/com/ddangddangddang/android/util/view/BackKeyHandler.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/util/view/BackKeyHandler.kt
@@ -1,0 +1,16 @@
+package com.ddangddangddang.android.util.view
+
+import android.app.Activity
+import com.ddangddangddang.android.R
+
+class BackKeyHandler(val activity: Activity) {
+    private var backPressedTime = 0L
+    fun onBackPressed() {
+        if (System.currentTimeMillis() > (backPressedTime + 2000)) {
+            backPressedTime = System.currentTimeMillis()
+            Toaster.showShort(activity, activity.getString(R.string.all_back_key_check_message))
+        } else if (System.currentTimeMillis() <= (backPressedTime + 2000)) {
+            activity.finish()
+        }
+    }
+}

--- a/android/app/src/main/java/com/ddangddangddang/android/util/view/BackKeyHandler.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/util/view/BackKeyHandler.kt
@@ -6,10 +6,10 @@ import com.ddangddangddang.android.R
 class BackKeyHandler(val activity: Activity) {
     private var backPressedTime = 0L
     fun onBackPressed() {
-        if (System.currentTimeMillis() > (backPressedTime + 2000)) {
+        if ((System.currentTimeMillis() - backPressedTime) > 2000L) {
             backPressedTime = System.currentTimeMillis()
             Toaster.showShort(activity, activity.getString(R.string.all_back_key_check_message))
-        } else if (System.currentTimeMillis() <= (backPressedTime + 2000)) {
+        } else {
             activity.finish()
         }
     }

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -35,7 +35,7 @@
 
         <com.google.android.material.bottomnavigation.BottomNavigationView
             android:id="@+id/bnv_navigation"
-            onNavigationItemSelected="@{viewModel::setCurrentFragment}"
+            onNavigationItemSelected="@{viewModel.fragmentChange}"
             android:layout_width="0dp"
             android:layout_height="65dp"
             app:backgroundTint="@color/base_background"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="all_date_format">yyyy년 M월 d일</string>
     <string name="all_time_format">h:mm a</string>
     <string name="all_default_reliability">( - )</string>
+    <string name="all_back_key_check_message">\'뒤로\' 버튼을 한번 더 누르시면 종료됩니다</string>
 
     <!-- splash -->
     <string name="splash_app_update_request_dialog_title">업데이트 알림</string>


### PR DESCRIPTION
## 📄 작업 내용 요약
메인 화면에서 뒤로가기 누를때 처리 로직 추가
- 홈이면, 뒤로 가기 두 번 눌러야 종료되는 로직 시작
- 홈이 아니면, 홈으로 이동.

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
![image](https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/c5fb015b-ddef-43a7-a43e-c789865d52fe)
뒤로 가기를 2초안에 다시 눌러야 종료되도록 되어있습니다.
![image](https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/d1fa0003-8a98-4a4b-bcf2-a54e50578bb4)
위의 콜백 로직을 보면 알 수 있듯이, 홈 프래그먼트에서 뒤로 두 번을 누르면 종료되도록 되어있습니다.
바텀네비게이션의 selectedId를 바꿔주면, 바텀탭이 이동하고 저희가 등록한 리스너도 호출되어서, 뷰모델이 보관하는 프래그먼트 상태도 바뀌게 됩니다.

## 📎 Issue 번호
- close: #580 

<!-- closed #번호 --> 
