### PR TITLE
경매 상세 조회 시 경매글을 찾을 수 없을 때만 404를 보내도록 수정

### DIFF
--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/ReadChatRoomDto.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/dto/ReadChatRoomDto.java
@@ -1,4 +1,6 @@
 package com.ddang.ddang.auction.application.dto;
 
 public record ReadChatRoomDto(Long id, boolean isChatParticipant) {
+
+    public static ReadChatRoomDto CANNOT_CHAT_DTO = new ReadChatRoomDto(null, false);
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
@@ -40,7 +40,6 @@ import java.util.Optional;
 @ToString(of = {"id", "title", "description", "bidUnit", "startPrice", "deleted", "closingTime", "auctioneerCount"})
 public class Auction extends BaseTimeEntity {
 
-    public static final Auction EMPTY_AUCTION = null;
     private static final boolean DELETED_STATUS = true;
 
     @Id

--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/domain/Auction.java
@@ -40,6 +40,7 @@ import java.util.Optional;
 @ToString(of = {"id", "title", "description", "bidUnit", "startPrice", "deleted", "closingTime", "auctioneerCount"})
 public class Auction extends BaseTimeEntity {
 
+    public static final Auction EMPTY_AUCTION = null;
     private static final boolean DELETED_STATUS = true;
 
     @Id

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/application/ChatRoomService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/application/ChatRoomService.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -114,12 +115,14 @@ public class ChatRoomService {
     }
 
     public ReadChatRoomDto readChatInfoByAuctionId(final Long auctionId, final AuthenticationUserInfo userInfo) {
-        final User findUser = userRepository.findById(userInfo.userId())
-                                            .orElseThrow(() -> new UserNotFoundException("회원 정보를 찾을 수 없습니다."));
-        final Auction findAuction = auctionRepository.findAuctionById(auctionId)
-                                                     .orElseThrow(() -> new AuctionNotFoundException(
-                                                             "지정한 아이디에 대한 경매를 찾을 수 없습니다."
-                                                     ));
+        final Optional<User> nullableUser = userRepository.findById(userInfo.userId());
+        final Optional<Auction> nullableAuction = auctionRepository.findAuctionById(auctionId);
+        if (nullableUser.isEmpty() || nullableAuction.isEmpty()) {
+            return ReadChatRoomDto.CANNOT_CHAT_DTO;
+        }
+
+        final User findUser = nullableUser.get();
+        final Auction findAuction = nullableAuction.get();
         final Long chatRoomId = chatRoomRepository.findChatRoomIdByAuctionId(findAuction.getId())
                                                   .orElse(DEFAULT_CHAT_ROOM_ID);
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/application/ChatRoomService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/application/ChatRoomService.java
@@ -117,9 +117,11 @@ public class ChatRoomService {
         final User findUser = userRepository.findById(userInfo.userId())
                                             .orElse(User.EMPTY_USER);
         final Auction findAuction = auctionRepository.findAuctionById(auctionId)
-                                                     .orElse(Auction.EMPTY_AUCTION);
+                                                     .orElseThrow(() -> new AuctionNotFoundException(
+                                                             "지정한 아이디에 대한 경매를 찾을 수 없습니다."
+                                                     ));
 
-        if (findUser == User.EMPTY_USER || findAuction == Auction.EMPTY_AUCTION) {
+        if (findUser == User.EMPTY_USER) {
             return ReadChatRoomDto.CANNOT_CHAT_DTO;
         }
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/application/ChatRoomService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/application/ChatRoomService.java
@@ -27,7 +27,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -115,14 +114,15 @@ public class ChatRoomService {
     }
 
     public ReadChatRoomDto readChatInfoByAuctionId(final Long auctionId, final AuthenticationUserInfo userInfo) {
-        final Optional<User> nullableUser = userRepository.findById(userInfo.userId());
-        final Optional<Auction> nullableAuction = auctionRepository.findAuctionById(auctionId);
-        if (nullableUser.isEmpty() || nullableAuction.isEmpty()) {
+        final User findUser = userRepository.findById(userInfo.userId())
+                                            .orElse(User.EMPTY_USER);
+        final Auction findAuction = auctionRepository.findAuctionById(auctionId)
+                                                     .orElse(Auction.EMPTY_AUCTION);
+
+        if (findUser == User.EMPTY_USER || findAuction == Auction.EMPTY_AUCTION) {
             return ReadChatRoomDto.CANNOT_CHAT_DTO;
         }
 
-        final User findUser = nullableUser.get();
-        final Auction findAuction = nullableAuction.get();
         final Long chatRoomId = chatRoomRepository.findChatRoomIdByAuctionId(findAuction.getId())
                                                   .orElse(DEFAULT_CHAT_ROOM_ID);
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/domain/User.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/domain/User.java
@@ -33,6 +33,7 @@ import java.util.List;
 @Table(name = "users")
 public class User extends BaseTimeEntity {
 
+    public static final User EMPTY_USER = null;
     private static final boolean DELETED_STATUS = true;
     private static final String UNKOWN_NAME = "알 수 없음";
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/application/ChatRoomServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/application/ChatRoomServiceTest.java
@@ -173,12 +173,11 @@ class ChatRoomServiceTest extends ChatRoomServiceFixture {
     }
 
     @Test
-    void 지정한_경매_아이디와_관련된_채팅방을_조회할_때_경매를_찾을_수_없다면_채팅방_아이디_null과_참여가능여부_거짓을_반환한다() {
-        // when
-        final ReadChatRoomDto actual = chatRoomService.readChatInfoByAuctionId(존재하지_않는_경매_아이디, 엔초_회원_정보);
-
-        // then
-        assertThat(actual).isEqualTo(채팅방_없고_참여_불가능);
+    void 지정한_경매_아이디와_관련된_채팅방을_조회할_때_경매를_찾을_수_없다면_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> chatRoomService.readChatInfoByAuctionId(존재하지_않는_경매_아이디, 엔초_회원_정보))
+                .isInstanceOf(AuctionNotFoundException.class)
+                .hasMessage("지정한 아이디에 대한 경매를 찾을 수 없습니다.");
     }
 
     @Test

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/application/ChatRoomServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/application/ChatRoomServiceTest.java
@@ -164,7 +164,7 @@ class ChatRoomServiceTest extends ChatRoomServiceFixture {
     }
 
     @Test
-    void 지정한_경매_아이디와_관련된_채팅방을_조회할_때_조회를_요청한_사용자_정보를_찾을_수_없다면_채팅방_아이디_null과_참여가능여부_거짓을_반환한다() {
+    void 지정한_경매_아이디와_관련된_채팅방을_조회할_때_조회를_요청한_사용자_정보를_찾을_수_없다면_무조건_채팅방_아이디_null과_참여가능여부_거짓을_반환한다() {
         // when
         final ReadChatRoomDto actual = chatRoomService.readChatInfoByAuctionId(판매자_엔초_구매자_지토_경매.getId(), 존재하지_않는_사용자_정보);
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/application/ChatRoomServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/application/ChatRoomServiceTest.java
@@ -164,23 +164,25 @@ class ChatRoomServiceTest extends ChatRoomServiceFixture {
     }
 
     @Test
-    void 지정한_경매_아이디와_관련된_채팅방을_조회할_때_조회를_요청한_사용자_정보를_찾을_수_없다면_예외가_발생한다() {
-        // when & then
-        assertThatThrownBy(() -> chatRoomService.readChatInfoByAuctionId(판매자_엔초_구매자_지토_경매.getId(), 존재하지_않는_사용자_정보))
-                .isInstanceOf(UserNotFoundException.class)
-                .hasMessage("회원 정보를 찾을 수 없습니다.");
+    void 지정한_경매_아이디와_관련된_채팅방을_조회할_때_조회를_요청한_사용자_정보를_찾을_수_없다면_채팅방_아이디_null과_참여가능여부_거짓을_반환한다() {
+        // when
+        final ReadChatRoomDto actual = chatRoomService.readChatInfoByAuctionId(판매자_엔초_구매자_지토_경매.getId(), 존재하지_않는_사용자_정보);
+
+        // then
+        assertThat(actual).isEqualTo(채팅방_없고_참여_불가능);
     }
 
     @Test
-    void 지정한_경매_아이디와_관련된_채팅방을_조회할_때_경매를_찾을_수_없다면_예외가_발생한다() {
-        // when & then
-        assertThatThrownBy(() -> chatRoomService.readChatInfoByAuctionId(존재하지_않는_경매_아이디, 엔초_회원_정보))
-                .isInstanceOf(AuctionNotFoundException.class)
-                .hasMessage("지정한 아이디에 대한 경매를 찾을 수 없습니다.");
+    void 지정한_경매_아이디와_관련된_채팅방을_조회할_때_경매를_찾을_수_없다면_채팅방_아이디_null과_참여가능여부_거짓을_반환한다() {
+        // when
+        final ReadChatRoomDto actual = chatRoomService.readChatInfoByAuctionId(존재하지_않는_경매_아이디, 엔초_회원_정보);
+
+        // then
+        assertThat(actual).isEqualTo(채팅방_없고_참여_불가능);
     }
 
     @Test
-    void 지정한_경매_아이디와_관련된_채팅방을_조회할_때_채팅방을_찾을_수_없다면_채팅방_아이디_null과_참여가능여부를_반환한다() {
+    void 지정한_경매_아이디와_관련된_채팅방을_조회할_때_채팅방을_찾을_수_없다면_채팅방_아이디_null과_참여가능을_반환한다() {
         // when
         final ReadChatRoomDto actual = chatRoomService.readChatInfoByAuctionId(채팅방이_없는_경매.getId(), 판매자_회원_정보);
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/application/fixture/ChatRoomServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/application/fixture/ChatRoomServiceFixture.java
@@ -82,6 +82,7 @@ public class ChatRoomServiceFixture {
     protected ReadChatRoomDto 엔초_지토_채팅방_정보_및_참여_가능;
     protected ReadChatRoomDto 엔초_지토_채팅방_정보_및_참여_불가능;
     protected ReadChatRoomDto 채팅방은_아직_없지만_참여_가능;
+    protected ReadChatRoomDto 채팅방_없고_참여_불가능;
     protected ReadChatRoomWithLastMessageDto 엔초_채팅_목록의_제이미_엔초_채팅방_정보;
     protected ReadChatRoomWithLastMessageDto 엔초_채팅_목록의_엔초_지토_채팅방_정보;
 
@@ -233,6 +234,7 @@ public class ChatRoomServiceFixture {
         엔초_지토_채팅방_정보_및_참여_가능 = new ReadChatRoomDto(엔초_지토_채팅방.getId(), true);
         엔초_지토_채팅방_정보_및_참여_불가능 = new ReadChatRoomDto(엔초_지토_채팅방.getId(), false);
         채팅방은_아직_없지만_참여_가능 = new ReadChatRoomDto(null, true);
+        채팅방_없고_참여_불가능 = new ReadChatRoomDto(null, false);
         엔초_채팅_목록의_제이미_엔초_채팅방_정보 = new ReadChatRoomWithLastMessageDto(
                 제이미_엔초_채팅방.getId(),
                 ReadAuctionInChatRoomDto.of(판매자_제이미_구매자_엔초_경매, 제이미의_경매_대표_이미지),


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
경매 상세 조회 시 경매글을 찾을 수 없을 때만 404를 보내도록 수정

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
없음

## 📎 Issue 번호
- closed #603 