### PR TITLE
경매 상세 페이지에서 이미지 스크롤 좌우 감지 안되던 버그 수정

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
@@ -2,10 +2,8 @@ package com.ddangddangddang.android.feature.detail
 
 import android.content.Context
 import android.content.Intent
-import android.content.res.Resources
 import android.os.Bundle
 import androidx.activity.viewModels
-import androidx.viewpager2.widget.MarginPageTransformer
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.ActivityAuctionDetailBinding
 import com.ddangddangddang.android.feature.common.notifyFailureMessage
@@ -29,6 +27,11 @@ class AuctionDetailActivity :
     BindingActivity<ActivityAuctionDetailBinding>(R.layout.activity_auction_detail) {
     private val viewModel: AuctionDetailViewModel by viewModels()
     private val auctionId: Long by lazy { intent.getLongExtra(AUCTION_ID_KEY, -1L) }
+
+    private val pageMarginPx by lazy {
+        resources.getDimensionPixelOffset(R.dimen.auction_detail_image_page_margin)
+    }
+    private val offsetPx by lazy { resources.getDimensionPixelOffset(R.dimen.auction_detail_image_offset) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -126,20 +129,15 @@ class AuctionDetailActivity :
 
     private fun setupAuctionImages(images: List<String>) {
         binding.vpImageList.apply {
-            clipToPadding = false
-            clipChildren = false
-            offscreenPageLimit = 1
+            offscreenPageLimit = 3
+            setPageTransformer { page, position ->
+                val offset = position * -(2 * offsetPx + pageMarginPx)
+                page.translationX = offset
+            }
             adapter = AuctionImageAdapter(images) { viewModel.navigateToImageDetail(it) }
-            setPageTransformer(MarginPageTransformer(convertDpToPx(20f)))
-            setPadding(200, 0, 200, 0)
         }
 
         TabLayoutMediator(binding.tlIndicator, binding.vpImageList) { _, _ -> }.attach()
-    }
-
-    private fun convertDpToPx(dp: Float): Int {
-        val density = Resources.getSystem().displayMetrics.density
-        return (dp * density + 0.5f).toInt()
     }
 
     private fun setupDirectRegions(regions: List<RegionModel>) {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.viewpager2.widget.ViewPager2
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.ActivityAuctionDetailBinding
 import com.ddangddangddang.android.feature.common.notifyFailureMessage
@@ -27,11 +28,6 @@ class AuctionDetailActivity :
     BindingActivity<ActivityAuctionDetailBinding>(R.layout.activity_auction_detail) {
     private val viewModel: AuctionDetailViewModel by viewModels()
     private val auctionId: Long by lazy { intent.getLongExtra(AUCTION_ID_KEY, -1L) }
-
-    private val pageMarginPx by lazy {
-        resources.getDimensionPixelOffset(R.dimen.auction_detail_image_page_margin)
-    }
-    private val offsetPx by lazy { resources.getDimensionPixelOffset(R.dimen.auction_detail_image_offset) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -130,14 +126,21 @@ class AuctionDetailActivity :
     private fun setupAuctionImages(images: List<String>) {
         binding.vpImageList.apply {
             offscreenPageLimit = 3
-            setPageTransformer { page, position ->
-                val offset = position * -(2 * offsetPx + pageMarginPx)
-                page.translationX = offset
-            }
+            setSideVisiblePageTransformer()
             adapter = AuctionImageAdapter(images) { viewModel.navigateToImageDetail(it) }
         }
 
         TabLayoutMediator(binding.tlIndicator, binding.vpImageList) { _, _ -> }.attach()
+    }
+
+    private fun ViewPager2.setSideVisiblePageTransformer() {
+        val pageMarginPx =
+            resources.getDimensionPixelOffset(R.dimen.auction_detail_image_page_margin)
+        val offsetPx = resources.getDimensionPixelOffset(R.dimen.auction_detail_image_page_offset)
+        setPageTransformer { page, position ->
+            val offset = position * (-2 * pageMarginPx + offsetPx)
+            page.translationX = offset
+        }
     }
 
     private fun setupDirectRegions(regions: List<RegionModel>) {

--- a/android/app/src/main/res/layout/activity_auction_detail.xml
+++ b/android/app/src/main/res/layout/activity_auction_detail.xml
@@ -113,6 +113,8 @@
                 <androidx.viewpager2.widget.ViewPager2
                     android:id="@+id/vp_image_list"
                     android:layout_width="match_parent"
+                    android:clipChildren="false"
+                    android:clipToPadding="false"
                     android:layout_height="250dp"
                     app:layout_constraintTop_toTopOf="parent" />
 

--- a/android/app/src/main/res/layout/item_detail_auction.xml
+++ b/android/app/src/main/res/layout/item_detail_auction.xml
@@ -16,6 +16,7 @@
         imageUrl="@{imageUrl}"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:layout_marginHorizontal="@dimen/auction_detail_image_page_margin_and_offset"
         android:contentDescription="@string/app_name"
         android:onClick="@{()->onImageClickListener.invoke(imageUrl)}"
         android:scaleType="centerCrop" />

--- a/android/app/src/main/res/layout/item_detail_auction.xml
+++ b/android/app/src/main/res/layout/item_detail_auction.xml
@@ -16,7 +16,7 @@
         imageUrl="@{imageUrl}"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginHorizontal="@dimen/auction_detail_image_page_margin_and_offset"
+        android:layout_marginHorizontal="@dimen/auction_detail_image_page_margin"
         android:contentDescription="@string/app_name"
         android:onClick="@{()->onImageClickListener.invoke(imageUrl)}"
         android:scaleType="centerCrop" />

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -11,7 +11,6 @@
     <dimen name="textsize_filter_chips">14sp</dimen>
     <dimen name="textsize_caption">12sp</dimen>
 
-    <dimen name="auction_detail_image_page_margin">20dp</dimen>
-    <dimen name="auction_detail_image_offset">60dp</dimen>
-    <dimen name="auction_detail_image_page_margin_and_offset">80dp</dimen>
+    <dimen name="auction_detail_image_page_offset">20dp</dimen>
+    <dimen name="auction_detail_image_page_margin">80dp</dimen>
 </resources>

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -10,4 +10,8 @@
     <dimen name="textsize_submit_button">18sp</dimen>
     <dimen name="textsize_filter_chips">14sp</dimen>
     <dimen name="textsize_caption">12sp</dimen>
+
+    <dimen name="auction_detail_image_page_margin">20dp</dimen>
+    <dimen name="auction_detail_image_offset">60dp</dimen>
+    <dimen name="auction_detail_image_page_margin_and_offset">80dp</dimen>
 </resources>


### PR DESCRIPTION
## 📄 작업 내용 요약
경매 상세 페이지에서 이미지 스크롤 좌우 감지 안되던 버그 수정

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<img width="514" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/074bfa8b-cdaa-4686-89cd-d80cc2d76f92">

<img width="760" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/1bc5a486-e603-4c1e-b1a9-9ff7964d712f">

<img width="963" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/1fd96ec3-da6b-4ef4-94f1-26c7a0b738d7">

<img width="779" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/ff8f2aeb-2860-4f5c-99a3-775e485a7a3d">

=> 뷰페이저가 스크롤될 때마다, 중앙에서 나가는 녀석들을 강제로 자신쪽으로 이동시킵니다.  들어오는 녀석들도 강제로 자신쪽으로 이동시킵니다. 즉, 만약 우측 이미지로 이동하고 있는 중이라면, 기존에 중앙보다 우측에 있던 이미지는 원래 있어야할 위치보다 x축으로 -만큼 당겨져오고, 기존에 중앙보다 좌측에 있던 이미지는 원래 있어야 할 위치보다 x축으로 +만큼 가게 되어서, 결국에는 기존의 뷰홀더 간 마진 거리보다 가까워지게 됩니다. 이때, 뷰페이저에서 여러 개의 뷰홀더 요소들을 보여주기 위해서는 뷰페이저에 clipToPadding과 clipChildren 값을 false로 줘야 합니다. 이것에 대한 정보는 제가 말로 하는 것보다 블로그를 참고하는 것이 빠를 것 같아서, 제가 아래에 링크도 남겨놓겠습니다. 해당 내용에 대해서는 내일 다시 말씀 드리겠습니다.

참고로 뷰페이저2는 내부적으로 리사이클러뷰를 갖고 있습니다. clipToPadding을 해줘서 뷰페이저에 대한 패딩이 아니라 뷰페이저 안에 있는 스크롤녀석들에 대해 첫번쨰와 마지막 요소에 대해서 패딩을 주게 됩니다, clipChildren을 사용해서 뷰페이저가 그릴 수 있도록 리사이클러뷰에게 원래 제공하는 영역을 넘어서, 사이드에 있는 페이지들에 대해서 뷰페이저 안에 그려질 수 있게 하는 것입니다.
좀 더 확실한 이해는 아래 블로그 짧으니 확인해주시면 될 것 같습니다.

- clipChildren 설명
https://leveloper.tistory.com/175
- clipToPadding 설명
https://parkho79.tistory.com/158


- 참고 자료
https://proandroiddev.com/look-deep-into-viewpager2-13eb8e06e419

## 📎 Issue 번호
- close: #588 
