### PR TITLE
User 관련 인프라 리팩토링

### DIFF
--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/application/AuctionService.java
@@ -21,21 +21,22 @@ import com.ddang.ddang.region.domain.Region;
 import com.ddang.ddang.region.infrastructure.persistence.JpaRegionRepository;
 import com.ddang.ddang.user.application.exception.UserNotFoundException;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class AuctionService {
 
-    private final JpaUserRepository userRepository;
+    private final UserRepository userRepository;
     private final AuctionRepository auctionRepository;
     private final JpaRegionRepository regionRepository;
     private final CategoryRepository categoryRepository;

--- a/backend/ddang/src/main/java/com/ddang/ddang/authentication/application/AuthenticationService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/authentication/application/AuthenticationService.java
@@ -163,7 +163,7 @@ public class AuthenticationService {
                                                         .orElseThrow(() ->
                                                                 new InvalidTokenException("유효한 토큰이 아닙니다.")
                                                         );
-        final User user = userRepository.findByIdAndDeletedIsFalse(privateClaims.userId())
+        final User user = userRepository.findById(privateClaims.userId())
                                         .orElseThrow(() -> new InvalidWithdrawalException("탈퇴에 대한 권한이 없습니다."));
         final OAuth2UserInformationProvider provider = providerComposite.findProvider(user.getOauthInformation()
                                                                                           .getOauth2Type());

--- a/backend/ddang/src/main/java/com/ddang/ddang/authentication/application/AuthenticationService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/authentication/application/AuthenticationService.java
@@ -1,7 +1,5 @@
 package com.ddang.ddang.authentication.application;
 
-import static com.ddang.ddang.image.domain.ProfileImage.DEFAULT_PROFILE_IMAGE_STORE_NAME;
-
 import com.ddang.ddang.authentication.application.dto.LoginInformationDto;
 import com.ddang.ddang.authentication.application.dto.LoginUserInformationDto;
 import com.ddang.ddang.authentication.application.dto.TokenDto;
@@ -24,13 +22,16 @@ import com.ddang.ddang.image.domain.ProfileImage;
 import com.ddang.ddang.image.infrastructure.persistence.JpaProfileImageRepository;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.time.LocalDateTime;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.ddang.ddang.image.domain.ProfileImage.DEFAULT_PROFILE_IMAGE_STORE_NAME;
 
 @Service
 @Transactional(readOnly = true)
@@ -41,7 +42,7 @@ public class AuthenticationService {
 
     private final DeviceTokenService deviceTokenService;
     private final Oauth2UserInformationProviderComposite providerComposite;
-    private final JpaUserRepository userRepository;
+    private final UserRepository userRepository;
     private final JpaProfileImageRepository profileImageRepository;
     private final TokenEncoder tokenEncoder;
     private final TokenDecoder tokenDecoder;

--- a/backend/ddang/src/main/java/com/ddang/ddang/authentication/application/AuthenticationUserService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/authentication/application/AuthenticationUserService.java
@@ -1,6 +1,6 @@
 package com.ddang.ddang.authentication.application;
 
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,7 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class AuthenticationUserService {
 
-    private final JpaUserRepository userRepository;
+    private final UserRepository userRepository;
 
     public boolean isWithdrawal(final Long userId) {
         return userRepository.existsByIdAndDeletedIsTrue(userId);

--- a/backend/ddang/src/main/java/com/ddang/ddang/bid/application/BidService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/bid/application/BidService.java
@@ -17,14 +17,15 @@ import com.ddang.ddang.bid.domain.BidPrice;
 import com.ddang.ddang.bid.infrastructure.persistence.JpaBidRepository;
 import com.ddang.ddang.user.application.exception.UserNotFoundException;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -34,7 +35,7 @@ public class BidService {
     private final ApplicationEventPublisher bidEventPublisher;
     private final AuctionRepository auctionRepository;
     private final AuctionAndImageRepository auctionAndImageRepository;
-    private final JpaUserRepository userRepository;
+    private final UserRepository userRepository;
     private final JpaBidRepository bidRepository;
 
     @Transactional

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/application/ChatRoomService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/application/ChatRoomService.java
@@ -20,12 +20,13 @@ import com.ddang.ddang.chat.infrastructure.persistence.dto.ChatRoomAndImageDto;
 import com.ddang.ddang.chat.infrastructure.persistence.dto.ChatRoomAndMessageAndImageDto;
 import com.ddang.ddang.user.application.exception.UserNotFoundException;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -37,7 +38,7 @@ public class ChatRoomService {
     private final JpaChatRoomRepository chatRoomRepository;
     private final QuerydslChatRoomAndImageRepositoryImpl querydslChatRoomAndImageRepository;
     private final QuerydslChatRoomAndMessageAndImageRepository querydslChatRoomAndMessageAndImageRepository;
-    private final JpaUserRepository userRepository;
+    private final UserRepository userRepository;
     private final AuctionRepository auctionRepository;
 
     @Transactional

--- a/backend/ddang/src/main/java/com/ddang/ddang/chat/application/MessageService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/chat/application/MessageService.java
@@ -13,7 +13,7 @@ import com.ddang.ddang.chat.infrastructure.persistence.JpaMessageRepository;
 import com.ddang.ddang.chat.presentation.dto.request.ReadMessageRequest;
 import com.ddang.ddang.user.application.exception.UserNotFoundException;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -31,7 +31,7 @@ public class MessageService {
     private final ApplicationEventPublisher messageEventPublisher;
     private final JpaMessageRepository messageRepository;
     private final JpaChatRoomRepository chatRoomRepository;
-    private final JpaUserRepository userRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public Long create(final CreateMessageDto dto, final String profileImageAbsoluteUrl) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/configuration/initialization/InitializationUserConfiguration.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/configuration/initialization/InitializationUserConfiguration.java
@@ -3,7 +3,7 @@ package com.ddang.ddang.configuration.initialization;
 import com.ddang.ddang.image.domain.ProfileImage;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class InitializationUserConfiguration implements ApplicationRunner {
 
-    private final JpaUserRepository userRepository;
+    private final UserRepository userRepository;
 
     @Override
     @Transactional

--- a/backend/ddang/src/main/java/com/ddang/ddang/device/application/DeviceTokenService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/device/application/DeviceTokenService.java
@@ -5,7 +5,7 @@ import com.ddang.ddang.device.domain.DeviceToken;
 import com.ddang.ddang.device.infrastructure.persistence.JpaDeviceTokenRepository;
 import com.ddang.ddang.user.application.exception.UserNotFoundException;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DeviceTokenService {
 
     private final JpaDeviceTokenRepository deviceTokenRepository;
-    private final JpaUserRepository userRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public void persist(final Long userId, final PersistDeviceTokenDto deviceTokenDto) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/qna/application/AnswerService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/qna/application/AnswerService.java
@@ -67,7 +67,7 @@ public class AnswerService {
     public void deleteById(final Long answerId, final Long userId) {
         final Answer answer = answerRepository.findByIdAndDeletedIsFalse(answerId)
                                               .orElseThrow(() -> new AnswerNotFoundException("해당 답변을 찾을 수 없습니다."));
-        final User user = userRepository.findByIdAndDeletedIsFalse(userId)
+        final User user = userRepository.findById(userId)
                                         .orElseThrow(() -> new UserNotFoundException("해당 사용자를 찾을 수 없습니다."));
 
         if (!answer.isWriter(user)) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/qna/application/AnswerService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/qna/application/AnswerService.java
@@ -13,7 +13,7 @@ import com.ddang.ddang.qna.infrastructure.JpaAnswerRepository;
 import com.ddang.ddang.qna.infrastructure.JpaQuestionRepository;
 import com.ddang.ddang.user.application.exception.UserNotFoundException;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -25,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AnswerService {
 
     private final ApplicationEventPublisher answerEventPublisher;
-    private final JpaUserRepository userRepository;
+    private final UserRepository userRepository;
     private final JpaQuestionRepository questionRepository;
     private final JpaAnswerRepository answerRepository;
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/qna/application/QuestionService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/qna/application/QuestionService.java
@@ -14,13 +14,14 @@ import com.ddang.ddang.qna.domain.Question;
 import com.ddang.ddang.qna.infrastructure.JpaQuestionRepository;
 import com.ddang.ddang.user.application.exception.UserNotFoundException;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -29,7 +30,7 @@ public class QuestionService {
 
     private final ApplicationEventPublisher questionEventPublisher;
     private final AuctionRepository auctionRepository;
-    private final JpaUserRepository userRepository;
+    private final UserRepository userRepository;
     private final JpaQuestionRepository questionRepository;
 
     @Transactional

--- a/backend/ddang/src/main/java/com/ddang/ddang/qna/application/QuestionService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/qna/application/QuestionService.java
@@ -35,7 +35,7 @@ public class QuestionService {
 
     @Transactional
     public Long create(final CreateQuestionDto questionDto, final String absoluteImageUrl) {
-        final User questioner = userRepository.findByIdAndDeletedIsFalse(questionDto.userId())
+        final User questioner = userRepository.findById(questionDto.userId())
                                               .orElseThrow(() -> new UserNotFoundException("해당 사용자를 찾을 수 없습니다."));
         final Auction auction = auctionRepository.findPureAuctionById(questionDto.auctionId())
                                                  .orElseThrow(() -> new AuctionNotFoundException("해당 경매를 찾을 수 없습니다."));
@@ -78,7 +78,7 @@ public class QuestionService {
     public void deleteById(final Long questionId, final Long userId) {
         final Question question = questionRepository.findById(questionId)
                                                     .orElseThrow(() -> new QuestionNotFoundException("해당 질문을 찾을 수 없습니다."));
-        final User user = userRepository.findByIdAndDeletedIsFalse(userId)
+        final User user = userRepository.findById(userId)
                                         .orElseThrow(() -> new UserNotFoundException("해당 사용자를 찾을 수 없습니다."));
 
         if (!question.isWriter(user)) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/report/application/AnswerReportService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/report/application/AnswerReportService.java
@@ -10,7 +10,7 @@ import com.ddang.ddang.report.domain.AnswerReport;
 import com.ddang.ddang.report.infrastructure.persistence.JpaAnswerReportRepository;
 import com.ddang.ddang.user.application.exception.UserNotFoundException;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +23,7 @@ import java.util.List;
 public class AnswerReportService {
 
     private final JpaAnswerRepository answerRepository;
-    private final JpaUserRepository userRepository;
+    private final UserRepository userRepository;
     private final JpaAnswerReportRepository answerReportRepository;
 
     @Transactional

--- a/backend/ddang/src/main/java/com/ddang/ddang/report/application/AnswerReportService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/report/application/AnswerReportService.java
@@ -32,7 +32,7 @@ public class AnswerReportService {
                                               .orElseThrow(() ->
                                                       new AnswerNotFoundException("해당 답변을 찾을 수 없습니다.")
                                               );
-        final User reporter = userRepository.findByIdAndDeletedIsFalse(answerReportDto.reporterId())
+        final User reporter = userRepository.findById(answerReportDto.reporterId())
                                             .orElseThrow(() -> new UserNotFoundException("해당 사용자를 찾을 수 없습니다."));
         checkInvalidAnswerReport(reporter, answer);
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/report/application/AuctionReportService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/report/application/AuctionReportService.java
@@ -11,11 +11,12 @@ import com.ddang.ddang.report.domain.AuctionReport;
 import com.ddang.ddang.report.infrastructure.persistence.JpaAuctionReportRepository;
 import com.ddang.ddang.user.application.exception.UserNotFoundException;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.util.List;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -23,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuctionReportService {
 
     private final AuctionRepository auctionRepository;
-    private final JpaUserRepository userRepository;
+    private final UserRepository userRepository;
     private final JpaAuctionReportRepository auctionReportRepository;
 
     @Transactional

--- a/backend/ddang/src/main/java/com/ddang/ddang/report/application/ChatRoomReportService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/report/application/ChatRoomReportService.java
@@ -11,7 +11,7 @@ import com.ddang.ddang.report.domain.ChatRoomReport;
 import com.ddang.ddang.report.infrastructure.persistence.JpaChatRoomReportRepository;
 import com.ddang.ddang.user.application.exception.UserNotFoundException;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +23,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ChatRoomReportService {
 
-    private final JpaUserRepository userRepository;
+    private final UserRepository userRepository;
     private final JpaChatRoomRepository chatRoomRepository;
     private final JpaChatRoomReportRepository chatRoomReportRepository;
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/report/application/QuestionReportService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/report/application/QuestionReportService.java
@@ -32,7 +32,7 @@ public class QuestionReportService {
                                                     .orElseThrow(() ->
                                                             new QuestionNotFoundException("해당 질문을 찾을 수 없습니다.")
                                                     );
-        final User reporter = userRepository.findByIdAndDeletedIsFalse(questionReportDto.reporterId())
+        final User reporter = userRepository.findById(questionReportDto.reporterId())
                                             .orElseThrow(() -> new UserNotFoundException("해당 사용자를 찾을 수 없습니다."));
         checkInvalidQuestionReport(reporter, question);
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/report/application/QuestionReportService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/report/application/QuestionReportService.java
@@ -10,7 +10,7 @@ import com.ddang.ddang.report.domain.QuestionReport;
 import com.ddang.ddang.report.infrastructure.persistence.JpaQuestionReportRepository;
 import com.ddang.ddang.user.application.exception.UserNotFoundException;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +23,7 @@ import java.util.List;
 public class QuestionReportService {
 
     private final JpaQuestionRepository questionRepository;
-    private final JpaUserRepository userRepository;
+    private final UserRepository userRepository;
     private final JpaQuestionReportRepository questionReportRepository;
 
     @Transactional
@@ -55,7 +55,7 @@ public class QuestionReportService {
         final List<QuestionReport> questionReports = questionReportRepository.findAllByOrderByIdAsc();
 
         return questionReports.stream()
-                             .map(ReadQuestionReportDto::from)
-                             .toList();
+                              .map(ReadQuestionReportDto::from)
+                              .toList();
     }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/review/application/ReviewService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/review/application/ReviewService.java
@@ -13,12 +13,13 @@ import com.ddang.ddang.review.domain.Review;
 import com.ddang.ddang.review.infrastructure.persistence.JpaReviewRepository;
 import com.ddang.ddang.user.application.exception.UserNotFoundException;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -27,7 +28,7 @@ public class ReviewService {
 
     private final JpaReviewRepository reviewRepository;
     private final AuctionRepository auctionRepository;
-    private final JpaUserRepository userRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public Long create(final CreateReviewDto reviewDto) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/application/UserService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/application/UserService.java
@@ -6,7 +6,7 @@ import com.ddang.ddang.user.application.dto.ReadUserDto;
 import com.ddang.ddang.user.application.dto.UpdateUserDto;
 import com.ddang.ddang.user.application.exception.UserNotFoundException;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserService {
 
-    private final JpaUserRepository userRepository;
+    private final UserRepository userRepository;
     private final StoreImageProcessor imageProcessor;
 
     public ReadUserDto readById(final Long userId) {

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/application/UserService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/application/UserService.java
@@ -28,7 +28,7 @@ public class UserService {
 
     @Transactional
     public ReadUserDto updateById(final Long userId, final UpdateUserDto userDto) {
-        final User user = userRepository.findByIdAndDeletedIsFalse(userId)
+        final User user = userRepository.findById(userId)
                                         .orElseThrow(() -> new UserNotFoundException("사용자 정보를 사용할 수 없습니다."));
 
         updateUserByRequest(userDto, user);

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/application/schedule/ReliabilityUpdateSchedulingService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/application/schedule/ReliabilityUpdateSchedulingService.java
@@ -6,8 +6,8 @@ import com.ddang.ddang.review.infrastructure.persistence.JpaReviewRepository;
 import com.ddang.ddang.user.domain.ReliabilityUpdateHistory;
 import com.ddang.ddang.user.domain.User;
 import com.ddang.ddang.user.domain.UserReliability;
+import com.ddang.ddang.user.domain.repository.ReliabilityUpdateHistoryRepository;
 import com.ddang.ddang.user.domain.repository.UserReliabilityRepository;
-import com.ddang.ddang.user.infrastructure.persistence.JpaReliabilityUpdateHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -21,7 +21,7 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class ReliabilityUpdateSchedulingService {
 
-    private final JpaReliabilityUpdateHistoryRepository updateHistoryRepository;
+    private final ReliabilityUpdateHistoryRepository updateHistoryRepository;
     private final JpaReviewRepository reviewRepository;
     private final UserReliabilityRepository userReliabilityRepository;
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/application/schedule/ReliabilityUpdateSchedulingService.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/application/schedule/ReliabilityUpdateSchedulingService.java
@@ -6,8 +6,8 @@ import com.ddang.ddang.review.infrastructure.persistence.JpaReviewRepository;
 import com.ddang.ddang.user.domain.ReliabilityUpdateHistory;
 import com.ddang.ddang.user.domain.User;
 import com.ddang.ddang.user.domain.UserReliability;
+import com.ddang.ddang.user.domain.repository.UserReliabilityRepository;
 import com.ddang.ddang.user.infrastructure.persistence.JpaReliabilityUpdateHistoryRepository;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserReliabilityRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -23,7 +23,7 @@ public class ReliabilityUpdateSchedulingService {
 
     private final JpaReliabilityUpdateHistoryRepository updateHistoryRepository;
     private final JpaReviewRepository reviewRepository;
-    private final JpaUserReliabilityRepository userReliabilityRepository;
+    private final UserReliabilityRepository userReliabilityRepository;
 
     @Transactional
     @Scheduled(cron = "0 0 4 ? * MON")

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/domain/UserReliability.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/domain/UserReliability.java
@@ -2,7 +2,6 @@ package com.ddang.ddang.user.domain;
 
 import com.ddang.ddang.review.domain.Reviews;
 import jakarta.persistence.AttributeOverride;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -30,7 +29,7 @@ public class UserReliability {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", foreignKey = @ForeignKey(name = "fk_user_reliability_user"), nullable = false)
     private User user;
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/domain/repository/ReliabilityUpdateHistoryRepository.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/domain/repository/ReliabilityUpdateHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.ddang.ddang.user.domain.repository;
+
+import com.ddang.ddang.user.domain.ReliabilityUpdateHistory;
+
+import java.util.Optional;
+
+public interface ReliabilityUpdateHistoryRepository {
+
+    ReliabilityUpdateHistory save(final ReliabilityUpdateHistory reliabilityUpdateHistory);
+
+    Optional<ReliabilityUpdateHistory> findFirstByOrderByIdDesc();
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/domain/repository/UserReliabilityRepository.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/domain/repository/UserReliabilityRepository.java
@@ -1,0 +1,12 @@
+package com.ddang.ddang.user.domain.repository;
+
+import com.ddang.ddang.user.domain.UserReliability;
+
+import java.util.Optional;
+
+public interface UserReliabilityRepository {
+
+    UserReliability save(final UserReliability userReliability);
+
+    Optional<UserReliability> findByUserId(final Long userId);
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/domain/repository/UserRepository.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/domain/repository/UserRepository.java
@@ -1,0 +1,22 @@
+package com.ddang.ddang.user.domain.repository;
+
+import com.ddang.ddang.user.domain.User;
+
+import java.util.Optional;
+
+public interface UserRepository {
+
+    User save(final User user);
+
+    Optional<User> findById(final Long id);
+
+    boolean existsById(final Long id);
+
+    Optional<User> findByOauthId(final String oauthId);
+
+    Optional<User> findByIdAndDeletedIsFalse(final Long id);
+
+    boolean existsByIdAndDeletedIsTrue(final Long id);
+
+    boolean existsByNameEndingWith(final String name);
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/domain/repository/UserRepository.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/domain/repository/UserRepository.java
@@ -14,8 +14,6 @@ public interface UserRepository {
 
     Optional<User> findByOauthId(final String oauthId);
 
-    Optional<User> findByIdAndDeletedIsFalse(final Long id);
-
     boolean existsByIdAndDeletedIsTrue(final Long id);
 
     boolean existsByNameEndingWith(final String name);

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/infrastructure/persistence/JpaUserReliabilityRepository.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/infrastructure/persistence/JpaUserReliabilityRepository.java
@@ -2,10 +2,17 @@ package com.ddang.ddang.user.infrastructure.persistence;
 
 import com.ddang.ddang.user.domain.UserReliability;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface JpaUserReliabilityRepository extends JpaRepository<UserReliability, Long> {
 
+    @Query("""
+        SELECT ur
+        FROM UserReliability  ur
+        JOIN FETCH ur.user u
+        WHERE u.id = :userId
+    """)
     Optional<UserReliability> findByUserId(final Long userId);
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/infrastructure/persistence/JpaUserRepository.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/infrastructure/persistence/JpaUserRepository.java
@@ -2,20 +2,24 @@ package com.ddang.ddang.user.infrastructure.persistence;
 
 import com.ddang.ddang.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
-import org.springframework.data.jpa.repository.Query;
 
 public interface JpaUserRepository extends JpaRepository<User, Long> {
 
+    @Query("""
+        SELECT u 
+        FROM User u 
+        WHERE u.deleted = false AND u.id = :id
+    """)
+    Optional<User> findById(final Long id);
     @Query("""
         SELECT u
         FROM User u
         WHERE u.deleted = false AND u.oauthInformation.oauthId = :oauthId
     """)
     Optional<User> findByOauthId(final String oauthId);
-
-    Optional<User> findByIdAndDeletedIsFalse(final Long id);
 
     boolean existsByIdAndDeletedIsTrue(final Long id);
 

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/infrastructure/persistence/JpaUserRepository.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/infrastructure/persistence/JpaUserRepository.java
@@ -14,6 +14,7 @@ public interface JpaUserRepository extends JpaRepository<User, Long> {
         WHERE u.deleted = false AND u.id = :id
     """)
     Optional<User> findById(final Long id);
+
     @Query("""
         SELECT u
         FROM User u

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/infrastructure/persistence/ReliabilityUpdateHistoryRepositoryImpl.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/infrastructure/persistence/ReliabilityUpdateHistoryRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.ddang.ddang.user.infrastructure.persistence;
+
+import com.ddang.ddang.user.domain.ReliabilityUpdateHistory;
+import com.ddang.ddang.user.domain.repository.ReliabilityUpdateHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class ReliabilityUpdateHistoryRepositoryImpl implements ReliabilityUpdateHistoryRepository {
+
+    private final JpaReliabilityUpdateHistoryRepository jpaReliabilityUpdateHistoryRepository;
+
+    @Override
+    public ReliabilityUpdateHistory save(final ReliabilityUpdateHistory reliabilityUpdateHistory) {
+        return jpaReliabilityUpdateHistoryRepository.save(reliabilityUpdateHistory);
+    }
+
+    @Override
+    public Optional<ReliabilityUpdateHistory> findFirstByOrderByIdDesc() {
+        return jpaReliabilityUpdateHistoryRepository.findFirstByOrderByIdDesc();
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/infrastructure/persistence/UserReliabilityRepositoryImpl.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/infrastructure/persistence/UserReliabilityRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.ddang.ddang.user.infrastructure.persistence;
+
+import com.ddang.ddang.user.domain.UserReliability;
+import com.ddang.ddang.user.domain.repository.UserReliabilityRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UserReliabilityRepositoryImpl implements UserReliabilityRepository {
+
+    private final JpaUserReliabilityRepository jpaUserReliabilityRepository;
+
+    @Override
+    public UserReliability save(final UserReliability userReliability) {
+        return jpaUserReliabilityRepository.save(userReliability);
+    }
+
+    @Override
+    public Optional<UserReliability> findByUserId(final Long userId) {
+        return jpaUserReliabilityRepository.findByUserId(userId);
+    }
+}

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -40,6 +40,6 @@ public class UserRepositoryImpl implements UserRepository {
 
     @Override
     public boolean existsByNameEndingWith(final String name) {
-        return existsByNameEndingWith(name);
+        return jpaUserRepository.existsByNameEndingWith(name);
     }
 }

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -34,11 +34,6 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public Optional<User> findByIdAndDeletedIsFalse(final Long id) {
-        return jpaUserRepository.findByIdAndDeletedIsFalse(id);
-    }
-
-    @Override
     public boolean existsByIdAndDeletedIsTrue(final Long id) {
         return jpaUserRepository.existsByIdAndDeletedIsTrue(id);
     }

--- a/backend/ddang/src/main/java/com/ddang/ddang/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.ddang.ddang.user.infrastructure.persistence;
+
+import com.ddang.ddang.user.domain.User;
+import com.ddang.ddang.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+
+    private final JpaUserRepository jpaUserRepository;
+
+    @Override
+    public User save(final User user) {
+        return jpaUserRepository.save(user);
+    }
+
+    @Override
+    public Optional<User> findById(final Long id) {
+        return jpaUserRepository.findById(id);
+    }
+
+    @Override
+    public boolean existsById(final Long id) {
+        return jpaUserRepository.existsById(id);
+    }
+
+    @Override
+    public Optional<User> findByOauthId(final String oauthId) {
+        return jpaUserRepository.findByOauthId(oauthId);
+    }
+
+    @Override
+    public Optional<User> findByIdAndDeletedIsFalse(final Long id) {
+        return jpaUserRepository.findByIdAndDeletedIsFalse(id);
+    }
+
+    @Override
+    public boolean existsByIdAndDeletedIsTrue(final Long id) {
+        return jpaUserRepository.existsByIdAndDeletedIsTrue(id);
+    }
+
+    @Override
+    public boolean existsByNameEndingWith(final String name) {
+        return existsByNameEndingWith(name);
+    }
+}

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/application/fixture/AuctionServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/application/fixture/AuctionServiceFixture.java
@@ -15,13 +15,14 @@ import com.ddang.ddang.region.domain.Region;
 import com.ddang.ddang.region.infrastructure.persistence.JpaRegionRepository;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class AuctionServiceFixture {
@@ -36,7 +37,7 @@ public class AuctionServiceFixture {
     private JpaCategoryRepository categoryRepository;
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private JpaBidRepository bidRepository;
@@ -51,11 +52,11 @@ public class AuctionServiceFixture {
                              .oauthId("12345")
                              .build();
     protected User 구매자 = User.builder()
-                           .name("구매자")
-                           .profileImage(new ProfileImage("upload.png", "store.png"))
-                           .reliability(new Reliability(4.7d))
-                           .oauthId("54321")
-                           .build();
+                             .name("구매자")
+                             .profileImage(new ProfileImage("upload.png", "store.png"))
+                             .reliability(new Reliability(4.7d))
+                             .oauthId("54321")
+                             .build();
 
     private MockMultipartFile 경매_이미지_파일 = new MockMultipartFile(
             "image.png",
@@ -102,7 +103,8 @@ public class AuctionServiceFixture {
 
         categoryRepository.save(가구_카테고리);
 
-        userRepository.saveAll(List.of(판매자, 구매자));
+        userRepository.save(판매자);
+        userRepository.save(구매자);
 
         유효한_경매_생성_dto = new CreateAuctionDto(
                 "제목",

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/fixture/AuctionRepositoryImplFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/fixture/AuctionRepositoryImplFixture.java
@@ -72,7 +72,7 @@ public class AuctionRepositoryImplFixture {
 
     @BeforeEach
     void fixtureSetUp(
-            @Autowired JpaUserRepository jpaUserRepository
+            @Autowired final JpaUserRepository jpaUserRepository
     ) {
         userRepository = new UserRepositoryImpl(jpaUserRepository);
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/fixture/AuctionRepositoryImplFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/fixture/AuctionRepositoryImplFixture.java
@@ -19,14 +19,17 @@ import com.ddang.ddang.region.domain.Region;
 import com.ddang.ddang.region.infrastructure.persistence.JpaRegionRepository;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.infrastructure.persistence.UserRepositoryImpl;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class AuctionRepositoryImplFixture {
@@ -37,8 +40,7 @@ public class AuctionRepositoryImplFixture {
     @Autowired
     private JPAQueryFactory queryFactory;
 
-    @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private JpaRegionRepository regionRepository;
@@ -69,7 +71,11 @@ public class AuctionRepositoryImplFixture {
     protected User 구매자;
 
     @BeforeEach
-    void fixtureSetUp() {
+    void fixtureSetUp(
+            @Autowired JpaUserRepository jpaUserRepository
+    ) {
+        userRepository = new UserRepositoryImpl(jpaUserRepository);
+
         final Region 서울특별시 = new Region("서울특별시");
         final Region 강남구 = new Region("강남구");
         final Region 역삼동 = new Region("역삼동");

--- a/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/fixture/AuctionRepositoryImplFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/auction/infrastructure/persistence/fixture/AuctionRepositoryImplFixture.java
@@ -34,8 +34,7 @@ import java.util.List;
 @SuppressWarnings("NonAsciiCharacters")
 public class AuctionRepositoryImplFixture {
 
-    @Autowired
-    private JpaAuctionRepository jpaAuctionRepository;
+    private AuctionRepository auctionRepository;
 
     @Autowired
     private JPAQueryFactory queryFactory;
@@ -72,8 +71,11 @@ public class AuctionRepositoryImplFixture {
 
     @BeforeEach
     void fixtureSetUp(
+            @Autowired final JPAQueryFactory jpaQueryFactory,
+            @Autowired final JpaAuctionRepository jpaAuctionRepository,
             @Autowired final JpaUserRepository jpaUserRepository
     ) {
+        auctionRepository = new AuctionRepositoryImpl(jpaAuctionRepository, new QuerydslAuctionRepository(jpaQueryFactory));
         userRepository = new UserRepositoryImpl(jpaUserRepository);
 
         final Region 서울특별시 = new Region("서울특별시");
@@ -133,11 +135,6 @@ public class AuctionRepositoryImplFixture {
         삭제된_경매_엔티티.delete();
         bidding(저장된_경매_엔티티, 구매자);
         addAuctioneerCount(저장된_경매_엔티티, 1);
-
-        final AuctionRepository auctionRepository = new AuctionRepositoryImpl(
-                jpaAuctionRepository,
-                new QuerydslAuctionRepository(queryFactory)
-        );
 
         auctionRepository.save(삭제된_경매_엔티티);
         auctionRepository.save(저장된_경매_엔티티);

--- a/backend/ddang/src/test/java/com/ddang/ddang/authentication/application/AuthenticationServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/authentication/application/AuthenticationServiceTest.java
@@ -1,10 +1,5 @@
 package com.ddang.ddang.authentication.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-
 import com.ddang.ddang.authentication.application.dto.LoginInformationDto;
 import com.ddang.ddang.authentication.application.dto.TokenDto;
 import com.ddang.ddang.authentication.application.exception.InvalidWithdrawalException;
@@ -20,7 +15,7 @@ import com.ddang.ddang.device.application.DeviceTokenService;
 import com.ddang.ddang.device.infrastructure.persistence.JpaDeviceTokenRepository;
 import com.ddang.ddang.image.application.exception.ImageNotFoundException;
 import com.ddang.ddang.image.infrastructure.persistence.JpaProfileImageRepository;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -29,6 +24,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 
 @IsolateDatabase
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -48,7 +48,7 @@ class AuthenticationServiceTest extends AuthenticationServiceFixture {
     DeviceTokenService deviceTokenService;
 
     @Autowired
-    JpaUserRepository userRepository;
+    UserRepository userRepository;
 
     @Autowired
     JpaProfileImageRepository profileImageRepository;

--- a/backend/ddang/src/test/java/com/ddang/ddang/authentication/application/fixture/AuthenticationServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/authentication/application/fixture/AuthenticationServiceFixture.java
@@ -11,7 +11,7 @@ import com.ddang.ddang.image.domain.ProfileImage;
 import com.ddang.ddang.image.infrastructure.persistence.JpaProfileImageRepository;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -50,7 +50,7 @@ public class AuthenticationServiceFixture {
     protected String 유효하지_않은_타입의_리프레시_토큰 = "invalidRefreshToken";
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private JpaProfileImageRepository profileImageRepository;

--- a/backend/ddang/src/test/java/com/ddang/ddang/authentication/application/fixture/AuthenticationUserServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/authentication/application/fixture/AuthenticationUserServiceFixture.java
@@ -3,7 +3,7 @@ package com.ddang.ddang.authentication.application.fixture;
 import com.ddang.ddang.image.domain.ProfileImage;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class AuthenticationUserServiceFixture {
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     protected User 사용자;
     protected User 탈퇴한_사용자;

--- a/backend/ddang/src/test/java/com/ddang/ddang/bid/application/fixture/BidServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/bid/application/fixture/BidServiceFixture.java
@@ -13,17 +13,18 @@ import com.ddang.ddang.image.domain.ProfileImage;
 import com.ddang.ddang.notification.domain.NotificationStatus;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class BidServiceFixture {
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private AuctionRepository auctionRepository;
@@ -125,7 +126,10 @@ public class BidServiceFixture {
                                       .build();
         삭제된_경매.delete();
 
-        userRepository.saveAll(List.of(판매자, 입찰자1, 입찰자2));
+        userRepository.save(판매자);
+        userRepository.save(입찰자1);
+        userRepository.save(입찰자2);
+
         경매1.addAuctionImages(List.of(경매_이미지1));
         경매2.addAuctionImages(List.of(경매_이미지2));
         경매3.addAuctionImages(List.of(경매_이미지3));

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/application/fixture/ChatRoomServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/application/fixture/ChatRoomServiceFixture.java
@@ -26,11 +26,12 @@ import com.ddang.ddang.image.domain.AuctionImage;
 import com.ddang.ddang.image.domain.ProfileImage;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class ChatRoomServiceFixture {
@@ -42,7 +43,7 @@ public class ChatRoomServiceFixture {
     private JpaCategoryRepository categoryRepository;
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private JpaBidRepository bidRepository;
@@ -139,7 +140,12 @@ public class ChatRoomServiceFixture {
                                     .reliability(new Reliability(4.7d))
                                     .oauthId("12349")
                                     .build();
-        userRepository.saveAll(List.of(판매자, 구매자, 엔초, 제이미, 지토, 경매에_참여한_적_없는_사용자));
+        userRepository.save(판매자);
+        userRepository.save(구매자);
+        userRepository.save(엔초);
+        userRepository.save(제이미);
+        userRepository.save(지토);
+        userRepository.save(경매에_참여한_적_없는_사용자);
 
         채팅방이_없는_경매 = Auction.builder()
                                .seller(판매자)

--- a/backend/ddang/src/test/java/com/ddang/ddang/chat/application/fixture/MessageServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/chat/application/fixture/MessageServiceFixture.java
@@ -15,12 +15,13 @@ import com.ddang.ddang.chat.presentation.dto.request.ReadMessageRequest;
 import com.ddang.ddang.image.domain.ProfileImage;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class MessageServiceFixture {
@@ -32,7 +33,7 @@ public class MessageServiceFixture {
     private JpaMessageRepository messageRepository;
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private JpaChatRoomRepository chatRoomRepository;
@@ -90,7 +91,9 @@ public class MessageServiceFixture {
                                  .oauthId("12347")
                                  .build();
         탈퇴한_사용자.withdrawal();
-        userRepository.saveAll(List.of(발신자, 수신자, 탈퇴한_사용자));
+        userRepository.save(발신자);
+        userRepository.save(수신자);
+        userRepository.save(탈퇴한_사용자);
 
         final ChatRoom 채팅방 = new ChatRoom(경매, 발신자);
         final ChatRoom 탈퇴한_사용자와의_채팅방 = new ChatRoom(경매, 탈퇴한_사용자);

--- a/backend/ddang/src/test/java/com/ddang/ddang/device/application/fixture/DeviceTokenServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/device/application/fixture/DeviceTokenServiceFixture.java
@@ -6,11 +6,9 @@ import com.ddang.ddang.device.infrastructure.persistence.JpaDeviceTokenRepositor
 import com.ddang.ddang.image.domain.ProfileImage;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.List;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class DeviceTokenServiceFixture {
@@ -19,7 +17,7 @@ public class DeviceTokenServiceFixture {
     private JpaDeviceTokenRepository deviceTokenRepository;
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
     private String 초기_디바이스_토큰_값 = "initialDeviceToken";
     private DeviceToken 사용자의_디바이스_토큰;
 
@@ -35,19 +33,22 @@ public class DeviceTokenServiceFixture {
     @BeforeEach
     void setUp() {
         디바이스_토큰이_있는_사용자 = User.builder()
-                                    .name("디바이스 토큰이 있는 사용자")
-                                    .profileImage(new ProfileImage("upload.png", "store.png"))
-                                    .reliability(new Reliability(4.7d))
-                                    .oauthId("12345")
-                                    .build();
+                              .name("디바이스 토큰이 있는 사용자")
+                              .profileImage(new ProfileImage("upload.png", "store.png"))
+                              .reliability(new Reliability(4.7d))
+                              .oauthId("12345")
+                              .build();
         디바이스_토큰이_없는_사용자 = User.builder()
-                                    .name("디바이스 토큰이 없는 사용자")
-                                    .profileImage(new ProfileImage("upload.png", "store.png"))
-                                    .reliability(new Reliability(4.7d))
-                                    .oauthId("12346")
-                                    .build();
+                              .name("디바이스 토큰이 없는 사용자")
+                              .profileImage(new ProfileImage("upload.png", "store.png"))
+                              .reliability(new Reliability(4.7d))
+                              .oauthId("12346")
+                              .build();
         사용자의_디바이스_토큰 = new DeviceToken(디바이스_토큰이_있는_사용자, 사용_중인_디바이스_토큰_값);
-        userRepository.saveAll(List.of(디바이스_토큰이_있는_사용자, 디바이스_토큰이_없는_사용자));
+
+        userRepository.save(디바이스_토큰이_있는_사용자);
+        userRepository.save(디바이스_토큰이_없는_사용자);
+
         deviceTokenRepository.save(사용자의_디바이스_토큰);
 
         디바이스_토큰_저장을_위한_DTO = new PersistDeviceTokenDto(초기_디바이스_토큰_값);

--- a/backend/ddang/src/test/java/com/ddang/ddang/notification/application/fixture/FcmNotificationServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/notification/application/fixture/FcmNotificationServiceFixture.java
@@ -20,17 +20,18 @@ import com.ddang.ddang.notification.application.dto.CreateNotificationDto;
 import com.ddang.ddang.notification.domain.NotificationType;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class FcmNotificationServiceFixture {
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private JpaMessageRepository messageRepository;

--- a/backend/ddang/src/test/java/com/ddang/ddang/notification/application/fixture/NotificationEventListenerFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/notification/application/fixture/NotificationEventListenerFixture.java
@@ -26,17 +26,18 @@ import com.ddang.ddang.qna.domain.Answer;
 import com.ddang.ddang.qna.domain.Question;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class NotificationEventListenerFixture {
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private JpaChatRoomRepository chatRoomRepository;

--- a/backend/ddang/src/test/java/com/ddang/ddang/qna/application/fixture/AnswerServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/qna/application/fixture/AnswerServiceFixture.java
@@ -12,11 +12,12 @@ import com.ddang.ddang.qna.infrastructure.JpaAnswerRepository;
 import com.ddang.ddang.qna.infrastructure.JpaQuestionRepository;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class AnswerServiceFixture {
@@ -25,7 +26,7 @@ public class AnswerServiceFixture {
     private AuctionRepository auctionRepository;
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private JpaQuestionRepository questionRepository;
@@ -81,7 +82,10 @@ public class AnswerServiceFixture {
         답변 = new Answer("답변드립니다.");
         답변한_질문.addAnswer(답변);
 
-        userRepository.saveAll(List.of(판매자, 질문자, 판매자가_아닌_사용자));
+        userRepository.save(판매자);
+        userRepository.save(질문자);
+        userRepository.save(판매자가_아닌_사용자);
+
         auctionRepository.save(경매);
         questionRepository.saveAll(List.of(질문, 답변한_질문));
         answerRepository.save(답변);

--- a/backend/ddang/src/test/java/com/ddang/ddang/qna/application/fixture/QuestionServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/qna/application/fixture/QuestionServiceFixture.java
@@ -19,17 +19,18 @@ import com.ddang.ddang.region.domain.Region;
 import com.ddang.ddang.region.infrastructure.persistence.JpaRegionRepository;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class QuestionServiceFixture {
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private AuctionRepository auctionRepository;
@@ -149,7 +150,10 @@ public class QuestionServiceFixture {
         질문.addAnswer(답변1);
         질문2.addAnswer(답변2);
 
-        userRepository.saveAll(List.of(판매자, 질문자, 질문하지_않은_사용자));
+        userRepository.save(판매자);
+        userRepository.save(질문자);
+        userRepository.save(질문하지_않은_사용자);
+
         auctionRepository.save(경매);
         auctionRepository.save(질문과_답변이_존재하는_경매);
         auctionRepository.save(종료된_경매);

--- a/backend/ddang/src/test/java/com/ddang/ddang/report/application/fixture/AnswerReportServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/report/application/fixture/AnswerReportServiceFixture.java
@@ -17,11 +17,12 @@ import com.ddang.ddang.report.domain.AnswerReport;
 import com.ddang.ddang.report.infrastructure.persistence.JpaAnswerReportRepository;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class AnswerReportServiceFixture {
@@ -30,7 +31,7 @@ public class AnswerReportServiceFixture {
     private JpaCategoryRepository categoryRepository;
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private AuctionRepository auctionRepository;
@@ -124,7 +125,14 @@ public class AnswerReportServiceFixture {
         답변_신고2 = new AnswerReport(이미_신고한_신고자2, 답변, "신고합니다.");
         답변_신고3 = new AnswerReport(이미_신고한_신고자3, 답변, "신고합니다.");
 
-        userRepository.saveAll(List.of(판매자, 질문자, 답변자, 신고자, 이미_신고한_신고자1, 이미_신고한_신고자2, 이미_신고한_신고자3));
+        userRepository.save(판매자);
+        userRepository.save(질문자);
+        userRepository.save(답변자);
+        userRepository.save(신고자);
+        userRepository.save(이미_신고한_신고자1);
+        userRepository.save(이미_신고한_신고자2);
+        userRepository.save(이미_신고한_신고자3);
+
         categoryRepository.saveAll(List.of(전자기기_카테고리, 전자기기_서브_노트북_카테고리));
         auctionRepository.save(경매);
         questionRepository.save(질문);

--- a/backend/ddang/src/test/java/com/ddang/ddang/report/application/fixture/AuctionReportServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/report/application/fixture/AuctionReportServiceFixture.java
@@ -15,11 +15,12 @@ import com.ddang.ddang.report.domain.AuctionReport;
 import com.ddang.ddang.report.infrastructure.persistence.JpaAuctionReportRepository;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class AuctionReportServiceFixture {
@@ -31,7 +32,7 @@ public class AuctionReportServiceFixture {
     private JpaProfileImageRepository profileImageRepository;
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private JpaAuctionImageRepository auctionImageRepository;
@@ -107,14 +108,14 @@ public class AuctionReportServiceFixture {
         경매.addAuctionImages(List.of(경매_이미지));
 
         final Auction 삭제된_경매 = Auction.builder()
-                        .seller(판매자)
-                        .title("삭제된 경매 상품")
-                        .description("이것은 삭제된 경매 상품입니다.")
-                        .subCategory(전자기기_서브_노트북_카테고리)
-                        .bidUnit(new BidUnit(1_000))
-                        .startPrice(new Price(1_000))
-                        .closingTime(LocalDateTime.now())
-                        .build();
+                                      .seller(판매자)
+                                      .title("삭제된 경매 상품")
+                                      .description("이것은 삭제된 경매 상품입니다.")
+                                      .subCategory(전자기기_서브_노트북_카테고리)
+                                      .bidUnit(new BidUnit(1_000))
+                                      .startPrice(new Price(1_000))
+                                      .closingTime(LocalDateTime.now())
+                                      .build();
         삭제된_경매.addAuctionImages(List.of(경매_이미지));
         삭제된_경매.delete();
 
@@ -123,7 +124,12 @@ public class AuctionReportServiceFixture {
         final AuctionReport 경매_신고3 = new AuctionReport(이미_신고한_신고자3, 경매, "신고합니다");
 
         profileImageRepository.save(프로필_이미지);
-        userRepository.saveAll(List.of(판매자, 새로운_신고자, 이미_신고한_신고자1, 이미_신고한_신고자2, 이미_신고한_신고자3));
+
+        userRepository.save(판매자);
+        userRepository.save(새로운_신고자);
+        userRepository.save(이미_신고한_신고자1);
+        userRepository.save(이미_신고한_신고자2);
+        userRepository.save(이미_신고한_신고자3);
 
         categoryRepository.saveAll(List.of(전자기기_카테고리, 전자기기_서브_노트북_카테고리));
         auctionImageRepository.save(경매_이미지);

--- a/backend/ddang/src/test/java/com/ddang/ddang/report/application/fixture/ChatRoomReportServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/report/application/fixture/ChatRoomReportServiceFixture.java
@@ -17,11 +17,12 @@ import com.ddang.ddang.report.domain.ChatRoomReport;
 import com.ddang.ddang.report.infrastructure.persistence.JpaChatRoomReportRepository;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class ChatRoomReportServiceFixture {
@@ -33,7 +34,7 @@ public class ChatRoomReportServiceFixture {
     private JpaProfileImageRepository profileImageRepository;
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private JpaAuctionImageRepository auctionImageRepository;
@@ -142,7 +143,12 @@ public class ChatRoomReportServiceFixture {
         final ChatRoomReport 채팅방_신고3 = new ChatRoomReport(이미_신고한_구매자3, 채팅방3, "신고합니다.");
 
         profileImageRepository.save(프로필_이미지);
-        userRepository.saveAll(List.of(판매자겸_아직_신고하지_않은_신고자, 이미_신고한_구매자1, 이미_신고한_구매자2, 이미_신고한_구매자3, 채팅방_참여자가_아닌_사용자));
+
+        userRepository.save(판매자겸_아직_신고하지_않은_신고자);
+        userRepository.save(이미_신고한_구매자1);
+        userRepository.save(이미_신고한_구매자2);
+        userRepository.save(이미_신고한_구매자3);
+        userRepository.save(채팅방_참여자가_아닌_사용자);
 
         categoryRepository.saveAll(List.of(전자기기_카테고리, 전자기기_서브_노트북_카테고리));
         auctionImageRepository.save(경매_이미지);

--- a/backend/ddang/src/test/java/com/ddang/ddang/report/application/fixture/QuestionReportServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/report/application/fixture/QuestionReportServiceFixture.java
@@ -15,11 +15,12 @@ import com.ddang.ddang.report.domain.QuestionReport;
 import com.ddang.ddang.report.infrastructure.persistence.JpaQuestionReportRepository;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class QuestionReportServiceFixture {
@@ -28,7 +29,7 @@ public class QuestionReportServiceFixture {
     private JpaCategoryRepository categoryRepository;
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private AuctionRepository auctionRepository;
@@ -115,7 +116,13 @@ public class QuestionReportServiceFixture {
         질문_신고2 = new QuestionReport(이미_신고한_신고자2, 질문, "신고합니다.");
         질문_신고3 = new QuestionReport(이미_신고한_신고자3, 질문, "신고합니다.");
 
-        userRepository.saveAll(List.of(판매자, 질문자, 신고자, 이미_신고한_신고자1, 이미_신고한_신고자2, 이미_신고한_신고자3));
+        userRepository.save(판매자);
+        userRepository.save(질문자);
+        userRepository.save(신고자);
+        userRepository.save(이미_신고한_신고자1);
+        userRepository.save(이미_신고한_신고자2);
+        userRepository.save(이미_신고한_신고자3);
+
         categoryRepository.saveAll(List.of(전자기기_카테고리, 전자기기_서브_노트북_카테고리));
         auctionRepository.save(경매);
         questionRepository.save(질문);

--- a/backend/ddang/src/test/java/com/ddang/ddang/review/application/fixture/ReviewServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/review/application/fixture/ReviewServiceFixture.java
@@ -14,7 +14,7 @@ import com.ddang.ddang.review.domain.Score;
 import com.ddang.ddang.review.infrastructure.persistence.JpaReviewRepository;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -28,7 +28,7 @@ public class ReviewServiceFixture {
     private JpaCategoryRepository categoryRepository;
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private AuctionRepository auctionRepository;
@@ -105,7 +105,11 @@ public class ReviewServiceFixture {
                              .reliability(new Reliability(4.7d))
                              .oauthId("12347")
                              .build();
-        userRepository.saveAll(List.of(판매자1, 판매자2, 평가_안한_경매_판매자, 구매자, 경매_참여자가_아닌_사용자));
+        userRepository.save(판매자1);
+        userRepository.save(판매자2);
+        userRepository.save(평가_안한_경매_판매자);
+        userRepository.save(구매자);
+        userRepository.save(경매_참여자가_아닌_사용자);
 
         판매자1이_평가한_경매 = Auction.builder()
                               .seller(판매자1)

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/application/fixture/UserServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/application/fixture/UserServiceFixture.java
@@ -5,7 +5,7 @@ import com.ddang.ddang.image.domain.dto.StoreImageDto;
 import com.ddang.ddang.user.application.dto.UpdateUserDto;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -15,7 +15,7 @@ import org.springframework.mock.web.MockMultipartFile;
 public class UserServiceFixture {
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     protected Long 존재하지_않는_사용자_아이디 = -999L;
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/application/schedule/ReliabilityUpdateSchedulingServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/application/schedule/ReliabilityUpdateSchedulingServiceTest.java
@@ -4,8 +4,8 @@ import com.ddang.ddang.configuration.IsolateDatabase;
 import com.ddang.ddang.user.application.schedule.fixture.ReliabilityUpdateSchedulingServiceFixture;
 import com.ddang.ddang.user.domain.ReliabilityUpdateHistory;
 import com.ddang.ddang.user.domain.UserReliability;
+import com.ddang.ddang.user.domain.repository.ReliabilityUpdateHistoryRepository;
 import com.ddang.ddang.user.domain.repository.UserReliabilityRepository;
-import com.ddang.ddang.user.infrastructure.persistence.JpaReliabilityUpdateHistoryRepository;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -25,7 +25,7 @@ class ReliabilityUpdateSchedulingServiceTest extends ReliabilityUpdateScheduling
     ReliabilityUpdateSchedulingService reliabilityUpdateSchedulingService;
 
     @Autowired
-    JpaReliabilityUpdateHistoryRepository reliabilityUpdateHistoryRepository;
+    ReliabilityUpdateHistoryRepository reliabilityUpdateHistoryRepository;
 
     @Autowired
     UserReliabilityRepository userReliabilityRepository;

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/application/schedule/ReliabilityUpdateSchedulingServiceTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/application/schedule/ReliabilityUpdateSchedulingServiceTest.java
@@ -4,8 +4,8 @@ import com.ddang.ddang.configuration.IsolateDatabase;
 import com.ddang.ddang.user.application.schedule.fixture.ReliabilityUpdateSchedulingServiceFixture;
 import com.ddang.ddang.user.domain.ReliabilityUpdateHistory;
 import com.ddang.ddang.user.domain.UserReliability;
+import com.ddang.ddang.user.domain.repository.UserReliabilityRepository;
 import com.ddang.ddang.user.infrastructure.persistence.JpaReliabilityUpdateHistoryRepository;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserReliabilityRepository;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -28,7 +28,7 @@ class ReliabilityUpdateSchedulingServiceTest extends ReliabilityUpdateScheduling
     JpaReliabilityUpdateHistoryRepository reliabilityUpdateHistoryRepository;
 
     @Autowired
-    JpaUserReliabilityRepository userReliabilityRepository;
+    UserReliabilityRepository userReliabilityRepository;
 
     @Test
     void 사용자의_신뢰도를_갱신한다() {

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/application/schedule/fixture/ReliabilityUpdateSchedulingServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/application/schedule/fixture/ReliabilityUpdateSchedulingServiceFixture.java
@@ -11,9 +11,9 @@ import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.ReliabilityUpdateHistory;
 import com.ddang.ddang.user.domain.User;
 import com.ddang.ddang.user.domain.UserReliability;
+import com.ddang.ddang.user.domain.repository.UserReliabilityRepository;
 import com.ddang.ddang.user.domain.repository.UserRepository;
 import com.ddang.ddang.user.infrastructure.persistence.JpaReliabilityUpdateHistoryRepository;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserReliabilityRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -32,7 +32,7 @@ public class ReliabilityUpdateSchedulingServiceFixture {
     private JpaReviewRepository reviewRepository;
 
     @Autowired
-    private JpaUserReliabilityRepository userReliabilityRepository;
+    private UserReliabilityRepository userReliabilityRepository;
 
     @Autowired
     private JpaReliabilityUpdateHistoryRepository reliabilityUpdateHistoryRepository;
@@ -293,7 +293,9 @@ public class ReliabilityUpdateSchedulingServiceFixture {
         final UserReliability 구매자3_기존_신뢰도_반영_정보 = new UserReliability(구매자3_기존_평가_5개_새로운_평가_1개);
         구매자3_기존_신뢰도_반영_정보.updateReliability(new Reviews(List.of(구매자3_기존_평가1, 구매자3_기존_평가2, 구매자3_기존_평가3, 구매자3_기존_평가4, 구매자3_기존_평가5)));
 
-        userReliabilityRepository.saveAll(List.of(구매자1_기존_신뢰도_반영_정보, 구매자2_기존_신뢰도_반영_정보, 구매자3_기존_신뢰도_반영_정보));
+        userReliabilityRepository.save(구매자1_기존_신뢰도_반영_정보);
+        userReliabilityRepository.save(구매자2_기존_신뢰도_반영_정보);
+        userReliabilityRepository.save(구매자3_기존_신뢰도_반영_정보);
 
         reliabilityUpdateHistoryRepository.save(new ReliabilityUpdateHistory(기존에_적용된_평가_중_마지막_평가의_아이디));
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/application/schedule/fixture/ReliabilityUpdateSchedulingServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/application/schedule/fixture/ReliabilityUpdateSchedulingServiceFixture.java
@@ -11,9 +11,9 @@ import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.ReliabilityUpdateHistory;
 import com.ddang.ddang.user.domain.User;
 import com.ddang.ddang.user.domain.UserReliability;
+import com.ddang.ddang.user.domain.repository.ReliabilityUpdateHistoryRepository;
 import com.ddang.ddang.user.domain.repository.UserReliabilityRepository;
 import com.ddang.ddang.user.domain.repository.UserRepository;
-import com.ddang.ddang.user.infrastructure.persistence.JpaReliabilityUpdateHistoryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -35,7 +35,7 @@ public class ReliabilityUpdateSchedulingServiceFixture {
     private UserReliabilityRepository userReliabilityRepository;
 
     @Autowired
-    private JpaReliabilityUpdateHistoryRepository reliabilityUpdateHistoryRepository;
+    private ReliabilityUpdateHistoryRepository reliabilityUpdateHistoryRepository;
 
     private double 구매자1_기존_신뢰도_점수 = 3.5d;
     private double 구매자2_기존_신뢰도_점수 = 4.0d;

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/application/schedule/fixture/ReliabilityUpdateSchedulingServiceFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/application/schedule/fixture/ReliabilityUpdateSchedulingServiceFixture.java
@@ -11,18 +11,19 @@ import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.ReliabilityUpdateHistory;
 import com.ddang.ddang.user.domain.User;
 import com.ddang.ddang.user.domain.UserReliability;
+import com.ddang.ddang.user.domain.repository.UserRepository;
 import com.ddang.ddang.user.infrastructure.persistence.JpaReliabilityUpdateHistoryRepository;
 import com.ddang.ddang.user.infrastructure.persistence.JpaUserReliabilityRepository;
-import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class ReliabilityUpdateSchedulingServiceFixture {
 
     @Autowired
-    private JpaUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
     private AuctionRepository auctionRepository;
@@ -120,14 +121,14 @@ public class ReliabilityUpdateSchedulingServiceFixture {
                                       .reliability(Reliability.INITIAL_RELIABILITY)
                                       .oauthId("1006")
                                       .build();
-        userRepository.saveAll(List.of(판매자,
-                구매자1_기존_평가_2개_새로운_평가_1개,
-                구매자2_기존_평가_3개_새로운_평가_2개,
-                구매자3_기존_평가_5개_새로운_평가_1개,
-                구매자4_기존_평가_없고_새로운_평가_1개,
-                구매자5_기존_평가_없고_새로운_평가_3개,
-                구매자6_기존_평가_없고_새로운_평가_없음
-        ));
+        userRepository.save(판매자);
+        userRepository.save(구매자1_기존_평가_2개_새로운_평가_1개);
+        userRepository.save(구매자2_기존_평가_3개_새로운_평가_2개);
+        userRepository.save(구매자3_기존_평가_5개_새로운_평가_1개);
+        userRepository.save(구매자4_기존_평가_없고_새로운_평가_1개);
+        userRepository.save(구매자5_기존_평가_없고_새로운_평가_3개);
+        userRepository.save(구매자6_기존_평가_없고_새로운_평가_없음);
+
         final Auction 경매1 = Auction.builder()
                                    .title("경매1")
                                    .seller(판매자)

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/JpaReliabilityUpdateHistoryRepositoryTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/JpaReliabilityUpdateHistoryRepositoryTest.java
@@ -3,8 +3,6 @@ package com.ddang.ddang.user.infrastructure.persistence;
 import com.ddang.ddang.configuration.JpaConfiguration;
 import com.ddang.ddang.configuration.QuerydslConfiguration;
 import com.ddang.ddang.user.domain.ReliabilityUpdateHistory;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -23,9 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SuppressWarnings("NonAsciiCharacters")
 class JpaReliabilityUpdateHistoryRepositoryTest {
 
-    @PersistenceContext
-    EntityManager em;
-
     @Autowired
     JpaReliabilityUpdateHistoryRepository reliabilityUpdateHistoryRepository;
 
@@ -36,9 +31,6 @@ class JpaReliabilityUpdateHistoryRepositoryTest {
 
         // when
         final ReliabilityUpdateHistory actual = reliabilityUpdateHistoryRepository.save(reliabilityUpdateHistory);
-
-        em.flush();
-        em.clear();
 
         // then
         assertThat(actual.getId()).isPositive();
@@ -61,9 +53,6 @@ class JpaReliabilityUpdateHistoryRepositoryTest {
         final ReliabilityUpdateHistory history3 = new ReliabilityUpdateHistory();
 
         reliabilityUpdateHistoryRepository.saveAll(List.of(history1, history2, history3));
-
-        em.flush();
-        em.clear();
 
         // when
         final Optional<ReliabilityUpdateHistory> actual = reliabilityUpdateHistoryRepository.findFirstByOrderByIdDesc();

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/JpaReliabilityUpdateHistoryRepositoryTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/JpaReliabilityUpdateHistoryRepositoryTest.java
@@ -30,6 +30,21 @@ class JpaReliabilityUpdateHistoryRepositoryTest {
     JpaReliabilityUpdateHistoryRepository reliabilityUpdateHistoryRepository;
 
     @Test
+    void 신뢰도_업데이트_기록을_저장한다() {
+        // given
+        final ReliabilityUpdateHistory reliabilityUpdateHistory = new ReliabilityUpdateHistory();
+
+        // when
+        final ReliabilityUpdateHistory actual = reliabilityUpdateHistoryRepository.save(reliabilityUpdateHistory);
+
+        em.flush();
+        em.clear();
+
+        // then
+        assertThat(actual.getId()).isPositive();
+    }
+
+    @Test
     void 신뢰도_업데이트_기록이_없으면_빈_Optional을_반환한다() {
         // when
         final Optional<ReliabilityUpdateHistory> actual = reliabilityUpdateHistoryRepository.findFirstByOrderByIdDesc();

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/JpaUserReliabilityRepositoryTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/JpaUserReliabilityRepositoryTest.java
@@ -4,8 +4,6 @@ import com.ddang.ddang.configuration.JpaConfiguration;
 import com.ddang.ddang.configuration.QuerydslConfiguration;
 import com.ddang.ddang.user.domain.UserReliability;
 import com.ddang.ddang.user.infrastructure.persistence.fixture.JpaUserReliabilityRepositoryFixture;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -23,9 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SuppressWarnings("NonAsciiCharacters")
 class JpaUserReliabilityRepositoryTest extends JpaUserReliabilityRepositoryFixture {
 
-    @PersistenceContext
-    EntityManager em;
-
     @Autowired
     JpaUserReliabilityRepository userReliabilityRepository;
 
@@ -33,9 +28,6 @@ class JpaUserReliabilityRepositoryTest extends JpaUserReliabilityRepositoryFixtu
     void 사용자_신뢰도_정보를_저장한다() {
         // when
         UserReliability actual = userReliabilityRepository.save(저장하기_전_사용자_신뢰도_엔티티);
-
-        em.flush();
-        em.clear();
 
         // then
         assertThat(actual.getId()).isPositive();

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/JpaUserReliabilityRepositoryTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/JpaUserReliabilityRepositoryTest.java
@@ -4,6 +4,8 @@ import com.ddang.ddang.configuration.JpaConfiguration;
 import com.ddang.ddang.configuration.QuerydslConfiguration;
 import com.ddang.ddang.user.domain.UserReliability;
 import com.ddang.ddang.user.infrastructure.persistence.fixture.JpaUserReliabilityRepositoryFixture;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -21,8 +23,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SuppressWarnings("NonAsciiCharacters")
 class JpaUserReliabilityRepositoryTest extends JpaUserReliabilityRepositoryFixture {
 
+    @PersistenceContext
+    EntityManager em;
+
     @Autowired
     JpaUserReliabilityRepository userReliabilityRepository;
+
+    @Test
+    void 사용자_신뢰도_정보를_저장한다() {
+        // when
+        UserReliability actual = userReliabilityRepository.save(저장하기_전_사용자_신뢰도_엔티티);
+
+        em.flush();
+        em.clear();
+
+        // then
+        assertThat(actual.getId()).isPositive();
+    }
 
     @Test
     void 주어진_사용자_아이디에_해당하는_사용자_신뢰도_정보를_반환한다() {

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/JpaUserRepositoryTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/JpaUserRepositoryTest.java
@@ -69,6 +69,15 @@ class JpaUserRepositoryTest extends JpaUserRepositoryFixture {
     }
 
     @Test
+    void 회원탈퇴한_사용자의_id를_전달하면_빈_Optional을_반환한다() {
+        // when
+        final Optional<User> actual = userRepository.findById(탈퇴한_사용자.getId());
+
+        // then
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
     void 존재하는_oauthId를_전달하면_해당_사용자를_Optional로_감싸_반환한다() {
         // when
         final Optional<User> actual = userRepository.findByOauthId(사용자.getOauthInformation().getOauthId());
@@ -81,33 +90,6 @@ class JpaUserRepositoryTest extends JpaUserRepositoryFixture {
     void 존재하지_않는_oauthId를_전달하면_해당_사용자를_빈_Optional로_반환한다() {
         // when
         final Optional<User> actual = userRepository.findByOauthId(존재하지_않는_oauth_아이디);
-
-        // then
-        assertThat(actual).isEmpty();
-    }
-
-    @Test
-    void 회원가입과_탈퇴하지_않은_사용자_id를_전달하면_해당_사용자를_Optional로_감싸_반환한다() {
-        // when
-        final Optional<User> actual = userRepository.findByIdAndDeletedIsFalse(사용자.getId());
-
-        // then
-        assertThat(actual).contains(사용자);
-    }
-
-    @Test
-    void 회원탈퇴한_사용자의_id를_전달하면_빈_Optional을_반환한다() {
-        // when
-        final Optional<User> actual = userRepository.findByIdAndDeletedIsFalse(탈퇴한_사용자.getId());
-
-        // then
-        assertThat(actual).isEmpty();
-    }
-
-    @Test
-    void 없는_id를_전달하면_빈_Optional을_반환한다() {
-        // when
-        final Optional<User> actual = userRepository.findByIdAndDeletedIsFalse(존재하지_않는_사용자_아이디);
 
         // then
         assertThat(actual).isEmpty();

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/JpaUserRepositoryTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/JpaUserRepositoryTest.java
@@ -5,8 +5,6 @@ import com.ddang.ddang.configuration.QuerydslConfiguration;
 import com.ddang.ddang.user.domain.Reliability;
 import com.ddang.ddang.user.domain.User;
 import com.ddang.ddang.user.infrastructure.persistence.fixture.JpaUserRepositoryFixture;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -23,9 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class JpaUserRepositoryTest extends JpaUserRepositoryFixture {
-
-    @PersistenceContext
-    EntityManager em;
 
     @Autowired
     JpaUserRepository userRepository;
@@ -44,9 +39,6 @@ class JpaUserRepositoryTest extends JpaUserRepositoryFixture {
         final User actual = userRepository.save(user);
 
         // then
-        em.flush();
-        em.clear();
-
         assertThat(actual.getId()).isPositive();
     }
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/JpaUserRepositoryTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/JpaUserRepositoryTest.java
@@ -1,7 +1,5 @@
 package com.ddang.ddang.user.infrastructure.persistence;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.ddang.ddang.configuration.JpaConfiguration;
 import com.ddang.ddang.configuration.QuerydslConfiguration;
 import com.ddang.ddang.user.domain.Reliability;
@@ -9,13 +7,16 @@ import com.ddang.ddang.user.domain.User;
 import com.ddang.ddang.user.infrastructure.persistence.fixture.JpaUserRepositoryFixture;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @Import({JpaConfiguration.class, QuerydslConfiguration.class})
@@ -50,7 +51,25 @@ class JpaUserRepositoryTest extends JpaUserRepositoryFixture {
     }
 
     @Test
-    void 존재하는_oauthId를_전달하면_해당_회원을_Optional로_감싸_반환한다() {
+    void 존재하는_사용자_아이디를_전달하면_해당_사용자를_Optional로_감싸_반환한다() {
+        // when
+        final Optional<User> actual = userRepository.findById(사용자.getId());
+
+        // then
+        assertThat(actual).contains(사용자);
+    }
+
+    @Test
+    void 존재하지_않는_사용자_아이디를_전달하면_빈_Optional을_반환한다() {
+        // when
+        final Optional<User> actual = userRepository.findById(존재하지_않는_사용자_아이디);
+
+        // then
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    void 존재하는_oauthId를_전달하면_해당_사용자를_Optional로_감싸_반환한다() {
         // when
         final Optional<User> actual = userRepository.findByOauthId(사용자.getOauthInformation().getOauthId());
 
@@ -59,7 +78,7 @@ class JpaUserRepositoryTest extends JpaUserRepositoryFixture {
     }
 
     @Test
-    void 존재하지_않는_oauthId를_전달하면_해당_회원을_빈_Optional로_반환한다() {
+    void 존재하지_않는_oauthId를_전달하면_해당_사용자를_빈_Optional로_반환한다() {
         // when
         final Optional<User> actual = userRepository.findByOauthId(존재하지_않는_oauth_아이디);
 
@@ -68,7 +87,7 @@ class JpaUserRepositoryTest extends JpaUserRepositoryFixture {
     }
 
     @Test
-    void 회원가입과_탈퇴하지_않은_회원_id를_전달하면_해당_회원을_Optional로_감싸_반환한다() {
+    void 회원가입과_탈퇴하지_않은_사용자_id를_전달하면_해당_사용자를_Optional로_감싸_반환한다() {
         // when
         final Optional<User> actual = userRepository.findByIdAndDeletedIsFalse(사용자.getId());
 
@@ -77,7 +96,7 @@ class JpaUserRepositoryTest extends JpaUserRepositoryFixture {
     }
 
     @Test
-    void 회원탈퇴한_회원의_id를_전달하면_빈_Optional을_반환한다() {
+    void 회원탈퇴한_사용자의_id를_전달하면_빈_Optional을_반환한다() {
         // when
         final Optional<User> actual = userRepository.findByIdAndDeletedIsFalse(탈퇴한_사용자.getId());
 
@@ -95,7 +114,7 @@ class JpaUserRepositoryTest extends JpaUserRepositoryFixture {
     }
 
     @Test
-    void 회원탈퇴한_회원의_id를_전달하면_참을_반환한다() {
+    void 회원탈퇴한_사용자의_id를_전달하면_참을_반환한다() {
         // when
         final boolean actual = userRepository.existsByIdAndDeletedIsTrue(탈퇴한_사용자.getId());
 
@@ -104,7 +123,7 @@ class JpaUserRepositoryTest extends JpaUserRepositoryFixture {
     }
 
     @Test
-    void 회원탈퇴하지_않거나_회원가입하지_않은_회원의_id를_전달하면_거짓을_반환한다() {
+    void 회원탈퇴하지_않거나_회원가입하지_않은_사용자의_id를_전달하면_거짓을_반환한다() {
         // when
         final boolean actual = userRepository.existsByIdAndDeletedIsTrue(사용자.getId());
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/ReliabilityUpdateHistoryRepositoryImplTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/ReliabilityUpdateHistoryRepositoryImplTest.java
@@ -1,0 +1,70 @@
+package com.ddang.ddang.user.infrastructure.persistence;
+
+import com.ddang.ddang.configuration.JpaConfiguration;
+import com.ddang.ddang.configuration.QuerydslConfiguration;
+import com.ddang.ddang.user.domain.ReliabilityUpdateHistory;
+import com.ddang.ddang.user.domain.repository.ReliabilityUpdateHistoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({JpaConfiguration.class, QuerydslConfiguration.class})
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ReliabilityUpdateHistoryRepositoryImplTest {
+
+    ReliabilityUpdateHistoryRepository reliabilityUpdateHistoryRepository;
+
+    @BeforeEach
+    void setUp(@Autowired JpaReliabilityUpdateHistoryRepository jpaReliabilityUpdateHistoryRepository) {
+        reliabilityUpdateHistoryRepository = new ReliabilityUpdateHistoryRepositoryImpl(jpaReliabilityUpdateHistoryRepository);
+    }
+
+    @Test
+    void 신뢰도_업데이트_기록을_저장한다() {
+        // given
+        final ReliabilityUpdateHistory reliabilityUpdateHistory = new ReliabilityUpdateHistory();
+
+        // when
+        final ReliabilityUpdateHistory actual = reliabilityUpdateHistoryRepository.save(reliabilityUpdateHistory);
+
+        // then
+        assertThat(actual.getId()).isPositive();
+    }
+
+    @Test
+    void 신뢰도_업데이트_기록이_없으면_빈_Optional을_반환한다() {
+        // when
+        final Optional<ReliabilityUpdateHistory> actual = reliabilityUpdateHistoryRepository.findFirstByOrderByIdDesc();
+
+        // then
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    void 신뢰도_업데이트_기록의_아이디가_가장_큰_것을_조회한다() {
+        // given
+        final ReliabilityUpdateHistory history1 = new ReliabilityUpdateHistory();
+        final ReliabilityUpdateHistory history2 = new ReliabilityUpdateHistory();
+        final ReliabilityUpdateHistory history3 = new ReliabilityUpdateHistory();
+
+        reliabilityUpdateHistoryRepository.save(history1);
+        reliabilityUpdateHistoryRepository.save(history2);
+        reliabilityUpdateHistoryRepository.save(history3);
+
+        // when
+        final Optional<ReliabilityUpdateHistory> actual = reliabilityUpdateHistoryRepository.findFirstByOrderByIdDesc();
+
+        // then
+        assertThat(actual).contains(history3);
+    }
+}

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/ReliabilityUpdateHistoryRepositoryImplTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/ReliabilityUpdateHistoryRepositoryImplTest.java
@@ -25,7 +25,7 @@ class ReliabilityUpdateHistoryRepositoryImplTest {
     ReliabilityUpdateHistoryRepository reliabilityUpdateHistoryRepository;
 
     @BeforeEach
-    void setUp(@Autowired JpaReliabilityUpdateHistoryRepository jpaReliabilityUpdateHistoryRepository) {
+    void setUp(@Autowired final JpaReliabilityUpdateHistoryRepository jpaReliabilityUpdateHistoryRepository) {
         reliabilityUpdateHistoryRepository = new ReliabilityUpdateHistoryRepositoryImpl(jpaReliabilityUpdateHistoryRepository);
     }
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/UserReliabilityRepositoryImplTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/UserReliabilityRepositoryImplTest.java
@@ -26,7 +26,7 @@ class UserReliabilityRepositoryImplTest extends UserReliabilityRepositoryImplFix
     UserReliabilityRepository userReliabilityRepository;
 
     @BeforeEach
-    void setUp(@Autowired JpaUserReliabilityRepository jpaUserReliabilityRepository) {
+    void setUp(@Autowired final JpaUserReliabilityRepository jpaUserReliabilityRepository) {
         userReliabilityRepository = new UserReliabilityRepositoryImpl(jpaUserReliabilityRepository);
     }
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/UserReliabilityRepositoryImplTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/UserReliabilityRepositoryImplTest.java
@@ -1,0 +1,50 @@
+package com.ddang.ddang.user.infrastructure.persistence;
+
+import com.ddang.ddang.configuration.JpaConfiguration;
+import com.ddang.ddang.configuration.QuerydslConfiguration;
+import com.ddang.ddang.user.domain.UserReliability;
+import com.ddang.ddang.user.domain.repository.UserReliabilityRepository;
+import com.ddang.ddang.user.infrastructure.persistence.fixture.UserReliabilityRepositoryImplFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({JpaConfiguration.class, QuerydslConfiguration.class})
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class UserReliabilityRepositoryImplTest extends UserReliabilityRepositoryImplFixture {
+
+    UserReliabilityRepository userReliabilityRepository;
+
+    @BeforeEach
+    void setUp(@Autowired JpaUserReliabilityRepository jpaUserReliabilityRepository) {
+        userReliabilityRepository = new UserReliabilityRepositoryImpl(jpaUserReliabilityRepository);
+    }
+
+    @Test
+    void 사용자_신뢰도_정보를_저장한다() {
+        // when
+        UserReliability actual = userReliabilityRepository.save(저장하기_전_사용자_신뢰도_엔티티);
+
+        // then
+        assertThat(actual.getId()).isPositive();
+    }
+
+    @Test
+    void 주어진_사용자_아이디에_해당하는_사용자_신뢰도_정보를_반환한다() {
+        // when
+        final Optional<UserReliability> actual = userReliabilityRepository.findByUserId(사용자.getId());
+
+        // then
+        assertThat(actual).contains(사용자_신뢰도_정보);
+    }
+}

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/UserReliabilityRepositoryImplTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/UserReliabilityRepositoryImplTest.java
@@ -33,7 +33,7 @@ class UserReliabilityRepositoryImplTest extends UserReliabilityRepositoryImplFix
     @Test
     void 사용자_신뢰도_정보를_저장한다() {
         // when
-        UserReliability actual = userReliabilityRepository.save(저장하기_전_사용자_신뢰도_엔티티);
+        final UserReliability actual = userReliabilityRepository.save(저장하기_전_사용자_신뢰도_엔티티);
 
         // then
         assertThat(actual.getId()).isPositive();

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/UserRepositoryImplTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/UserRepositoryImplTest.java
@@ -67,6 +67,15 @@ class UserRepositoryImplTest extends UserRepositoryImplFixture {
     }
 
     @Test
+    void 회원탈퇴한_사용자의_id를_전달하면_빈_Optional을_반환한다() {
+        // when
+        final Optional<User> actual = userRepository.findById(탈퇴한_사용자.getId());
+
+        // then
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
     void 존재하는_oauthId를_전달하면_해당_사용자를_Optional로_감싸_반환한다() {
         // when
         final Optional<User> actual = userRepository.findByOauthId(사용자.getOauthInformation().getOauthId());
@@ -79,33 +88,6 @@ class UserRepositoryImplTest extends UserRepositoryImplFixture {
     void 존재하지_않는_oauthId를_전달하면_해당_사용자를_빈_Optional로_반환한다() {
         // when
         final Optional<User> actual = userRepository.findByOauthId(존재하지_않는_oauth_아이디);
-
-        // then
-        assertThat(actual).isEmpty();
-    }
-
-    @Test
-    void 회원가입과_탈퇴하지_않은_사용자_id를_전달하면_해당_사용자를_Optional로_감싸_반환한다() {
-        // when
-        final Optional<User> actual = userRepository.findByIdAndDeletedIsFalse(사용자.getId());
-
-        // then
-        assertThat(actual).contains(사용자);
-    }
-
-    @Test
-    void 회원탈퇴한_사용자의_id를_전달하면_빈_Optional을_반환한다() {
-        // when
-        final Optional<User> actual = userRepository.findByIdAndDeletedIsFalse(탈퇴한_사용자.getId());
-
-        // then
-        assertThat(actual).isEmpty();
-    }
-
-    @Test
-    void 없는_id를_전달하면_빈_Optional을_반환한다() {
-        // when
-        final Optional<User> actual = userRepository.findByIdAndDeletedIsFalse(존재하지_않는_사용자_아이디);
 
         // then
         assertThat(actual).isEmpty();

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/UserRepositoryImplTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/UserRepositoryImplTest.java
@@ -1,0 +1,149 @@
+package com.ddang.ddang.user.infrastructure.persistence;
+
+import com.ddang.ddang.configuration.JpaConfiguration;
+import com.ddang.ddang.configuration.QuerydslConfiguration;
+import com.ddang.ddang.user.domain.Reliability;
+import com.ddang.ddang.user.domain.User;
+import com.ddang.ddang.user.domain.repository.UserRepository;
+import com.ddang.ddang.user.infrastructure.persistence.fixture.UserRepositoryImplFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({JpaConfiguration.class, QuerydslConfiguration.class})
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class UserRepositoryImplTest extends UserRepositoryImplFixture {
+
+    UserRepository userRepository;
+
+    @BeforeEach
+    void setUp(@Autowired JpaUserRepository jpaUserRepository) {
+        userRepository = new UserRepositoryImpl(jpaUserRepository);
+    }
+
+    @Test
+    void 사용자를_저장한다() {
+        // given
+        final User user = User.builder()
+                              .name("새로운 사용자")
+                              .profileImage(프로필_이미지)
+                              .reliability(new Reliability(4.7d))
+                              .oauthId("12345")
+                              .build();
+
+        // when
+        final User actual = userRepository.save(user);
+
+        // then
+        assertThat(actual.getId()).isPositive();
+    }
+
+    @Test
+    void 존재하는_사용자_아이디를_전달하면_해당_사용자를_Optional로_감싸_반환한다() {
+        // when
+        final Optional<User> actual = userRepository.findById(사용자.getId());
+
+        // then
+        assertThat(actual).contains(사용자);
+    }
+
+    @Test
+    void 존재하지_않는_사용자_아이디를_전달하면_빈_Optional을_반환한다() {
+        // when
+        final Optional<User> actual = userRepository.findById(존재하지_않는_사용자_아이디);
+
+        // then
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    void 존재하는_oauthId를_전달하면_해당_사용자를_Optional로_감싸_반환한다() {
+        // when
+        final Optional<User> actual = userRepository.findByOauthId(사용자.getOauthInformation().getOauthId());
+
+        // then
+        assertThat(actual).contains(사용자);
+    }
+
+    @Test
+    void 존재하지_않는_oauthId를_전달하면_해당_사용자를_빈_Optional로_반환한다() {
+        // when
+        final Optional<User> actual = userRepository.findByOauthId(존재하지_않는_oauth_아이디);
+
+        // then
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    void 회원가입과_탈퇴하지_않은_사용자_id를_전달하면_해당_사용자를_Optional로_감싸_반환한다() {
+        // when
+        final Optional<User> actual = userRepository.findByIdAndDeletedIsFalse(사용자.getId());
+
+        // then
+        assertThat(actual).contains(사용자);
+    }
+
+    @Test
+    void 회원탈퇴한_사용자의_id를_전달하면_빈_Optional을_반환한다() {
+        // when
+        final Optional<User> actual = userRepository.findByIdAndDeletedIsFalse(탈퇴한_사용자.getId());
+
+        // then
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    void 없는_id를_전달하면_빈_Optional을_반환한다() {
+        // when
+        final Optional<User> actual = userRepository.findByIdAndDeletedIsFalse(존재하지_않는_사용자_아이디);
+
+        // then
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    void 회원탈퇴한_사용자의_id를_전달하면_참을_반환한다() {
+        // when
+        final boolean actual = userRepository.existsByIdAndDeletedIsTrue(탈퇴한_사용자.getId());
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void 회원탈퇴하지_않거나_회원가입하지_않은_사용자의_id를_전달하면_거짓을_반환한다() {
+        // when
+        final boolean actual = userRepository.existsByIdAndDeletedIsTrue(사용자.getId());
+
+        // then
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void 이름이_아직_없다면_거짓을_반환한다() {
+        // when
+        final boolean actual = userRepository.existsByNameEndingWith(존재하지_않는_사용자_이름);
+
+        // then
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void 이름이_있다면_참을_반환한다() {
+        // when
+        final boolean actual = userRepository.existsByNameEndingWith(존재하는_사용자_이름);
+
+        // then
+        assertThat(actual).isTrue();
+    }
+}

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/UserRepositoryImplTest.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/UserRepositoryImplTest.java
@@ -27,7 +27,7 @@ class UserRepositoryImplTest extends UserRepositoryImplFixture {
     UserRepository userRepository;
 
     @BeforeEach
-    void setUp(@Autowired JpaUserRepository jpaUserRepository) {
+    void setUp(@Autowired final JpaUserRepository jpaUserRepository) {
         userRepository = new UserRepositoryImpl(jpaUserRepository);
     }
 

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/fixture/JpaUserReliabilityRepositoryFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/fixture/JpaUserReliabilityRepositoryFixture.java
@@ -24,6 +24,7 @@ public class JpaUserReliabilityRepositoryFixture {
     private JpaUserReliabilityRepository userReliabilityRepository;
 
     protected User 사용자;
+    protected UserReliability 저장하기_전_사용자_신뢰도_엔티티;
     protected UserReliability 사용자_신뢰도_정보;
 
     @BeforeEach
@@ -35,6 +36,8 @@ public class JpaUserReliabilityRepositoryFixture {
                   .oauthId("12345")
                   .build();
         userRepository.save(사용자);
+
+        저장하기_전_사용자_신뢰도_엔티티 = new UserReliability(사용자);
 
         사용자_신뢰도_정보 = new UserReliability(사용자);
         userReliabilityRepository.save(사용자_신뢰도_정보);

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/fixture/UserReliabilityRepositoryImplFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/fixture/UserReliabilityRepositoryImplFixture.java
@@ -1,0 +1,47 @@
+package com.ddang.ddang.user.infrastructure.persistence.fixture;
+
+import com.ddang.ddang.image.domain.ProfileImage;
+import com.ddang.ddang.user.domain.Reliability;
+import com.ddang.ddang.user.domain.User;
+import com.ddang.ddang.user.domain.UserReliability;
+import com.ddang.ddang.user.domain.repository.UserReliabilityRepository;
+import com.ddang.ddang.user.domain.repository.UserRepository;
+import com.ddang.ddang.user.infrastructure.persistence.JpaUserReliabilityRepository;
+import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.infrastructure.persistence.UserReliabilityRepositoryImpl;
+import com.ddang.ddang.user.infrastructure.persistence.UserRepositoryImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class UserReliabilityRepositoryImplFixture {
+
+    private UserRepository userRepository;
+    private UserReliabilityRepository userReliabilityRepository;
+
+    protected User 사용자;
+    protected UserReliability 저장하기_전_사용자_신뢰도_엔티티;
+    protected UserReliability 사용자_신뢰도_정보;
+
+    @BeforeEach
+    void setUp(
+            @Autowired JpaUserRepository jpaUserRepository,
+            @Autowired JpaUserReliabilityRepository jpaUserReliabilityRepository
+    ) {
+        userRepository = new UserRepositoryImpl(jpaUserRepository);
+        userReliabilityRepository = new UserReliabilityRepositoryImpl(jpaUserReliabilityRepository);
+
+        사용자 = User.builder()
+                  .name("사용자")
+                  .profileImage(new ProfileImage("uplad.png", "store.png"))
+                  .reliability(Reliability.INITIAL_RELIABILITY)
+                  .oauthId("12345")
+                  .build();
+        userRepository.save(사용자);
+
+        저장하기_전_사용자_신뢰도_엔티티 = new UserReliability(사용자);
+
+        사용자_신뢰도_정보 = new UserReliability(사용자);
+        userReliabilityRepository.save(사용자_신뢰도_정보);
+    }
+}

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/fixture/UserReliabilityRepositoryImplFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/fixture/UserReliabilityRepositoryImplFixture.java
@@ -25,8 +25,8 @@ public class UserReliabilityRepositoryImplFixture {
 
     @BeforeEach
     void setUp(
-            @Autowired JpaUserRepository jpaUserRepository,
-            @Autowired JpaUserReliabilityRepository jpaUserReliabilityRepository
+            @Autowired final JpaUserRepository jpaUserRepository,
+            @Autowired final JpaUserReliabilityRepository jpaUserReliabilityRepository
     ) {
         userRepository = new UserRepositoryImpl(jpaUserRepository);
         userReliabilityRepository = new UserReliabilityRepositoryImpl(jpaUserReliabilityRepository);

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/fixture/UserRepositoryImplFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/fixture/UserRepositoryImplFixture.java
@@ -1,0 +1,50 @@
+package com.ddang.ddang.user.infrastructure.persistence.fixture;
+
+import com.ddang.ddang.image.domain.ProfileImage;
+import com.ddang.ddang.user.domain.Reliability;
+import com.ddang.ddang.user.domain.User;
+import com.ddang.ddang.user.domain.repository.UserRepository;
+import com.ddang.ddang.user.infrastructure.persistence.JpaUserRepository;
+import com.ddang.ddang.user.infrastructure.persistence.UserRepositoryImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class UserRepositoryImplFixture {
+
+    private UserRepository userRepository;
+
+    protected ProfileImage 프로필_이미지 = new ProfileImage("upload.png", "store.png");
+    protected String 존재하지_않는_oauth_아이디 = "invalidOauthId";
+    protected Long 존재하지_않는_사용자_아이디 = -999L;
+    protected String 존재하지_않는_사용자_이름 = "새로운 이름";
+    protected String 존재하는_사용자_이름;
+    protected User 사용자;
+    protected User 탈퇴한_사용자;
+
+    @BeforeEach
+    void setUp(@Autowired JpaUserRepository jpaUserRepository) {
+        userRepository = new UserRepositoryImpl(jpaUserRepository);
+
+        final ProfileImage 사용자_프로필_이미지 = new ProfileImage("upload.png", "store.png");
+        사용자 = User.builder()
+                  .name("사용자")
+                  .profileImage(사용자_프로필_이미지)
+                  .reliability(new Reliability(4.7d))
+                  .oauthId("12345")
+                  .build();
+
+        탈퇴한_사용자 = User.builder()
+                      .name("탈퇴한 사용자")
+                      .profileImage(사용자_프로필_이미지)
+                      .reliability(new Reliability(4.7d))
+                      .oauthId("12345")
+                      .build();
+        탈퇴한_사용자.withdrawal();
+
+        userRepository.save(사용자);
+        userRepository.save(탈퇴한_사용자);
+
+        존재하는_사용자_이름 = 사용자.getName();
+    }
+}

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/fixture/UserRepositoryImplFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/fixture/UserRepositoryImplFixture.java
@@ -23,7 +23,7 @@ public class UserRepositoryImplFixture {
     protected User 탈퇴한_사용자;
 
     @BeforeEach
-    void setUp(@Autowired JpaUserRepository jpaUserRepository) {
+    void setUpFixture(@Autowired JpaUserRepository jpaUserRepository) {
         userRepository = new UserRepositoryImpl(jpaUserRepository);
 
         final ProfileImage 사용자_프로필_이미지 = new ProfileImage("upload.png", "store.png");

--- a/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/fixture/UserRepositoryImplFixture.java
+++ b/backend/ddang/src/test/java/com/ddang/ddang/user/infrastructure/persistence/fixture/UserRepositoryImplFixture.java
@@ -23,7 +23,7 @@ public class UserRepositoryImplFixture {
     protected User 탈퇴한_사용자;
 
     @BeforeEach
-    void setUpFixture(@Autowired JpaUserRepository jpaUserRepository) {
+    void fixtureSetUp(@Autowired final JpaUserRepository jpaUserRepository) {
         userRepository = new UserRepositoryImpl(jpaUserRepository);
 
         final ProfileImage 사용자_프로필_이미지 = new ProfileImage("upload.png", "store.png");


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
User 관련 인프라 리팩토링

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
- JpaUserRepository의 findByIdAndDeletedIsFalse()를 삭제하고 findById에 JPQL 추가했습니다.
- JpaUserReliabilityRepository의 findByUserId() 메서드에서 User를 fetch join 해서 가져오도록 했습니다.

## 📎 Issue 번호
- closed #655 
