### PR TITLE
이전에 선택한 지역 유지 기능 추가

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionActivity.kt
@@ -149,8 +149,8 @@ class RegisterAuctionActivity :
                 navigationToCategorySelection()
             }
 
-            RegisterAuctionViewModel.RegisterAuctionEvent.PickRegion -> {
-                navigationToRegionSelection()
+            is RegisterAuctionViewModel.RegisterAuctionEvent.PickRegion -> {
+                navigationToRegionSelection(event.directRegion)
             }
         }
     }
@@ -216,8 +216,8 @@ class RegisterAuctionActivity :
         categoryActivityLauncher.launch(SelectCategoryActivity.getIntent(this))
     }
 
-    private fun navigationToRegionSelection() {
-        regionActivityLauncher.launch(SelectRegionsActivity.getIntent(this))
+    private fun navigationToRegionSelection(directRegion: List<RegionSelectionModel>) {
+        regionActivityLauncher.launch(SelectRegionsActivity.getIntent(this, directRegion))
     }
 
     private fun setPrice(editText: EditText, watcher: DefaultTextWatcher, price: Int) {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionActivity.kt
@@ -150,7 +150,7 @@ class RegisterAuctionActivity :
             }
 
             is RegisterAuctionViewModel.RegisterAuctionEvent.PickRegion -> {
-                navigationToRegionSelection(event.directRegion)
+                navigationToRegionSelection(event.regionSelected)
             }
         }
     }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionViewModel.kt
@@ -204,7 +204,7 @@ class RegisterAuctionViewModel @Inject constructor(private val repository: Aucti
     }
 
     fun setPickRegionEvent() {
-        _event.value = RegisterAuctionEvent.PickRegion
+        _event.value = RegisterAuctionEvent.PickRegion(_directRegion.value ?: emptyList())
     }
 
     private fun setBlankExistEvent() {
@@ -237,7 +237,7 @@ class RegisterAuctionViewModel @Inject constructor(private val repository: Aucti
         object MultipleMediaPicker : RegisterAuctionEvent()
 
         object PickCategory : RegisterAuctionEvent()
-        object PickRegion : RegisterAuctionEvent()
+        class PickRegion(val directRegion: List<RegionSelectionModel>) : RegisterAuctionEvent()
     }
 
     companion object {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionViewModel.kt
@@ -237,7 +237,7 @@ class RegisterAuctionViewModel @Inject constructor(private val repository: Aucti
         object MultipleMediaPicker : RegisterAuctionEvent()
 
         object PickCategory : RegisterAuctionEvent()
-        class PickRegion(val directRegion: List<RegionSelectionModel>) : RegisterAuctionEvent()
+        class PickRegion(val regionSelected: List<RegionSelectionModel>) : RegisterAuctionEvent()
     }
 
     companion object {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/register/region/SelectRegionsActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/register/region/SelectRegionsActivity.kt
@@ -99,6 +99,12 @@ class SelectRegionsActivity :
     }
 
     companion object {
-        fun getIntent(context: Context): Intent = Intent(context, SelectRegionsActivity::class.java)
+        private const val KEY_DIRECT_REGION = "direct_region"
+
+        fun getIntent(context: Context, directRegion: List<RegionSelectionModel>): Intent {
+            val intent = Intent(context, SelectRegionsActivity::class.java)
+            intent.putExtra(KEY_DIRECT_REGION, directRegion.toTypedArray())
+            return intent
+        }
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/register/region/SelectRegionsActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/register/region/SelectRegionsActivity.kt
@@ -10,6 +10,7 @@ import com.ddangddangddang.android.feature.common.notifyFailureMessage
 import com.ddangddangddang.android.feature.register.RegisterAuctionActivity
 import com.ddangddangddang.android.model.RegionSelectionModel
 import com.ddangddangddang.android.util.binding.BindingActivity
+import com.ddangddangddang.android.util.compat.getSerializableExtraCompat
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -43,6 +44,7 @@ class SelectRegionsActivity :
         setupAdapter()
         setupObserve()
         viewModel.loadFirstRegions()
+        setupRegionSelected()
     }
 
     private fun setupAdapter() {
@@ -98,12 +100,18 @@ class SelectRegionsActivity :
         finish()
     }
 
-    companion object {
-        private const val KEY_DIRECT_REGION = "direct_region"
+    private fun setupRegionSelected() {
+        val regionSelected =
+            intent.getSerializableExtraCompat<Array<RegionSelectionModel>>(KEY_REGION_SELECTED)
+        regionSelected?.let { viewModel.setupRegionSelected(it.toList()) }
+    }
 
-        fun getIntent(context: Context, directRegion: List<RegionSelectionModel>): Intent {
+    companion object {
+        private const val KEY_REGION_SELECTED = "region_selected"
+
+        fun getIntent(context: Context, regionSelected: List<RegionSelectionModel>): Intent {
             val intent = Intent(context, SelectRegionsActivity::class.java)
-            intent.putExtra(KEY_DIRECT_REGION, directRegion.toTypedArray())
+            intent.putExtra(KEY_REGION_SELECTED, regionSelected.toTypedArray())
             return intent
         }
     }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/register/region/SelectRegionsViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/register/region/SelectRegionsViewModel.kt
@@ -70,6 +70,10 @@ class SelectRegionsViewModel @Inject constructor(private val regionRepository: R
         }
     }
 
+    fun setupRegionSelected(regionSelected: List<RegionSelectionModel>) {
+        _regionSelections.value = regionSelected
+    }
+
     fun setExitEvent() {
         _event.value = SelectRegionsEvent.Exit
     }


### PR DESCRIPTION
## 📄 작업 내용 요약
지역을 선택한 후 다시 지역을 선택하더라도 이전에 선택한 지역을 유지하도록 기능을 추가했습니다! 

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
ParcelableArrayCompat을 정의하면 Parcelable로도 리스트 전달이 가능할 것 같지만 기존에 Serializable을 사용하고 있었기 때문에 이번에도 Serializable 형태로 전송하도록 했습니다! 😉

## 📎 Issue 번호
- close : #629 