### PR TITLE
메시지 방 목록에 브로드캐스트 리시버 등록 및 해제 로직 추가

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/message/MessageViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/message/MessageViewModel.kt
@@ -12,6 +12,7 @@ import com.ddangddangddang.data.remote.ApiResponse
 import com.ddangddangddang.data.repository.ChatRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 
 @HiltViewModel
@@ -26,7 +27,10 @@ class MessageViewModel @Inject constructor(
     val messageRooms: LiveData<List<MessageRoomModel>>
         get() = _messageRooms
 
+    private var isLoading: AtomicBoolean = AtomicBoolean(false)
+
     fun loadMessageRooms() {
+        if (isLoading.getAndSet(true)) return
         viewModelScope.launch {
             when (val response = repository.getChatRoomPreviews()) {
                 is ApiResponse.Success -> {
@@ -46,6 +50,7 @@ class MessageViewModel @Inject constructor(
                     _event.value = MessageEvent.MessageLoadFailure(ErrorType.UNEXPECTED)
                 }
             }
+            isLoading.set(false)
         }
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/notification/DdangDdangDdangFirebaseMessagingService.kt
@@ -66,9 +66,8 @@ class DdangDdangDdangFirebaseMessagingService : FirebaseMessagingService() {
             when (type) {
                 NotificationType.MESSAGE -> {
                     val activeRoomId = (application as DdangDdangDdang).activeMessageRoomId
-                    if (activeRoomId == id) {
-                        sendBroadcastToMessageReceiver(id)
-                    } else {
+                    sendBroadcastToMessageReceiver(id) // 항상 호출. 이 리시버를 받을지 말지는 거기서 정함.
+                    if (activeRoomId != id) {
                         val notification = createMessageNotification(tag, id, remoteMessage)
                         notificationManager.notify(tag, id.toInt(), notification)
                     }


### PR DESCRIPTION
## 📄 작업 내용 요약
메시지 방 목록에 브로드캐스트 리시버 등록 및 해제 로직 추가

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
사실 아래 코드가 전부 입니다.
<img width="795" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/12b6e2f0-9978-44a0-a96d-b506ddebee2e">
우선 저희가 지금 프래그먼트를 사용하고 hide/show를 사용해서 onResume 혹은 onPause는 바텀 네비게이션 탭간 전환으로는 발생하지 않습니다. 
또한, 메시지방에 다녀오거나 홈키를 눌러서 아예 앱을 나갔다가 다시 메시지 프래그먼트로 돌아오는 경우에는 onHiddenChanged가 발생하지 않습니다.

이 모든 문제를 해결하기 위해서 양쪽에 모두 등록과 해제 로직을 설정해줬습니다. 
다만 여기서 문제가 하나 있었는데, 브로드캐스트 리시버 등록 같은 경우는 동일한 리시버를 여러번 등록해도 한 번밖에 수신되지 않고 또 한 객체를 여러번 등록을 시도한다고 해서 예외가 발생하지도 않습니다, 
해제에서 문제가 발생했었는데, 등록된 리시버가 아닌데 해제를 시도하면 예외를 발생하고 터지는 문제가 발생했습니다. 때문에 runChatching으로 해제 로직을 한 번 잡아주고 있습니다.

그렇다면, 해제가 문제가 되는 경우는 언제가 있는지 말씀드려보면, 다음과 같은 상황이 있습니다.
메시지 프래그먼트로 바텀 탭 눌러서 이동(리시버 등록됨) -> 다른 프래그먼트로 탭 눌러서 이동(리시버는 해제됐으나 프래그먼트는 Resumed상태로 hide됨) -> 이 상태에서 홈키를 눌러서 나감 -> Resumed상태였던 메시지 프래그먼트가 onPause 호출 -> 해제하려고 시도하나 등록된게 없어서 예외 발생
-> 추가로 위 사진에서, show될때와 onResume에서 모두 loadMessage()를 호출하고 있어서, 중복 호출은 아닐지 걱정하실 수 있는데, 저희 구조는 기존에 프래그먼트 매니저에 붙었던 녀석들을 모두 하이드시키고 이번에 보여줄 프래그먼트가 만약 없다면, create하고 add하는 방식이라서 절대 onResume과 onHiddenChanged가 같이 호출되지 않습니다.

<img width="866" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/5f1126d7-f1ae-429e-a771-341e15ea3a2e">
추가로, 메시지 브로드 캐스트리시버에게 항상 송신하도록 수정했습니다. 어차피 자신의 id와 다르다면 MessageRoomActivity에서는 수신해도 받지 않습니다, 반면, MessageFragment에서 등록된 브로드캐스트 리시버는 자신이 등록되어있는 한에는 항상 수신 받기를 원하기 때문입니다.

그외에, MessageViewModel에서 isLoading으로 AtomicBoolean을 사용해서 좀 더 안정성을 강화했습니다.
(저번에 메시지가 동일한게 두 번 보내진 적이 있었는데, 아토믹 불리언으로 가능하다면 모두 수정하는게 안정성 측면에서 좋아보인다고 생각합니다)

## 📎 Issue 번호
- close: #607 
