### PR TITLE
입찰시 커서 유지 기능 추가

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/common/PriceTextWatcher.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/common/PriceTextWatcher.kt
@@ -1,4 +1,4 @@
-package com.ddangddangddang.android.feature.register
+package com.ddangddangddang.android.feature.common
 
 import android.text.Editable
 import android.text.TextWatcher
@@ -27,5 +27,18 @@ class PriceTextWatcher(private val onAfterChanged: (Int, String) -> Unit) : Text
 
     override fun afterTextChanged(s: Editable?) {
         s?.let { onAfterChanged(cursorPositionFromEnd, s.toString()) }
+    }
+
+    companion object {
+        fun getCursorPosition(
+            textLength: Int,
+            prevCursorPositionFromEnd: Int,
+            defaultCursorPositionFromEnd: Int,
+        ): Int {
+            val cursorPositionFromEnd =
+                if (prevCursorPositionFromEnd > 0) prevCursorPositionFromEnd else defaultCursorPositionFromEnd
+            val cursorPosition = textLength - cursorPositionFromEnd
+            return if (cursorPosition > 0) cursorPosition else 0
+        }
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/common/PriceTextWatcher.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/common/PriceTextWatcher.kt
@@ -17,10 +17,11 @@ class PriceTextWatcher(private val onAfterChanged: (Int, String) -> Unit) : Text
 
     private fun moveCursorIfOnlyCommaRemoved(str: CharSequence, before: Int) {
         val strOnlyNumber = str.filter { it.isDigit() }
-        val commaCount = (strOnlyNumber.length - 1) / 3
+        val expectedCommaCount = (strOnlyNumber.length - 1) / 3
 
-        // 쉼표의 개수가 맞지 않고 지워진 문자가 1개인 경우 커서를 앞으로 1 움직입니다.
-        if ((str.count { it == ',' } != commaCount) && before == 1) {
+        // 쉼표의 개수가 적고 지워진 문자가 1개인 경우 커서를 앞으로 1 움직입니다.
+        val actualCommaCount = str.count { it == ',' }
+        if (actualCommaCount < expectedCommaCount && before == 1) {
             cursorPositionFromEnd++
         }
     }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/common/PriceTextWatcher.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/common/PriceTextWatcher.kt
@@ -3,7 +3,7 @@ package com.ddangddangddang.android.feature.common
 import android.text.Editable
 import android.text.TextWatcher
 
-class PriceTextWatcher(private val onAfterChanged: (Int, String) -> Unit) : TextWatcher {
+class PriceTextWatcher(private val onAfterChanged: (String) -> Unit) : TextWatcher {
     private var cursorPositionFromEnd: Int = 0
 
     override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
@@ -27,19 +27,16 @@ class PriceTextWatcher(private val onAfterChanged: (Int, String) -> Unit) : Text
     }
 
     override fun afterTextChanged(s: Editable?) {
-        s?.let { onAfterChanged(cursorPositionFromEnd, s.toString()) }
+        s?.let { onAfterChanged(s.toString()) }
     }
 
-    companion object {
-        fun getCursorPosition(
-            textLength: Int,
-            prevCursorPositionFromEnd: Int,
-            defaultCursorPositionFromEnd: Int,
-        ): Int {
-            val cursorPositionFromEnd =
-                if (prevCursorPositionFromEnd > 0) prevCursorPositionFromEnd else defaultCursorPositionFromEnd
-            val cursorPosition = textLength - cursorPositionFromEnd
-            return if (cursorPosition > 0) cursorPosition else 0
-        }
+    fun getCursorPosition(
+        textLength: Int,
+        defaultCursorPositionFromEnd: Int,
+    ): Int {
+        cursorPositionFromEnd =
+            if (cursorPositionFromEnd > 0) cursorPositionFromEnd else defaultCursorPositionFromEnd
+        val cursorPosition = textLength - cursorPositionFromEnd
+        return if (cursorPosition > 0) cursorPosition else 0
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/bid/AuctionBidDialog.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/bid/AuctionBidDialog.kt
@@ -17,7 +17,6 @@ import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.FragmentAuctionBidDialogBinding
 import com.ddangddangddang.android.feature.common.ErrorType
 import com.ddangddangddang.android.feature.common.PriceTextWatcher
-import com.ddangddangddang.android.feature.common.PriceTextWatcher.Companion.getCursorPosition
 import com.ddangddangddang.android.feature.detail.AuctionDetailViewModel
 import com.ddangddangddang.android.feature.register.RegisterAuctionViewModel
 import com.ddangddangddang.android.util.view.Toaster
@@ -31,13 +30,7 @@ class AuctionBidDialog : DialogFragment() {
 
     private val viewModel: AuctionBidViewModel by viewModels()
     private val activityViewModel: AuctionDetailViewModel by activityViewModels()
-    private var bidPriceCursorPositionFromEnd: Int = 0
-    private val bidPriceWatcher by lazy {
-        PriceTextWatcher { cursorPositionFromEnd: Int, bidPrice: String ->
-            bidPriceCursorPositionFromEnd = cursorPositionFromEnd
-            viewModel.changeInputPriceText(bidPrice)
-        }
-    }
+    private val bidPriceWatcher by lazy { PriceTextWatcher { viewModel.changeInputPriceText(it) } }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -132,7 +125,12 @@ class AuctionBidDialog : DialogFragment() {
         val displayPrice = getString(R.string.all_price, price)
         binding.etBidPrice.removeTextChangedListener(bidPriceWatcher)
         binding.etBidPrice.setText(displayPrice)
-        binding.etBidPrice.setSelection(getCursorPosition(displayPrice.length, bidPriceCursorPositionFromEnd, RegisterAuctionViewModel.SUFFIX_INPUT_PRICE.length)) // 이전 커서 위치로 이동
+        binding.etBidPrice.setSelection(
+            bidPriceWatcher.getCursorPosition(
+                displayPrice.length,
+                RegisterAuctionViewModel.SUFFIX_INPUT_PRICE.length,
+            ),
+        ) // 이전 커서 위치로 이동
         binding.etBidPrice.addTextChangedListener(bidPriceWatcher)
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/bid/AuctionBidDialog.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/bid/AuctionBidDialog.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
-import android.text.Editable
-import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -18,7 +16,10 @@ import androidx.fragment.app.viewModels
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.FragmentAuctionBidDialogBinding
 import com.ddangddangddang.android.feature.common.ErrorType
+import com.ddangddangddang.android.feature.common.PriceTextWatcher
+import com.ddangddangddang.android.feature.common.PriceTextWatcher.Companion.getCursorPosition
 import com.ddangddangddang.android.feature.detail.AuctionDetailViewModel
+import com.ddangddangddang.android.feature.register.RegisterAuctionViewModel
 import com.ddangddangddang.android.util.view.Toaster
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -30,14 +31,11 @@ class AuctionBidDialog : DialogFragment() {
 
     private val viewModel: AuctionBidViewModel by viewModels()
     private val activityViewModel: AuctionDetailViewModel by activityViewModels()
-
-    private val watcher = object : TextWatcher {
-        override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-
-        override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
-
-        override fun afterTextChanged(s: Editable?) {
-            s?.let { viewModel.changeInputPriceText(s.toString()) }
+    private var bidPriceCursorPositionFromEnd: Int = 0
+    private val bidPriceWatcher by lazy {
+        PriceTextWatcher { cursorPositionFromEnd: Int, bidPrice: String ->
+            bidPriceCursorPositionFromEnd = cursorPositionFromEnd
+            viewModel.changeInputPriceText(bidPrice)
         }
     }
 
@@ -91,10 +89,7 @@ class AuctionBidDialog : DialogFragment() {
     }
 
     private fun setupListener() {
-        binding.etBidPrice.addTextChangedListener(watcher)
-        binding.etBidPrice.setOnClickListener {
-            binding.etBidPrice.setSelection(getCursorPositionFrontSuffix(binding.etBidPrice.text.toString()))
-        }
+        binding.etBidPrice.addTextChangedListener(bidPriceWatcher)
     }
 
     private fun setupObserver() {
@@ -134,15 +129,11 @@ class AuctionBidDialog : DialogFragment() {
     }
 
     private fun setInputBidPrice(price: Int) {
-        val displayPrice = getString(R.string.detail_auction_bid_dialog_input_price, price)
-        binding.etBidPrice.removeTextChangedListener(watcher)
+        val displayPrice = getString(R.string.all_price, price)
+        binding.etBidPrice.removeTextChangedListener(bidPriceWatcher)
         binding.etBidPrice.setText(displayPrice)
-        binding.etBidPrice.setSelection(getCursorPositionFrontSuffix(displayPrice)) // " 원" 앞으로 커서 이동
-        binding.etBidPrice.addTextChangedListener(watcher)
-    }
-
-    private fun getCursorPositionFrontSuffix(content: String): Int {
-        return content.length - AuctionBidViewModel.SUFFIX_INPUT_PRICE.length
+        binding.etBidPrice.setSelection(getCursorPosition(displayPrice.length, bidPriceCursorPositionFromEnd, RegisterAuctionViewModel.SUFFIX_INPUT_PRICE.length)) // 이전 커서 위치로 이동
+        binding.etBidPrice.addTextChangedListener(bidPriceWatcher)
     }
 
     private fun showMessage(message: String) {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/bid/AuctionBidViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/bid/AuctionBidViewModel.kt
@@ -35,7 +35,7 @@ class AuctionBidViewModel @Inject constructor(
 
     private fun convertStringPriceToInt(text: String): Int {
         val originalValue = text.replace(",", "") // 문자열 내 들어있는 콤마를 모두 제거
-        val priceValue = originalValue.substringBefore(SUFFIX_INPUT_PRICE) // " 원"
+        val priceValue = originalValue.substringBefore(SUFFIX_INPUT_PRICE.trim()).trim() // " 원"
         val parsedValue =
             priceValue.toBigIntegerOrNull() ?: return ZERO // 입력에 문자가 섞인 경우
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionActivity.kt
@@ -14,7 +14,6 @@ import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.ActivityRegisterAuctionBinding
 import com.ddangddangddang.android.feature.common.ErrorType
 import com.ddangddangddang.android.feature.common.PriceTextWatcher
-import com.ddangddangddang.android.feature.common.PriceTextWatcher.Companion.getCursorPosition
 import com.ddangddangddang.android.feature.detail.AuctionDetailActivity
 import com.ddangddangddang.android.feature.register.RegisterAuctionViewModel.Companion.SUFFIX_INPUT_PRICE
 import com.ddangddangddang.android.feature.register.category.SelectCategoryActivity
@@ -43,20 +42,8 @@ class RegisterAuctionActivity :
     private val pickMultipleMediaLaunchers = setupMultipleMediaLaunchers()
     private val categoryActivityLauncher = setupCategoryLauncher()
     private val regionActivityLauncher = setupRegionLauncher()
-    private var startPriceCursorPositionFromEnd: Int = 0
-    private var bidUnitCursorPositionFromEnd: Int = 0
-    private val startPriceWatcher by lazy {
-        PriceTextWatcher { cursorPositionFromEnd: Int, startPrice: String ->
-            startPriceCursorPositionFromEnd = cursorPositionFromEnd
-            viewModel.setStartPrice(startPrice)
-        }
-    }
-    private val bidUnitWatcher by lazy {
-        PriceTextWatcher { cursorPositionFromEnd: Int, bidUnit: String ->
-            bidUnitCursorPositionFromEnd = cursorPositionFromEnd
-            viewModel.setBidUnit(bidUnit)
-        }
-    }
+    private val startPriceWatcher by lazy { PriceTextWatcher { viewModel.setStartPrice(it) } }
+    private val bidUnitWatcher by lazy { PriceTextWatcher { viewModel.setBidUnit(it) } }
 
     private fun setupMultipleMediaLaunchers(): List<ActivityResultLauncher<PickVisualMediaRequest>> {
         return List(RegisterAuctionViewModel.MAXIMUM_IMAGE_SIZE) { index ->
@@ -117,10 +104,10 @@ class RegisterAuctionActivity :
         viewModel.images.observe(this) { imageAdapter.setImages(it) }
         viewModel.event.observe(this) { handleEvent(it) }
         viewModel.startPrice.observe(this) {
-            setPrice(binding.etStartPrice, startPriceWatcher, it.toInt(), startPriceCursorPositionFromEnd)
+            setPrice(binding.etStartPrice, startPriceWatcher, it.toInt())
         }
         viewModel.bidUnit.observe(this) {
-            setPrice(binding.etBidUnit, bidUnitWatcher, it.toInt(), bidUnitCursorPositionFromEnd)
+            setPrice(binding.etBidUnit, bidUnitWatcher, it.toInt())
         }
     }
 
@@ -241,11 +228,20 @@ class RegisterAuctionActivity :
         regionActivityLauncher.launch(SelectRegionsActivity.getIntent(this, directRegion))
     }
 
-    private fun setPrice(editText: EditText, watcher: PriceTextWatcher, price: Int, cursorPositionFromEnd: Int) {
+    private fun setPrice(
+        editText: EditText,
+        watcher: PriceTextWatcher,
+        price: Int,
+    ) {
         val displayPrice = getString(R.string.all_price, price)
         editText.removeTextChangedListener(watcher)
         editText.setText(displayPrice)
-        editText.setSelection(getCursorPosition(displayPrice.length, cursorPositionFromEnd, SUFFIX_INPUT_PRICE.length)) // 이전 커서 위치로 이동
+        editText.setSelection(
+            watcher.getCursorPosition(
+                displayPrice.length,
+                SUFFIX_INPUT_PRICE.length,
+            ),
+        ) // 이전 커서 위치로 이동
         editText.addTextChangedListener(watcher)
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/register/RegisterAuctionActivity.kt
@@ -13,7 +13,10 @@ import androidx.activity.viewModels
 import com.ddangddangddang.android.R
 import com.ddangddangddang.android.databinding.ActivityRegisterAuctionBinding
 import com.ddangddangddang.android.feature.common.ErrorType
+import com.ddangddangddang.android.feature.common.PriceTextWatcher
+import com.ddangddangddang.android.feature.common.PriceTextWatcher.Companion.getCursorPosition
 import com.ddangddangddang.android.feature.detail.AuctionDetailActivity
+import com.ddangddangddang.android.feature.register.RegisterAuctionViewModel.Companion.SUFFIX_INPUT_PRICE
 import com.ddangddangddang.android.feature.register.category.SelectCategoryActivity
 import com.ddangddangddang.android.feature.register.region.SelectRegionsActivity
 import com.ddangddangddang.android.global.AnalyticsDelegate
@@ -239,17 +242,11 @@ class RegisterAuctionActivity :
     }
 
     private fun setPrice(editText: EditText, watcher: PriceTextWatcher, price: Int, cursorPositionFromEnd: Int) {
-        val displayPrice = getString(R.string.detail_auction_bid_dialog_input_price, price)
+        val displayPrice = getString(R.string.all_price, price)
         editText.removeTextChangedListener(watcher)
         editText.setText(displayPrice)
-        editText.setSelection(getCursorPosition(displayPrice.length, cursorPositionFromEnd)) // " 원" 앞으로 커서 이동
+        editText.setSelection(getCursorPosition(displayPrice.length, cursorPositionFromEnd, SUFFIX_INPUT_PRICE.length)) // 이전 커서 위치로 이동
         editText.addTextChangedListener(watcher)
-    }
-
-    private fun getCursorPosition(textLength: Int, prevCursorPositionFromEnd: Int): Int {
-        val cursorPositionFromEnd = if (prevCursorPositionFromEnd > 0) prevCursorPositionFromEnd else RegisterAuctionViewModel.SUFFIX_INPUT_PRICE.length
-        val cursorPosition = textLength - cursorPositionFromEnd
-        return if (cursorPosition > 0) cursorPosition else 0
     }
 
     private fun showDeleteImageDialog(image: RegisterImageModel) {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="all_time_format">h:mm a</string>
     <string name="all_default_reliability">( - )</string>
     <string name="all_back_key_check_message">\'뒤로\' 버튼을 한번 더 누르시면 종료됩니다</string>
+    <string name="all_price">%,d 원</string>
 
     <!-- splash -->
     <string name="splash_app_update_request_dialog_title">업데이트 알림</string>
@@ -95,7 +96,6 @@
 
     <!-- detail_auction_bid_dialog -->
     <string name="detail_auction_bid_dialog_title">입찰하기</string>
-    <string name="detail_auction_bid_dialog_input_price">%,d 원</string>
     <string name="detail_auction_bid_dialog_unit_price">판매자가 설정한 경매 단위: %,d원</string>
     <string name="detail_auction_bid_dialog_cancel">취소</string>
     <string name="detail_auction_bid_dialog_submit">입찰</string>


### PR DESCRIPTION
## 📄 작업 내용 요약
입찰시 커서 유지 기능 추가

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
- getCursorPosition 함수에서 PriceTextWatcher에서 관리하는 cursorPositionFromEnd 값을 사용하지 않는 이유는 커서를 가져오기 이전에 새로운 입력이 발생하여 값이 변경될 수 있기 때문입니다!
- _**근데 생각해보니 커서를 세팅하기 이전에 새로운 입력이 발생할 수 있을지 의문이 드는데 여러분의 생각은 어떠신가요? 🤔**_
- 쉼표 개수가 필요한 쉼표보다 적은 경우에만 커서를 한 칸 앞으로 이동한 이유는 쉼표가 지워진 경우에만 한 칸 앞으로 이동하기 위해서 입니다!
- trim을 두 번 해준 이유는 사용자가 원 또는 공백을 지운 경우에 입찰 금액이 0으로 초기화되는 것을 막기 위해서 입니다!

## 📎 Issue 번호
- close: #675 
