### PR TITLE
소셜 로그인할 때 만약 첫 회원가입인 경우, 닉네임 및 프로필 설정페이지를 먼저 보여주기

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,9 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
+            android:name=".feature.onboarding.OnBoardingActivity"
+            android:exported="false" />
+        <activity
             android:name=".feature.imageDetail.ImageDetailActivity"
             android:exported="false" />
         <activity

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/common/ErrorTypeHandler.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/common/ErrorTypeHandler.kt
@@ -1,10 +1,45 @@
 package com.ddangddangddang.android.feature.common
 
 import android.app.Activity
+import android.view.View
 import androidx.annotation.StringRes
+import androidx.fragment.app.Fragment
 import com.ddangddangddang.android.util.view.Toaster
+import com.ddangddangddang.android.util.view.showSnackbar
 
 fun Activity.notifyFailureMessage(errorType: ErrorType, @StringRes defaultMessageId: Int) {
     val defaultMessage = getString(defaultMessageId)
     Toaster.showShort(this, errorType.message ?: defaultMessage)
+}
+
+fun Activity.notifyFailureSnackBar(
+    anchorView: View,
+    errorType: ErrorType,
+    @StringRes defaultMessageId: Int,
+    @StringRes actionMessageId: Int,
+    action: () -> Unit = {},
+) {
+    val defaultMessage = getString(defaultMessageId)
+    val actionMessage = getString(actionMessageId)
+    anchorView.showSnackbar(
+        message = errorType.message ?: defaultMessage,
+        actionMessage = actionMessage,
+        action,
+    )
+}
+
+fun Fragment.notifyFailureSnackBar(
+    anchorView: View,
+    errorType: ErrorType,
+    @StringRes defaultMessageId: Int,
+    @StringRes actionMessageId: Int,
+    action: () -> Unit = {},
+) {
+    val defaultMessage = getString(defaultMessageId)
+    val actionMessage = getString(actionMessageId)
+    anchorView.showSnackbar(
+        message = errorType.message ?: defaultMessage,
+        actionMessage = actionMessage,
+        action,
+    )
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/DetailFragmentType.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/DetailFragmentType.kt
@@ -3,6 +3,7 @@ package com.ddangddangddang.android.feature.detail
 import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
 import com.ddangddangddang.android.R
+import com.ddangddangddang.android.feature.detail.bidHistory.BidHistoryFragment
 import com.ddangddangddang.android.feature.detail.info.AuctionInfoFragment
 import com.ddangddangddang.android.feature.detail.qna.QnaFragment
 
@@ -18,11 +19,11 @@ enum class DetailFragmentType(val tag: String, @StringRes val nameId: Int) {
             return QnaFragment()
         }
     },
-//    BID_HISTORY("bid_history_tag", R.string.detail_auction_bid_history) {
-//        override fun create(): Fragment {
-//            return BidHistoryFragment()
-//        }
-//    },
+    BID_HISTORY("bid_history_tag", R.string.detail_auction_bid_history) {
+        override fun create(): Fragment {
+            return BidHistoryFragment()
+        }
+    },
     ;
 
     abstract fun create(): Fragment

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/login/LoginActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/login/LoginActivity.kt
@@ -8,6 +8,7 @@ import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.ActivityLoginBinding
 import com.ddangddangddang.android.feature.common.ErrorType
 import com.ddangddangddang.android.feature.main.MainActivity
+import com.ddangddangddang.android.feature.onboarding.OnBoardingActivity
 import com.ddangddangddang.android.global.AnalyticsDelegate
 import com.ddangddangddang.android.global.AnalyticsDelegateImpl
 import com.ddangddangddang.android.util.binding.BindingActivity
@@ -38,6 +39,7 @@ class LoginActivity :
                 is LoginViewModel.LoginEvent.KakaoLoginEvent -> loginByKakao()
                 is LoginViewModel.LoginEvent.CompleteLoginEvent -> navigateToMain()
                 is LoginViewModel.LoginEvent.FailureLoginEvent -> notifyLoginFailed(it.type)
+                LoginViewModel.LoginEvent.SignUpEvent -> navigateToOnBoarding()
             }
         }
     }
@@ -85,6 +87,11 @@ class LoginActivity :
 
     private fun navigateToMain() {
         startActivity(Intent(this, MainActivity::class.java))
+        finish()
+    }
+
+    private fun navigateToOnBoarding() {
+        startActivity(Intent(this, OnBoardingActivity::class.java))
         finish()
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/login/LoginActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/login/LoginActivity.kt
@@ -1,5 +1,6 @@
 package com.ddangddangddang.android.feature.login
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
@@ -86,12 +87,12 @@ class LoginActivity :
     }
 
     private fun navigateToMain() {
-        startActivity(Intent(this, MainActivity::class.java))
+        startActivity(MainActivity.getIntent(this))
         finish()
     }
 
     private fun navigateToOnBoarding() {
-        startActivity(Intent(this, OnBoardingActivity::class.java))
+        startActivity(OnBoardingActivity.getIntent(this))
         finish()
     }
 
@@ -102,5 +103,11 @@ class LoginActivity :
             message = type.message ?: defaultMessage,
             actionMessage = actionMessage,
         )
+    }
+
+    companion object {
+        fun getIntent(context: Context): Intent {
+            return Intent(context, LoginActivity::class.java)
+        }
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/login/LoginViewModel.kt
@@ -34,16 +34,32 @@ class LoginViewModel @Inject constructor(
 
             val request = KakaoLoginRequest(accessToken, deviceToken)
             when (val response = repository.loginByKakao(request)) {
-                is ApiResponse.Success -> _event.value = LoginEvent.CompleteLoginEvent
-                is ApiResponse.Failure -> _event.value = LoginEvent.FailureLoginEvent(ErrorType.FAILURE(response.error))
-                is ApiResponse.NetworkError -> _event.value = LoginEvent.FailureLoginEvent(ErrorType.NETWORK_ERROR)
-                is ApiResponse.Unexpected -> _event.value = LoginEvent.FailureLoginEvent(ErrorType.UNEXPECTED)
+                is ApiResponse.Success -> {
+                    if (response.body.isSignUpUser) {
+                        _event.value = LoginEvent.SignUpEvent
+                    } else {
+                        _event.value = LoginEvent.CompleteLoginEvent
+                    }
+                }
+
+                is ApiResponse.Failure -> {
+                    _event.value = LoginEvent.FailureLoginEvent(ErrorType.FAILURE(response.error))
+                }
+
+                is ApiResponse.NetworkError -> {
+                    _event.value = LoginEvent.FailureLoginEvent(ErrorType.NETWORK_ERROR)
+                }
+
+                is ApiResponse.Unexpected -> {
+                    _event.value = LoginEvent.FailureLoginEvent(ErrorType.UNEXPECTED)
+                }
             }
         }
     }
 
     sealed class LoginEvent {
         object KakaoLoginEvent : LoginEvent()
+        object SignUpEvent : LoginEvent()
         object CompleteLoginEvent : LoginEvent()
         data class FailureLoginEvent(val type: ErrorType) : LoginEvent()
     }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/login/LoginViewModel.kt
@@ -28,7 +28,7 @@ class LoginViewModel @Inject constructor(
         viewModelScope.launch {
             val deviceToken = repository.getDeviceToken()
             if (deviceToken.isNullOrBlank()) {
-                LoginEvent.FailureLoginEvent(ErrorType.UNEXPECTED)
+                _event.value = LoginEvent.FailureLoginEvent(ErrorType.UNEXPECTED)
                 return@launch
             }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.ddangddangddang.android.feature.main
 
 import android.Manifest
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
@@ -163,5 +164,11 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         val intent = Intent(ACTION_APP_NOTIFICATION_SETTINGS)
         intent.putExtra(EXTRA_APP_PACKAGE, this.packageName)
         startActivity(intent)
+    }
+
+    companion object {
+        fun getIntent(context: Context): Intent {
+            return Intent(context, MainActivity::class.java)
+        }
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingActivity.kt
@@ -1,5 +1,6 @@
 package com.ddangddangddang.android.feature.onboarding
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
@@ -62,7 +63,13 @@ class OnBoardingActivity :
     }
 
     private fun navigateToMain() {
-        startActivity(Intent(this, MainActivity::class.java))
+        startActivity(MainActivity.getIntent(this))
         finish()
+    }
+
+    companion object {
+        fun getIntent(context: Context): Intent {
+            return Intent(context, OnBoardingActivity::class.java)
+        }
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingActivity.kt
@@ -16,7 +16,9 @@ class OnBoardingActivity :
     BindingActivity<ActivityOnboardingBinding>(R.layout.activity_onboarding) {
     private val viewModel: OnBoardingViewModel by viewModels()
     private val callback = object : OnBackPressedCallback(true) {
-        override fun handleOnBackPressed() {}
+        override fun handleOnBackPressed() {
+            viewModel.previousPage()
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -28,7 +30,8 @@ class OnBoardingActivity :
     }
 
     private fun setupOnBoardingFragmentAdapter() {
-        binding.vpOnboarding.isUserInputEnabled = false
+        binding.vpOnboarding.adapter = OnBoardingFragmentAdapter(this)
+        binding.vpOnboarding.isUserInputEnabled = false // 유저가 직접 스와이프 이동 못하게 막기.
     }
 
     private fun setupViewModel() {
@@ -42,19 +45,17 @@ class OnBoardingActivity :
 
     private fun handleEvent(event: OnBoardingViewModel.Event) {
         when (event) {
-            OnBoardingViewModel.Event.Exit -> showExitDialog()
-            OnBoardingViewModel.Event.CompleteExit -> navigateToMain()
+            OnBoardingViewModel.Event.Skip -> showSkipDialog() // 건너뛰기 버튼을 누르는 경우
+            OnBoardingViewModel.Event.Exit -> navigateToMain() // 모든 과정을 완료했을때
         }
     }
 
-    private fun showExitDialog() {
+    private fun showSkipDialog() {
         showDialog(
-            titleId = R.string.onboarding_page_exit_dialog_title,
-            messageId = R.string.onboarding_page_exit_dialog_message,
-            positiveStringId = R.string.onboarding_page_exit_dialog_positive_button,
-            actionPositive = {
-                navigateToMain()
-            },
+            titleId = R.string.onboarding_page_skip_dialog_title,
+            messageId = R.string.onboarding_page_skip_dialog_message,
+            positiveStringId = R.string.onboarding_page_skip_dialog_positive_button,
+            actionPositive = { navigateToMain() },
             isCancelable = false,
         )
     }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingActivity.kt
@@ -1,0 +1,66 @@
+package com.ddangddangddang.android.feature.onboarding
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.viewModels
+import com.ddangddangddang.android.R
+import com.ddangddangddang.android.databinding.ActivityOnboardingBinding
+import com.ddangddangddang.android.feature.main.MainActivity
+import com.ddangddangddang.android.util.binding.BindingActivity
+import com.ddangddangddang.android.util.view.showDialog
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class OnBoardingActivity :
+    BindingActivity<ActivityOnboardingBinding>(R.layout.activity_onboarding) {
+    private val viewModel: OnBoardingViewModel by viewModels()
+    private val callback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {}
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding.viewModel = viewModel
+        onBackPressedDispatcher.addCallback(this, callback)
+        setupOnBoardingFragmentAdapter()
+        setupViewModel()
+    }
+
+    private fun setupOnBoardingFragmentAdapter() {
+        binding.vpOnboarding.isUserInputEnabled = false
+    }
+
+    private fun setupViewModel() {
+        viewModel.event.observe(this) {
+            handleEvent(it)
+        }
+        viewModel.currentPageType.observe(this) {
+            binding.vpOnboarding.currentItem = it.ordinal // 해당 페이지로 이동
+        }
+    }
+
+    private fun handleEvent(event: OnBoardingViewModel.Event) {
+        when (event) {
+            OnBoardingViewModel.Event.Exit -> showExitDialog()
+            OnBoardingViewModel.Event.CompleteExit -> navigateToMain()
+        }
+    }
+
+    private fun showExitDialog() {
+        showDialog(
+            titleId = R.string.onboarding_page_exit_dialog_title,
+            messageId = R.string.onboarding_page_exit_dialog_message,
+            positiveStringId = R.string.onboarding_page_exit_dialog_positive_button,
+            actionPositive = {
+                navigateToMain()
+            },
+            isCancelable = false,
+        )
+    }
+
+    private fun navigateToMain() {
+        startActivity(Intent(this, MainActivity::class.java))
+        finish()
+    }
+}

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingActivity.kt
@@ -45,7 +45,7 @@ class OnBoardingActivity :
 
     private fun handleEvent(event: OnBoardingViewModel.Event) {
         when (event) {
-            OnBoardingViewModel.Event.Skip -> showSkipDialog() // 건너뛰기 버튼을 누르는 경우
+            OnBoardingViewModel.Event.Skip -> showSkipDialog() // 건너 뛰기 버튼을 누르는 경우
             OnBoardingViewModel.Event.Exit -> navigateToMain() // 모든 과정을 완료했을때
         }
     }
@@ -55,6 +55,7 @@ class OnBoardingActivity :
             titleId = R.string.onboarding_page_skip_dialog_title,
             messageId = R.string.onboarding_page_skip_dialog_message,
             positiveStringId = R.string.onboarding_page_skip_dialog_positive_button,
+            negativeStringId = R.string.all_dialog_default_negative_button,
             actionPositive = { navigateToMain() },
             isCancelable = false,
         )

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingFragmentAdapter.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingFragmentAdapter.kt
@@ -1,0 +1,16 @@
+package com.ddangddangddang.android.feature.onboarding
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.ddangddangddang.android.feature.onboarding.profile.ProfileSettingFragment
+
+class OnBoardingFragmentAdapter(activity: FragmentActivity) : FragmentStateAdapter(activity) {
+    override fun getItemCount(): Int = OnBoardingPageType.values().size
+
+    override fun createFragment(position: Int): Fragment {
+        return when (OnBoardingPageType.values()[position]) {
+            OnBoardingPageType.ProfileSetting -> ProfileSettingFragment()
+        }
+    }
+}

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingPageType.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingPageType.kt
@@ -4,5 +4,5 @@ import androidx.annotation.StringRes
 import com.ddangddangddang.android.R
 
 enum class OnBoardingPageType(@StringRes val titleId: Int) {
-    ProfileChange(R.string.onboarding_profile_page_title),
+    ProfileSetting(R.string.onboarding_profile_setting_title),
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingPageType.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingPageType.kt
@@ -1,0 +1,8 @@
+package com.ddangddangddang.android.feature.onboarding
+
+import androidx.annotation.StringRes
+import com.ddangddangddang.android.R
+
+enum class OnBoardingPageType(@StringRes val titleId: Int) {
+    ProfileChange(R.string.onboarding_profile_page_title),
+}

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingViewModel.kt
@@ -13,7 +13,7 @@ class OnBoardingViewModel @Inject constructor() : ViewModel() {
     val event: LiveData<Event>
         get() = _event
 
-    private val _currentPageType = MutableLiveData(OnBoardingPageType.ProfileChange)
+    private val _currentPageType = MutableLiveData(OnBoardingPageType.ProfileSetting)
     val currentPageType: LiveData<OnBoardingPageType>
         get() = _currentPageType
 
@@ -26,19 +26,21 @@ class OnBoardingViewModel @Inject constructor() : ViewModel() {
 
     fun nextPage() {
         _currentPageType.value?.let {
-            if (it.ordinal == OnBoardingPageType.values().size - 1) {
-                _event.value = Event.CompleteExit
-            }
+            if (it.ordinal == OnBoardingPageType.values().size - 1) return done()
             _currentPageType.value = OnBoardingPageType.values()[it.ordinal + 1]
         }
     }
 
-    fun setExitEvent() {
+    private fun done() {
         _event.value = Event.Exit
     }
 
+    fun setSkipEvent() {
+        _event.value = Event.Skip
+    }
+
     sealed class Event {
+        object Skip : Event()
         object Exit : Event()
-        object CompleteExit : Event()
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/OnBoardingViewModel.kt
@@ -1,0 +1,44 @@
+package com.ddangddangddang.android.feature.onboarding
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.ddangddangddang.android.util.livedata.SingleLiveEvent
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class OnBoardingViewModel @Inject constructor() : ViewModel() {
+    private val _event: SingleLiveEvent<Event> = SingleLiveEvent()
+    val event: LiveData<Event>
+        get() = _event
+
+    private val _currentPageType = MutableLiveData(OnBoardingPageType.ProfileChange)
+    val currentPageType: LiveData<OnBoardingPageType>
+        get() = _currentPageType
+
+    fun previousPage() {
+        _currentPageType.value?.let {
+            if (it.ordinal == 0) return
+            _currentPageType.value = OnBoardingPageType.values()[it.ordinal - 1]
+        }
+    }
+
+    fun nextPage() {
+        _currentPageType.value?.let {
+            if (it.ordinal == OnBoardingPageType.values().size - 1) {
+                _event.value = Event.CompleteExit
+            }
+            _currentPageType.value = OnBoardingPageType.values()[it.ordinal + 1]
+        }
+    }
+
+    fun setExitEvent() {
+        _event.value = Event.Exit
+    }
+
+    sealed class Event {
+        object Exit : Event()
+        object CompleteExit : Event()
+    }
+}

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/profile/ProfileSettingFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/profile/ProfileSettingFragment.kt
@@ -11,10 +11,10 @@ import androidx.fragment.app.viewModels
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.FragmentProfileSettingBinding
 import com.ddangddangddang.android.feature.common.ErrorType
+import com.ddangddangddang.android.feature.common.notifyFailureSnackBar
 import com.ddangddangddang.android.feature.onboarding.OnBoardingViewModel
 import com.ddangddangddang.android.util.binding.BindingFragment
 import com.ddangddangddang.android.util.view.observeLoadingWithDialog
-import com.ddangddangddang.android.util.view.showSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -72,20 +72,20 @@ class ProfileSettingFragment :
     }
 
     private fun notifyProfileInitLoadFailed(type: ErrorType) {
-        val defaultMessage = getString(R.string.mypage_snackbar_load_profile_failed_title)
-        val actionMessage = getString(R.string.all_snackbar_default_action)
-        binding.root.showSnackbar(
-            message = type.message ?: defaultMessage,
-            actionMessage = actionMessage,
+        notifyFailureSnackBar(
+            binding.root,
+            type,
+            R.string.mypage_snackbar_load_profile_failed_title,
+            R.string.all_snackbar_default_action,
         )
     }
 
     private fun notifyProfileChangeFailed(type: ErrorType) {
-        val defaultMessage = getString(R.string.profile_change_failed)
-        val actionMessage = getString(R.string.all_snackbar_default_action)
-        binding.root.showSnackbar(
-            message = type.message ?: defaultMessage,
-            actionMessage = actionMessage,
+        notifyFailureSnackBar(
+            binding.root,
+            type,
+            R.string.profile_change_failed,
+            R.string.all_snackbar_default_action,
         )
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/profile/ProfileSettingFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/profile/ProfileSettingFragment.kt
@@ -39,6 +39,7 @@ class ProfileSettingFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding.viewModel = viewModel
         requireContext().observeLoadingWithDialog(viewLifecycleOwner, viewModel.isLoading)
         if (viewModel.profile.value == null) viewModel.setupProfile(defaultUri)
         setupViewModel()

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/profile/ProfileSettingFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/profile/ProfileSettingFragment.kt
@@ -1,16 +1,90 @@
 package com.ddangddangddang.android.feature.onboarding.profile
 
+import android.content.ContentResolver
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.FragmentProfileSettingBinding
+import com.ddangddangddang.android.feature.common.ErrorType
+import com.ddangddangddang.android.feature.onboarding.OnBoardingViewModel
 import com.ddangddangddang.android.util.binding.BindingFragment
+import com.ddangddangddang.android.util.view.observeLoadingWithDialog
+import com.ddangddangddang.android.util.view.showSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class ProfileSettingFragment :
     BindingFragment<FragmentProfileSettingBinding>(R.layout.fragment_profile_setting) {
+    private val activityViewModel: OnBoardingViewModel by activityViewModels()
+    private val viewModel: ProfileSettingViewModel by viewModels()
+
+    private val launcher =
+        registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+            if (uri != null) viewModel.setProfileImageUri(uri)
+        }
+
+    private val defaultUri by lazy {
+        Uri.Builder()
+            .scheme(ContentResolver.SCHEME_ANDROID_RESOURCE)
+            .authority(resources.getResourcePackageName(R.drawable.img_default_profile))
+            .appendPath(resources.getResourceTypeName(R.drawable.img_default_profile))
+            .appendPath(resources.getResourceEntryName(R.drawable.img_default_profile))
+            .build()
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        requireContext().observeLoadingWithDialog(viewLifecycleOwner, viewModel.isLoading)
+        if (viewModel.profile.value == null) viewModel.setupProfile(defaultUri)
+        setupViewModel()
+    }
+
+    private fun setupViewModel() {
+        viewModel.event.observe(viewLifecycleOwner) {
+            handleEvent(it)
+        }
+    }
+
+    private fun handleEvent(event: ProfileSettingViewModel.Event) {
+        when (event) {
+            is ProfileSettingViewModel.Event.FailureInitSetupProfileEvent -> {
+                notifyProfileInitLoadFailed(event.errorType)
+            }
+
+            is ProfileSettingViewModel.Event.FailureChangeProfileEvent -> {
+                notifyProfileChangeFailed(event.errorType)
+            }
+
+            ProfileSettingViewModel.Event.NavigateToNext -> {
+                activityViewModel.nextPage()
+            }
+
+            ProfileSettingViewModel.Event.NavigateToSelectProfileImage -> {
+                launcher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+            }
+        }
+    }
+
+    private fun notifyProfileInitLoadFailed(type: ErrorType) {
+        val defaultMessage = getString(R.string.mypage_snackbar_load_profile_failed_title)
+        val actionMessage = getString(R.string.all_snackbar_default_action)
+        binding.root.showSnackbar(
+            message = type.message ?: defaultMessage,
+            actionMessage = actionMessage,
+        )
+    }
+
+    private fun notifyProfileChangeFailed(type: ErrorType) {
+        val defaultMessage = getString(R.string.profile_change_failed)
+        val actionMessage = getString(R.string.all_snackbar_default_action)
+        binding.root.showSnackbar(
+            message = type.message ?: defaultMessage,
+            actionMessage = actionMessage,
+        )
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/profile/ProfileSettingFragment.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/profile/ProfileSettingFragment.kt
@@ -1,0 +1,16 @@
+package com.ddangddangddang.android.feature.onboarding.profile
+
+import android.os.Bundle
+import android.view.View
+import com.ddangddangddang.android.R
+import com.ddangddangddang.android.databinding.FragmentProfileSettingBinding
+import com.ddangddangddang.android.util.binding.BindingFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class ProfileSettingFragment :
+    BindingFragment<FragmentProfileSettingBinding>(R.layout.fragment_profile_setting) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+    }
+}

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/profile/ProfileSettingViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/profile/ProfileSettingViewModel.kt
@@ -85,7 +85,7 @@ class ProfileSettingViewModel @Inject constructor(
         val profileImageUri = profile.value?.takeIf { it.path != currentProfileUri.path }
 
         // 만약 이전과 상태가 같다면, 변경 요청 보내지 않을 것임. 그냥 다음 페이지로 이동
-        if (name == currentProfileName && profile.value?.path == currentProfileUri.path) return setNavigateToNextEvent()
+        if (name == currentProfileName && profileImageUri == null) return setNavigateToNextEvent()
 
         if (_isLoading.value == true) return
         _isLoading.value = true

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/profile/ProfileSettingViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/profile/ProfileSettingViewModel.kt
@@ -2,7 +2,6 @@ package com.ddangddangddang.android.feature.onboarding.profile
 
 import android.content.Context
 import android.net.Uri
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -51,10 +50,9 @@ class ProfileSettingViewModel @Inject constructor(
                     val originProfileUri =
                         profileModel.profileImage?.let { Uri.parse(it) } ?: defaultUri
                     _profile.value = originProfileUri
-                    userNickname.value = profileModel.name
+                    userNickname.value = profileModel.name.trim()
                     currentProfileUri = originProfileUri
-                    currentProfileName = profileModel.name
-                    Log.d("mendel", "setupProfile, ${profile.value}, ${userNickname.value}")
+                    currentProfileName = profileModel.name.trim()
                 }
 
                 is ApiResponse.Failure -> {
@@ -87,7 +85,7 @@ class ProfileSettingViewModel @Inject constructor(
         val profileImageUri = profile.value?.takeIf { it.path != currentProfileUri.path }
 
         // 만약 이전과 상태가 같다면, 변경 요청 보내지 않을 것임. 그냥 다음 페이지로 이동
-        if (name == currentProfileName && profileImageUri == currentProfileUri) return setNavigateToNextEvent()
+        if (name == currentProfileName && profile.value?.path == currentProfileUri.path) return setNavigateToNextEvent()
 
         if (_isLoading.value == true) return
         _isLoading.value = true

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/profile/ProfileSettingViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/onboarding/profile/ProfileSettingViewModel.kt
@@ -1,0 +1,129 @@
+package com.ddangddangddang.android.feature.onboarding.profile
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ddangddangddang.android.feature.common.ErrorType
+import com.ddangddangddang.android.model.mapper.ProfileModelMapper.toPresentation
+import com.ddangddangddang.android.util.image.toAdjustImageFile
+import com.ddangddangddang.android.util.livedata.SingleLiveEvent
+import com.ddangddangddang.data.model.request.ProfileUpdateRequest
+import com.ddangddangddang.data.remote.ApiResponse
+import com.ddangddangddang.data.repository.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ProfileSettingViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+) : ViewModel() {
+    private val _event: SingleLiveEvent<Event> = SingleLiveEvent()
+    val event: LiveData<Event>
+        get() = _event
+
+    private lateinit var currentProfileUri: Uri
+    private lateinit var currentProfileName: String
+
+    private val _profile: MutableLiveData<Uri> = MutableLiveData()
+    val profile: LiveData<Uri>
+        get() = _profile
+
+    val userNickname: MutableLiveData<String> = MutableLiveData()
+
+    private val _isLoading: MutableLiveData<Boolean> = MutableLiveData(false)
+    val isLoading: LiveData<Boolean>
+        get() = _isLoading
+
+    // 처음 프로필 설정 정보를 불러오는 과정. 이것은 전체를 온보딩 작업 내에서 딱 한 번만 일어난다.
+    fun setupProfile(defaultUri: Uri) {
+        if (_isLoading.value == true) return
+        _isLoading.value = true
+
+        viewModelScope.launch {
+            when (val response = userRepository.getProfile()) {
+                is ApiResponse.Success -> {
+                    val profileModel = response.body.toPresentation()
+                    val originProfileUri =
+                        profileModel.profileImage?.let { Uri.parse(it) } ?: defaultUri
+                    _profile.value = originProfileUri
+                    userNickname.value = profileModel.name
+                    currentProfileUri = originProfileUri
+                    currentProfileName = profileModel.name
+                    Log.d("mendel", "setupProfile, ${profile.value}, ${userNickname.value}")
+                }
+
+                is ApiResponse.Failure -> {
+                    _event.value =
+                        Event.FailureInitSetupProfileEvent(ErrorType.FAILURE(response.error))
+                }
+
+                is ApiResponse.NetworkError -> {
+                    _event.value = Event.FailureInitSetupProfileEvent(ErrorType.NETWORK_ERROR)
+                }
+
+                is ApiResponse.Unexpected -> {
+                    _event.value = Event.FailureInitSetupProfileEvent(ErrorType.UNEXPECTED)
+                }
+            }
+            _isLoading.value = false
+        }
+    }
+
+    fun setProfileImageUri(uri: Uri) {
+        _profile.value = uri
+    }
+
+    fun selectProfileImage() {
+        _event.value = Event.NavigateToSelectProfileImage
+    }
+
+    fun submitProfile(context: Context) {
+        val name = userNickname.value?.trim() ?: return
+        val profileImageUri = profile.value?.takeIf { it.path != currentProfileUri.path }
+
+        // 만약 이전과 상태가 같다면, 변경 요청 보내지 않을 것임. 그냥 다음 페이지로 이동
+        if (name == currentProfileName && profileImageUri == currentProfileUri) return setNavigateToNextEvent()
+
+        if (_isLoading.value == true) return
+        _isLoading.value = true
+        viewModelScope.launch {
+            val file = runCatching { profileImageUri?.toAdjustImageFile(context) }.getOrNull()
+            when (val response = userRepository.updateProfile(file, ProfileUpdateRequest(name))) {
+                is ApiResponse.Success -> {
+                    currentProfileUri = profileImageUri ?: currentProfileUri
+                    setNavigateToNextEvent()
+                }
+
+                is ApiResponse.Failure -> {
+                    _event.value =
+                        Event.FailureChangeProfileEvent(ErrorType.FAILURE(response.error))
+                }
+
+                is ApiResponse.NetworkError -> {
+                    _event.value = Event.FailureChangeProfileEvent(ErrorType.NETWORK_ERROR)
+                }
+
+                is ApiResponse.Unexpected -> {
+                    _event.value = Event.FailureChangeProfileEvent(ErrorType.UNEXPECTED)
+                }
+            }
+            _isLoading.value = false
+        }
+    }
+
+    private fun setNavigateToNextEvent() {
+        _event.value = Event.NavigateToNext
+    }
+
+    sealed class Event {
+        data class FailureInitSetupProfileEvent(val errorType: ErrorType) : Event()
+        data class FailureChangeProfileEvent(val errorType: ErrorType) : Event()
+        object NavigateToSelectProfileImage : Event()
+        object NavigateToNext : Event()
+    }
+}

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/profile/ProfileChangeViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/profile/ProfileChangeViewModel.kt
@@ -53,7 +53,7 @@ class ProfileChangeViewModel @Inject constructor(
     }
 
     fun submitProfile(context: Context) {
-        val name = userNickname.value ?: return
+        val name = userNickname.value?.trim() ?: return
         val profileImageUri = profile.value?.takeIf { it.path != originalProfileUri.path }
         viewModelScope.launch {
             val file = runCatching { profileImageUri?.toAdjustImageFile(context) }.getOrNull()
@@ -63,7 +63,8 @@ class ProfileChangeViewModel @Inject constructor(
                 }
 
                 is ApiResponse.Failure -> {
-                    _event.value = Event.FailureChangeProfileEvent(ErrorType.FAILURE(response.error))
+                    _event.value =
+                        Event.FailureChangeProfileEvent(ErrorType.FAILURE(response.error))
                 }
 
                 is ApiResponse.NetworkError -> {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/splash/SplashActivity.kt
@@ -55,12 +55,12 @@ class SplashActivity : BindingActivity<ActivitySplashBinding>(R.layout.activity_
     }
 
     private fun navigateToMain() {
-        startActivity(Intent(this, MainActivity::class.java))
+        startActivity(MainActivity.getIntent(this))
         finish()
     }
 
     private fun navigateToLogin() {
-        startActivity(Intent(this, LoginActivity::class.java))
+        startActivity(LoginActivity.getIntent(this))
         finish()
     }
 

--- a/android/app/src/main/res/layout/activity_onboarding.xml
+++ b/android/app/src/main/res/layout/activity_onboarding.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.ddangddangddang.android.feature.onboarding.OnBoardingViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".feature.onboarding.OnBoardingActivity">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/tb_onboarding"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:contentInsetLeft="0dp"
+            app:contentInsetStart="0dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <TextView
+                    style="@style/Header1"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/margin_side_layout"
+                    android:maxLines="1"
+                    android:text="@{context.getString(viewModel.currentPageType.titleId)}"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/tv_skip"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="현재 페이지 제목" />
+
+                <TextView
+                    android:id="@+id/tv_skip"
+                    style="@style/Body"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/margin_side_layout"
+                    android:onClick="@{() -> viewModel.setExitEvent()}"
+                    android:text="@string/onboarding_page_exit_dialog_title"
+                    android:textColor="@color/grey_700"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:tint="@color/grey_900" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.appcompat.widget.Toolbar>
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/vp_onboarding"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tb_onboarding" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/android/app/src/main/res/layout/activity_onboarding.xml
+++ b/android/app/src/main/res/layout/activity_onboarding.xml
@@ -5,6 +5,10 @@
 
     <data>
 
+        <import type="android.view.View" />
+
+        <import type="com.ddangddangddang.android.feature.onboarding.OnBoardingPageType" />
+
         <variable
             name="viewModel"
             type="com.ddangddangddang.android.feature.onboarding.OnBoardingViewModel" />
@@ -47,8 +51,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="@dimen/margin_side_layout"
-                    android:onClick="@{() -> viewModel.setExitEvent()}"
-                    android:text="@string/onboarding_page_exit_dialog_title"
+                    android:onClick="@{() -> viewModel.setSkipEvent()}"
+                    android:text="@string/onboarding_page_skip_dialog_title"
                     android:textColor="@color/grey_700"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"

--- a/android/app/src/main/res/layout/fragment_profile_setting.xml
+++ b/android/app/src/main/res/layout/fragment_profile_setting.xml
@@ -1,11 +1,119 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.ddangddangddang.android.feature.onboarding.profile.ProfileSettingViewModel" />
+    </data>
 
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".feature.onboarding.profile.ProfileSettingFragment">
+
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="80dp">
+
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/cv_image"
+                    android:layout_width="130dp"
+                    android:layout_height="130dp"
+                    android:layout_marginTop="38dp"
+                    app:cardCornerRadius="65dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <ImageView
+                        imageUri="@{viewModel.profile}"
+                        placeholder="@{@drawable/img_default_profile}"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:contentDescription="@string/register_auction_image_description"
+                        android:onClick="@{()->viewModel.selectProfileImage()}"
+                        android:scaleType="centerCrop"
+                        tools:src="@drawable/ic_launcher_background" />
+
+                </androidx.cardview.widget.CardView>
+
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/cv_camera"
+                    android:layout_width="36dp"
+                    android:layout_height="36dp"
+                    android:layout_marginTop="38dp"
+                    android:backgroundTint="#D9D9D9"
+                    android:onClick="@{()->viewModel.selectProfileImage()}"
+                    app:cardCornerRadius="18dp"
+                    app:layout_constraintBottom_toBottomOf="@id/cv_image"
+                    app:layout_constraintEnd_toEndOf="@id/cv_image">
+
+                    <ImageView
+                        android:id="@+id/iv_delete_image"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:adjustViewBounds="true"
+                        android:contentDescription="@string/profile_change_profile_image_button_description"
+                        android:scaleType="fitXY"
+                        android:src="@drawable/ic_camera_20_18" />
+
+                </androidx.cardview.widget.CardView>
+
+                <TextView
+                    android:id="@+id/tv_user_nickname"
+                    style="@style/Header2"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="@string/profile_change_nickname"
+                    app:layout_constraintStart_toStartOf="@id/et_user_nickname"
+                    app:layout_constraintTop_toBottomOf="@id/cv_image" />
+
+                <EditText
+                    android:id="@+id/et_user_nickname"
+                    style="@style/Body"
+                    android:layout_width="match_parent"
+                    android:layout_height="48dp"
+                    android:layout_marginHorizontal="16dp"
+                    android:layout_marginTop="12dp"
+                    android:background="@drawable/bg_white_grey_radius_10dp"
+                    android:hint="@string/profile_change_nickname_text_hint"
+                    android:inputType="text"
+                    android:maxLength="25"
+                    android:maxLines="1"
+                    android:paddingHorizontal="16dp"
+                    android:text="@={viewModel.userNickname}"
+                    android:textCursorDrawable="@drawable/ic_edittext_cursor"
+                    app:layout_constraintTop_toBottomOf="@id/tv_user_nickname" />
+
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </androidx.core.widget.NestedScrollView>
+
+        <TextView
+            android:id="@+id/btn_done"
+            style="@style/Header2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_marginEnd="@dimen/margin_side_layout"
+            android:layout_marginBottom="@dimen/margin_side_layout"
+            android:gravity="center"
+            android:onClick="@{()->viewModel.submitProfile(context)}"
+            android:padding="@dimen/padding_vertical_filter_chips"
+            android:text="@string/onboarding_all_done"
+            app:tint="@color/grey_700" />
 
     </FrameLayout>
 

--- a/android/app/src/main/res/layout/fragment_profile_setting.xml
+++ b/android/app/src/main/res/layout/fragment_profile_setting.xml
@@ -39,7 +39,6 @@
                         placeholder="@{@drawable/img_default_profile}"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
-                        android:contentDescription="@string/register_auction_image_description"
                         android:onClick="@{()->viewModel.selectProfileImage()}"
                         android:scaleType="centerCrop"
                         tools:src="@drawable/ic_launcher_background" />

--- a/android/app/src/main/res/layout/fragment_profile_setting.xml
+++ b/android/app/src/main/res/layout/fragment_profile_setting.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".feature.onboarding.profile.ProfileSettingFragment">
+
+    </FrameLayout>
+
+</layout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -249,8 +249,8 @@
 
     <!-- onboarding -->
     <string name="onboarding_profile_setting_title">프로필 설정</string>
-    <string name="onboarding_page_exit_dialog_title">건너뛰기</string>
-    <string name="onboarding_page_exit_dialog_message">정말 건너뛰시겠습니까?</string>
-    <string name="onboarding_page_exit_dialog_positive_button">확인</string>
-    <string name="onboarding_profile_page_title">프로필 수정</string>
+    <string name="onboarding_page_skip_dialog_title">건너뛰기</string>
+    <string name="onboarding_page_skip_dialog_message">정말 건너뛰시겠습니까?</string>
+    <string name="onboarding_page_skip_dialog_positive_button">확인</string>
+    <string name="onboarding_all_done">마치기</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -246,4 +246,11 @@
     <string name="user_review_failure">평가에 실패했습니다</string>
     <string name="user_review_success">평가가 완료되었습니다</string>
     <string name="user_review_load_failure">평가 내용을 가져오는데 실패했습니다</string>
+
+    <!-- onboarding -->
+    <string name="onboarding_profile_setting_title">프로필 설정</string>
+    <string name="onboarding_page_exit_dialog_title">건너뛰기</string>
+    <string name="onboarding_page_exit_dialog_message">정말 건너뛰시겠습니까?</string>
+    <string name="onboarding_page_exit_dialog_positive_button">확인</string>
+    <string name="onboarding_profile_page_title">프로필 수정</string>
 </resources>

--- a/android/data/src/main/java/com/ddangddangddang/data/datasource/AuthRemoteDataSource.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/datasource/AuthRemoteDataSource.kt
@@ -4,6 +4,7 @@ import com.ddangddangddang.data.model.request.KakaoLoginRequest
 import com.ddangddangddang.data.model.request.LogoutRequest
 import com.ddangddangddang.data.model.request.RefreshTokenRequest
 import com.ddangddangddang.data.model.request.WithdrawalRequest
+import com.ddangddangddang.data.model.response.LoginByKakaoResponse
 import com.ddangddangddang.data.model.response.TokenResponse
 import com.ddangddangddang.data.model.response.ValidateTokenResponse
 import com.ddangddangddang.data.remote.ApiResponse
@@ -11,7 +12,7 @@ import com.ddangddangddang.data.remote.AuthService
 import javax.inject.Inject
 
 class AuthRemoteDataSource @Inject constructor(private val service: AuthService) {
-    suspend fun loginByKakao(kakaoLoginRequest: KakaoLoginRequest): ApiResponse<TokenResponse> =
+    suspend fun loginByKakao(kakaoLoginRequest: KakaoLoginRequest): ApiResponse<LoginByKakaoResponse> =
         service.loginByKakao(kakaoLoginRequest)
 
     suspend fun refreshToken(refreshToken: String): ApiResponse<TokenResponse> =

--- a/android/data/src/main/java/com/ddangddangddang/data/model/response/LoginByKakaoResponse.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/model/response/LoginByKakaoResponse.kt
@@ -1,0 +1,17 @@
+package com.ddangddangddang.data.model.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LoginByKakaoResponse(
+    val accessToken: String,
+    val refreshToken: String,
+    val isSignUpUser: Boolean,
+) {
+    fun toTokenResponse(): TokenResponse {
+        return TokenResponse(
+            accessToken,
+            refreshToken,
+        )
+    }
+}

--- a/android/data/src/main/java/com/ddangddangddang/data/remote/AuthService.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/remote/AuthService.kt
@@ -34,7 +34,7 @@ interface AuthService {
         @Header("Authorization") authorization: String,
     ): ApiResponse<ValidateTokenResponse>
 
-    @POST("/oauth2/withdrawal/kakao")
+    @POST("/oauth2/withdrawal")
     suspend fun withdrawal(
         @Header("Authorization") authorization: String,
         @Body request: WithdrawalRequest,

--- a/android/data/src/main/java/com/ddangddangddang/data/remote/AuthService.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/remote/AuthService.kt
@@ -4,6 +4,7 @@ import com.ddangddangddang.data.model.request.KakaoLoginRequest
 import com.ddangddangddang.data.model.request.LogoutRequest
 import com.ddangddangddang.data.model.request.RefreshTokenRequest
 import com.ddangddangddang.data.model.request.WithdrawalRequest
+import com.ddangddangddang.data.model.response.LoginByKakaoResponse
 import com.ddangddangddang.data.model.response.TokenResponse
 import com.ddangddangddang.data.model.response.ValidateTokenResponse
 import retrofit2.http.Body
@@ -15,7 +16,7 @@ interface AuthService {
     @POST("/oauth2/login/kakao")
     suspend fun loginByKakao(
         @Body kakaoLoginRequest: KakaoLoginRequest,
-    ): ApiResponse<TokenResponse>
+    ): ApiResponse<LoginByKakaoResponse>
 
     @POST("/oauth2/refresh-token")
     suspend fun refreshToken(

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuthRepository.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuthRepository.kt
@@ -1,12 +1,13 @@
 package com.ddangddangddang.data.repository
 
 import com.ddangddangddang.data.model.request.KakaoLoginRequest
+import com.ddangddangddang.data.model.response.LoginByKakaoResponse
 import com.ddangddangddang.data.model.response.TokenResponse
 import com.ddangddangddang.data.model.response.ValidateTokenResponse
 import com.ddangddangddang.data.remote.ApiResponse
 
 interface AuthRepository {
-    suspend fun loginByKakao(kakaoLoginRequest: KakaoLoginRequest): ApiResponse<TokenResponse>
+    suspend fun loginByKakao(kakaoLoginRequest: KakaoLoginRequest): ApiResponse<LoginByKakaoResponse>
 
     suspend fun refreshToken(): ApiResponse<TokenResponse>
 

--- a/android/data/src/main/java/com/ddangddangddang/data/repository/AuthRepositoryImpl.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/repository/AuthRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.ddangddangddang.data.repository
 import com.ddangddangddang.data.datasource.AuthLocalDataSource
 import com.ddangddangddang.data.datasource.AuthRemoteDataSource
 import com.ddangddangddang.data.model.request.KakaoLoginRequest
+import com.ddangddangddang.data.model.response.LoginByKakaoResponse
 import com.ddangddangddang.data.model.response.TokenResponse
 import com.ddangddangddang.data.model.response.ValidateTokenResponse
 import com.ddangddangddang.data.remote.ApiResponse
@@ -15,10 +16,10 @@ class AuthRepositoryImpl @Inject constructor(
     private val localDataSource: AuthLocalDataSource,
     private val remoteDataSource: AuthRemoteDataSource,
 ) : AuthRepository {
-    override suspend fun loginByKakao(kakaoLoginRequest: KakaoLoginRequest): ApiResponse<TokenResponse> {
+    override suspend fun loginByKakao(kakaoLoginRequest: KakaoLoginRequest): ApiResponse<LoginByKakaoResponse> {
         val response = remoteDataSource.loginByKakao(kakaoLoginRequest)
         if (response is ApiResponse.Success) {
-            localDataSource.saveToken(response.body)
+            localDataSource.saveToken(response.body.toTokenResponse())
         }
         return response
     }


### PR DESCRIPTION
## 📄 작업 내용 요약
소셜 로그인할 때 만약 첫 회원가입인 경우, 닉네임 및 프로필 설정페이지를 먼저 보여주기
온보딩 액티비티 및 프로필 세팅 프래그먼트 추가 및 로그인 로직 수정

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
로그인 api에 대한 응답값을 다음과 같이 변경했습니다.
<img width="394" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/d48c39a5-b812-41ba-b538-1f4515b6f471">
그에 따라, 로그인 api 결과를 분기처리 하는 로직이 추가됐습니다. 
<img width="542" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/489bbda7-c67b-4ff8-87bf-093d39cb8e81">


온보딩 액티비티 주요로직
<img width="660" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/ec705ae4-56a7-4c95-9542-421141a97a7c">
온보딩 화면에서 뒤로가기는 이전 프래그먼트로 돌아가는 처리로 설정했습니다. 이 액티비티를 나가고 싶다면, 마지막 프래그먼트 페이지에 도달해서 '마치기' 버튼을 클릭하거나, 상단에 있는 건너뛰기 버튼을 눌러야 합니다. 

건너뛰기를 누르는 경우, 다음과 같은 화면이 나옵니다.
![image](https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/fe563560-d9d0-413d-9e91-08170a18793d)

우선, 온보딩 액티비티는 회원가입을 한 유저를 위한 페이지입니다. 프로필 설정 외에도 추후에 여러 소개 페이지들이 추가되어야 할 수 있다라고 생각을 해서, 다음과 같이 뷰페이저로 화면을 분할해서 이전과 다음 페이지로 넘길 수 있게 했습니다.
현재는 아래처럼, ProfileSettingFragment 만 있습니다. 때문에 ProfileSettingFragment가 마지막 프래그먼트이므로, '마치기' 버튼을 갖고 있습니다. 만약 이 뒤에 새로운 프래그먼트가 더 보여져야 한다면, > 와 같은 이동 버튼이 필요할 것입니다.
<img width="566" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/9b9b9628-b78c-4291-97a6-d9c02554b231">

온보딩뷰모델에서는 다음과 같은 함수들을 제공합니다.
여기서, 이전페이지 이동과 다음페이지 이동 메소드는 각 프래그먼트들이 액티비티뷰모델을 통해서 호출할 녀석들입니다. 
<img width="769" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/d156f5f0-727b-48f9-8ad6-0a45db9d19f8">

온보딩 액티비티의 주요 옵저빙 로직은 다음과 같습니다.
<img width="814" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/cad60b87-f7c1-40b2-8a7f-04416af1672c">

마지막으로, ProfileSettingViewModel은 기존의  ProfileChangeViewModel과 비슷합니다.
다만, 기존의 ProfileChange액티비티의 액션바 좌상단에 있던 뒤로가기 버튼이 없습니다.
하단에 마치기 버튼 혹은 > 버튼 밖에 없습니다. 때문에 사용자가 변경을 안하고 그냥 다음 페이지로 이동하고 싶을 수 있습니다. 이를 위해서. 기존의 ProfileChangeViewModel의 submitProfile 함수와 달리, 특별한 로직이 조금 추가됐습니다.
아래처럼, currentProfileName과 currentProfileUri를 보관해서, 변경이 됐는지 안됐는지를 판단합니다. 
만약 되지 않았다면, 그냥 서버 통신없이 즉 프로필 변경 요청 없이 그냥 다음 페이지로 넘어갑니다.
<img width="997" alt="image" src="https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/2432d260-024f-4be0-bf1a-211b35ea64dc">







## 📎 Issue 번호
- close: #652 
