### PR TITLE
화면 구성 변경이 되더라도 알림 권한을 다시 묻지 않도록 수정

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainActivity.kt
@@ -61,7 +61,6 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         binding.viewModel = viewModel
 
         setupViewModel()
-        askNotificationPermission()
         onBackPressedDispatcher.addCallback(this, callback)
     }
 
@@ -85,6 +84,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     private fun handleEvent(event: MainViewModel.MainEvent) {
         when (event) {
             MainViewModel.MainEvent.HomeToTop -> scrollHomeToTop()
+            MainViewModel.MainEvent.NotificationPermissionCheck -> askNotificationPermission()
         }
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainViewModel.kt
@@ -21,6 +21,10 @@ class MainViewModel @Inject constructor() : ViewModel() {
         changeCurrentFragmentType(fragmentType)
     }
 
+    init {
+        _event.value = MainEvent.NotificationPermissionCheck
+    }
+
     private fun changeCurrentFragmentType(fragmentType: MainFragmentType) {
         if (currentFragmentType.value == fragmentType) {
             if (fragmentType == MainFragmentType.HOME) {
@@ -33,5 +37,6 @@ class MainViewModel @Inject constructor() : ViewModel() {
 
     sealed class MainEvent {
         object HomeToTop : MainEvent()
+        object NotificationPermissionCheck : MainEvent()
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
알림 권한 묻는 이벤트를 SingleLiveEvent로 변경
MainViewModel이 초기화될 때 알림 권한 이벤트 trigger

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
- 화면 구성이 변경되면 알림 권한을 설정하지 않은 경우, 알림 권한을 다시 묻고 있어서 위와 같이 수정했습니다.
- MainViewModel이 초기화될 때 알림 권한 이벤트를 trigger하게 했는데 이렇게하면 직접적인 의존성은 없지만 뷰모델이 뷰에 의존적이게 되는 걸까요...?

## 📎 Issue 번호
- close: #682 
