### PR TITLE
경매 상세 페이지 수정(마감기한 시간 정보 뷰 수정 및 최고 입찰자 표시)

### DIFF
--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
@@ -3,6 +3,7 @@ package com.ddangddangddang.android.feature.detail
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.util.TypedValue
 import android.view.View
 import androidx.activity.viewModels
 import androidx.viewpager2.widget.ViewPager2
@@ -41,11 +42,9 @@ class AuctionDetailActivity :
 
     // 액션바 높이를 반환하는 함수
     private fun getActionBarHeight(context: Context): Int {
-        val styledAttributes =
-            context.theme.obtainStyledAttributes(intArrayOf(androidx.appcompat.R.attr.actionBarSize))
-        val actionBarHeight = styledAttributes.getDimension(0, 0f).toInt()
-        styledAttributes.recycle()
-        return actionBarHeight
+        val typedValue = TypedValue()
+        context.theme.resolveAttribute(androidx.appcompat.R.attr.actionBarSize, typedValue, true)
+        return TypedValue.complexToDimensionPixelSize(typedValue.data, resources.displayMetrics)
     }
 
     private fun getRemainingHeight(context: Context): Int {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
@@ -50,7 +50,7 @@ class AuctionDetailActivity :
 
     private fun getRemainingHeight(context: Context): Int {
         val screenHeight = context.resources.displayMetrics.heightPixels
-        val statusBarHeight = convertDpToPx(24f) // 탭 레이아웃의 톱 마진과도 같은 값임.
+        val statusBarHeight = convertDpToPx(ACTION_BAR_HEIGHT) // 탭 레이아웃의 톱 마진과도 같은 값임.
         val actionBarHeight = getActionBarHeight(context)
         val tabLayoutHeight = resources.getDimensionPixelOffset(R.dimen.height_submit_button)
         val bottomButtonHeight = resources.getDimensionPixelOffset(R.dimen.height_submit_button)
@@ -187,6 +187,7 @@ class AuctionDetailActivity :
 
     companion object {
         private const val AUCTION_ID_KEY = "auction_id_key"
+        private const val ACTION_BAR_HEIGHT = 24f
 
         fun getIntent(context: Context, auctionId: Long): Intent {
             return Intent(context, AuctionDetailActivity::class.java).apply {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
@@ -42,7 +42,7 @@ class AuctionDetailActivity :
     // 액션바 높이를 반환하는 함수
     private fun getActionBarHeight(context: Context): Int {
         val styledAttributes =
-            context.theme.obtainStyledAttributes(intArrayOf(com.google.android.material.R.attr.actionBarSize))
+            context.theme.obtainStyledAttributes(intArrayOf(androidx.appcompat.R.attr.actionBarSize))
         val actionBarHeight = styledAttributes.getDimension(0, 0f).toInt()
         styledAttributes.recycle()
         return actionBarHeight
@@ -50,7 +50,7 @@ class AuctionDetailActivity :
 
     private fun getRemainingHeight(context: Context): Int {
         val screenHeight = context.resources.displayMetrics.heightPixels
-        val statusBarHeight = convertDpToPx(ACTION_BAR_HEIGHT) // 탭 레이아웃의 톱 마진과도 같은 값임.
+        val statusBarHeight = convertDpToPx(STATUS_BAR_HEIGHT) // 탭 레이아웃의 톱 마진과도 같은 값임.
         val actionBarHeight = getActionBarHeight(context)
         val tabLayoutHeight = resources.getDimensionPixelOffset(R.dimen.height_submit_button)
         val bottomButtonHeight = resources.getDimensionPixelOffset(R.dimen.height_submit_button)
@@ -187,7 +187,7 @@ class AuctionDetailActivity :
 
     companion object {
         private const val AUCTION_ID_KEY = "auction_id_key"
-        private const val ACTION_BAR_HEIGHT = 24f
+        private const val STATUS_BAR_HEIGHT = 24f
 
         fun getIntent(context: Context, auctionId: Long): Intent {
             return Intent(context, AuctionDetailActivity::class.java).apply {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
@@ -48,13 +48,13 @@ class AuctionDetailActivity :
         return actionBarHeight
     }
 
-    // 스크린 높이에서 액션바 높이를 뺀 높이를 계산하는 함수
     private fun getRemainingHeight(context: Context): Int {
         val screenHeight = context.resources.displayMetrics.heightPixels
+        val statusBarHeight = convertDpToPx(24f) // 탭 레이아웃의 톱 마진과도 같은 값임.
         val actionBarHeight = getActionBarHeight(context)
-        val tabLayoutHeight = convertDpToPx(48f + 24f)
+        val tabLayoutHeight = resources.getDimensionPixelOffset(R.dimen.height_submit_button)
         val bottomButtonHeight = resources.getDimensionPixelOffset(R.dimen.height_submit_button)
-        return screenHeight - actionBarHeight - tabLayoutHeight - bottomButtonHeight
+        return screenHeight - statusBarHeight - actionBarHeight - tabLayoutHeight - bottomButtonHeight
     }
 
     // 뷰의 높이를 동적으로 설정하는 함수

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
@@ -18,6 +18,7 @@ import com.ddangddangddang.android.notification.NotificationType
 import com.ddangddangddang.android.notification.cancelActiveNotification
 import com.ddangddangddang.android.util.binding.BindingActivity
 import com.ddangddangddang.android.util.view.Toaster
+import com.ddangddangddang.android.util.view.convertDpToPx
 import com.ddangddangddang.android.util.view.observeLoadingWithDialog
 import com.ddangddangddang.android.util.view.showDialog
 import com.google.android.material.tabs.TabLayoutMediator
@@ -41,7 +42,7 @@ class AuctionDetailActivity :
     // 액션바 높이를 반환하는 함수
     private fun getActionBarHeight(context: Context): Int {
         val styledAttributes =
-            context.theme.obtainStyledAttributes(intArrayOf(android.R.attr.actionBarSize))
+            context.theme.obtainStyledAttributes(intArrayOf(com.google.android.material.R.attr.actionBarSize))
         val actionBarHeight = styledAttributes.getDimension(0, 0f).toInt()
         styledAttributes.recycle()
         return actionBarHeight
@@ -51,7 +52,9 @@ class AuctionDetailActivity :
     private fun getRemainingHeight(context: Context): Int {
         val screenHeight = context.resources.displayMetrics.heightPixels
         val actionBarHeight = getActionBarHeight(context)
-        return screenHeight - actionBarHeight * 2
+        val tabLayoutHeight = convertDpToPx(48f + 24f)
+        val bottomButtonHeight = resources.getDimensionPixelOffset(R.dimen.height_submit_button)
+        return screenHeight - actionBarHeight - tabLayoutHeight - bottomButtonHeight
     }
 
     // 뷰의 높이를 동적으로 설정하는 함수

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailActivity.kt
@@ -3,8 +3,6 @@ package com.ddangddangddang.android.feature.detail
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.util.TypedValue
-import android.view.View
 import androidx.activity.viewModels
 import androidx.viewpager2.widget.ViewPager2
 import com.ddangddangddang.android.R
@@ -19,7 +17,6 @@ import com.ddangddangddang.android.notification.NotificationType
 import com.ddangddangddang.android.notification.cancelActiveNotification
 import com.ddangddangddang.android.util.binding.BindingActivity
 import com.ddangddangddang.android.util.view.Toaster
-import com.ddangddangddang.android.util.view.convertDpToPx
 import com.ddangddangddang.android.util.view.observeLoadingWithDialog
 import com.ddangddangddang.android.util.view.showDialog
 import com.google.android.material.tabs.TabLayoutMediator
@@ -36,31 +33,7 @@ class AuctionDetailActivity :
         binding.viewModel = viewModel
         setupDetailView()
         setupViewModel()
-        setDynamicHeight(binding.vpDetailInfo, this)
         if (savedInstanceState == null) viewModel.loadAuctionDetail(auctionId)
-    }
-
-    // 액션바 높이를 반환하는 함수
-    private fun getActionBarHeight(context: Context): Int {
-        val typedValue = TypedValue()
-        context.theme.resolveAttribute(androidx.appcompat.R.attr.actionBarSize, typedValue, true)
-        return TypedValue.complexToDimensionPixelSize(typedValue.data, resources.displayMetrics)
-    }
-
-    private fun getRemainingHeight(context: Context): Int {
-        val screenHeight = context.resources.displayMetrics.heightPixels
-        val statusBarHeight = convertDpToPx(STATUS_BAR_HEIGHT) // 탭 레이아웃의 톱 마진과도 같은 값임.
-        val actionBarHeight = getActionBarHeight(context)
-        val tabLayoutHeight = resources.getDimensionPixelOffset(R.dimen.height_submit_button)
-        val bottomButtonHeight = resources.getDimensionPixelOffset(R.dimen.height_submit_button)
-        return screenHeight - statusBarHeight - actionBarHeight - tabLayoutHeight - bottomButtonHeight
-    }
-
-    // 뷰의 높이를 동적으로 설정하는 함수
-    private fun setDynamicHeight(view: View, context: Context) {
-        val params = view.layoutParams
-        params.height = getRemainingHeight(context)
-        view.layoutParams = params
     }
 
     private fun setupDetailView() {
@@ -186,7 +159,6 @@ class AuctionDetailActivity :
 
     companion object {
         private const val AUCTION_ID_KEY = "auction_id_key"
-        private const val STATUS_BAR_HEIGHT = 24f
 
         fun getIntent(context: Context, auctionId: Long): Intent {
             return Intent(context, AuctionDetailActivity::class.java).apply {

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailBottomButtonStatus.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailBottomButtonStatus.kt
@@ -32,7 +32,7 @@ enum class AuctionDetailBottomButtonStatus(
             return when {
                 canEnterMessageRoom(chatStatus) -> EnterAuctionChatRoom
                 canBidAuction(auctionStatus, isOwner) -> {
-                    if (auctionDetailModel.hasLastBidder) {
+                    if (auctionDetailModel.isLastBidder) {
                         AlreadyLastBidder
                     } else {
                         BidAuction

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailBottomButtonStatus.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailBottomButtonStatus.kt
@@ -17,6 +17,8 @@ enum class AuctionDetailBottomButtonStatus(
     EnterAuctionChatRoom(R.string.detail_auction_chat_room_entrance, true),
 
     MyAuction(R.string.detail_auction_my_auction, false),
+
+    AlreadyLastBidder(R.string.detail_auction_already_last_bidder, false),
     ;
 
     companion object {
@@ -29,7 +31,14 @@ enum class AuctionDetailBottomButtonStatus(
 
             return when {
                 canEnterMessageRoom(chatStatus) -> EnterAuctionChatRoom
-                canBidAuction(auctionStatus, isOwner) -> BidAuction
+                canBidAuction(auctionStatus, isOwner) -> {
+                    if (auctionDetailModel.hasLastBidder) {
+                        AlreadyLastBidder
+                    } else {
+                        BidAuction
+                    }
+                }
+
                 isOwner -> MyAuction
                 else -> FinishAuction
             }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailBottomButtonStatus.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailBottomButtonStatus.kt
@@ -28,11 +28,12 @@ enum class AuctionDetailBottomButtonStatus(
             val isOwner = auctionDetailModel.isOwner
             val auctionStatus = auctionDetailModel.auctionDetailStatusModel
             val chatStatus = auctionDetailModel.chatAuctionDetailModel
+            val isLastBidder = auctionDetailModel.isLastBidder
 
             return when {
                 canEnterMessageRoom(chatStatus) -> EnterAuctionChatRoom
                 canBidAuction(auctionStatus, isOwner) -> {
-                    if (auctionDetailModel.isLastBidder) {
+                    if (isLastBidder) {
                         AlreadyLastBidder
                     } else {
                         BidAuction

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailFormatter.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailFormatter.kt
@@ -70,9 +70,8 @@ object AuctionDetailFormatter {
         val minutes = (differenceInMills / (60 * 1000L)) % 60
 
         return buildString {
-            if (days > 0L) append("${days}일")
-            if (hours > 0L) append(" ${hours}시간")
-            if (minutes > 0L) append(" ${minutes}분")
+            if (days > 0L) append("${days}일 ")
+            append(" ${String.format("%02d:%02d", hours, minutes)}")
         }.trim()
     }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/detail/AuctionDetailViewModel.kt
@@ -80,8 +80,9 @@ class AuctionDetailViewModel @Inject constructor(
             when (it) {
                 AuctionDetailBottomButtonStatus.BidAuction -> popupAuctionBidEvent()
                 AuctionDetailBottomButtonStatus.EnterAuctionChatRoom -> enterChatRoomEvent()
-                AuctionDetailBottomButtonStatus.FinishAuction -> {}
+                AuctionDetailBottomButtonStatus.AlreadyLastBidder -> {}
                 AuctionDetailBottomButtonStatus.MyAuction -> {}
+                AuctionDetailBottomButtonStatus.FinishAuction -> {}
             }
         }
     }

--- a/android/app/src/main/java/com/ddangddangddang/android/model/AuctionDetailModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/model/AuctionDetailModel.kt
@@ -20,5 +20,5 @@ data class AuctionDetailModel(
     val sellerModel: SellerModel,
     val chatAuctionDetailModel: ChatAuctionDetailModel,
     val isOwner: Boolean,
-    val hasLastBidder: Boolean,
+    val isLastBidder: Boolean,
 )

--- a/android/app/src/main/java/com/ddangddangddang/android/model/AuctionDetailModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/model/AuctionDetailModel.kt
@@ -20,4 +20,5 @@ data class AuctionDetailModel(
     val sellerModel: SellerModel,
     val chatAuctionDetailModel: ChatAuctionDetailModel,
     val isOwner: Boolean,
+    val hasLastBidder: Boolean,
 )

--- a/android/app/src/main/java/com/ddangddangddang/android/model/mapper/AuctionDetailModelMapper.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/model/mapper/AuctionDetailModelMapper.kt
@@ -34,6 +34,7 @@ object AuctionDetailModelMapper : Mapper<AuctionDetailModel, AuctionDetailRespon
             SellerModel(seller.id, seller.image ?: "", seller.nickname, seller.reliability),
             ChatAuctionDetailModel(chat.id, chat.isChatParticipant),
             isOwner,
+            auction.hasLastBidder ?: false,
         )
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/model/mapper/AuctionDetailModelMapper.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/model/mapper/AuctionDetailModelMapper.kt
@@ -34,7 +34,7 @@ object AuctionDetailModelMapper : Mapper<AuctionDetailModel, AuctionDetailRespon
             SellerModel(seller.id, seller.image ?: "", seller.nickname, seller.reliability),
             ChatAuctionDetailModel(chat.id, chat.isChatParticipant),
             isOwner,
-            auction.hasLastBidder ?: false,
+            isLastBidder,
         )
     }
 }

--- a/android/app/src/main/res/layout-land/activity_auction_detail.xml
+++ b/android/app/src/main/res/layout-land/activity_auction_detail.xml
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <import type="com.ddangddangddang.android.feature.detail.AuctionDetailFormatter" />
+
+        <import type="android.view.View" />
+
+        <variable
+            name="viewModel"
+            type="com.ddangddangddang.android.feature.detail.AuctionDetailViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/clAuctionDetailContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/grey_50">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/tb_detail_auction"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:layout_gravity="top"
+            app:contentInsetLeft="0dp"
+            app:contentInsetStart="0dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center_vertical|start"
+                android:orientation="horizontal">
+
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginStart="@dimen/margin_side_layout"
+                    android:contentDescription="@string/all_app_bar_back_key_description"
+                    android:onClick="@{()->viewModel.setExitEvent()}"
+                    android:src="@drawable/ic_left_24"
+                    app:tint="@color/grey_900" />
+
+                <TextView
+                    android:id="@+id/tv_detail_title"
+                    style="@style/Header1"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="20dp"
+                    android:layout_marginEnd="20dp"
+                    android:layout_weight="1"
+                    android:ellipsize="marquee"
+                    android:marqueeRepeatLimit="marquee_forever"
+                    android:maxLines="1"
+                    android:selected="@{true}"
+                    android:singleLine="true"
+                    android:text="@{viewModel.auctionDetailModel.title}"
+                    tools:text="M1 맥북 에어" />
+
+                <ImageView
+                    android:id="@+id/iv_report"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_gravity="center_vertical|end"
+                    android:layout_marginEnd="@dimen/margin_side_layout"
+                    android:onClick="@{() -> viewModel.reportAuction()}"
+                    android:src="@drawable/ic_report_24"
+                    android:visibility="@{viewModel.auctionDetailModel.owner ? View.GONE : View.VISIBLE}" />
+
+                <ImageView
+                    android:id="@+id/iv_delete"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_gravity="center_vertical|end"
+                    android:layout_marginEnd="@dimen/margin_side_layout"
+                    android:onClick="@{() -> viewModel.setDeleteAuctionEvent()}"
+                    android:src="@drawable/ic_delete_24"
+                    android:visibility="@{viewModel.auctionDetailModel.owner ? View.VISIBLE : View.GONE}" />
+
+            </LinearLayout>
+        </androidx.appcompat.widget.Toolbar>
+
+        <androidx.coordinatorlayout.widget.CoordinatorLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toTopOf="@id/btn_auction_detail_bottom_button"
+            app:layout_constraintTop_toBottomOf="@id/tb_detail_auction">
+
+            <com.google.android.material.appbar.AppBarLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <com.google.android.material.appbar.CollapsingToolbarLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@color/grey_50"
+                    app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingBottom="24dp"
+                        app:layout_collapseMode="parallax">
+
+                        <androidx.viewpager2.widget.ViewPager2
+                            android:id="@+id/vp_image_list"
+                            android:layout_width="match_parent"
+                            android:layout_height="250dp"
+                            android:clipChildren="false"
+                            android:clipToPadding="false"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <com.google.android.material.tabs.TabLayout
+                            android:id="@+id/tl_indicator"
+                            style="@style/Widget.Design.TabLayout"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            app:layout_constraintTop_toBottomOf="@id/vp_image_list"
+                            app:tabBackground="@drawable/bg_detail_normal_dot_to_selected_dot"
+                            app:tabGravity="center"
+                            app:tabIndicatorHeight="0dp" />
+
+                        <androidx.constraintlayout.widget.Guideline
+                            android:id="@+id/gl_begin"
+                            android:layout_width="wrap_content"
+                            android:layout_height="match_parent"
+                            android:orientation="vertical"
+                            app:layout_constraintGuide_begin="@dimen/margin_side_layout" />
+
+                        <androidx.constraintlayout.widget.Guideline
+                            android:id="@+id/gl_end"
+                            android:layout_width="wrap_content"
+                            android:layout_height="match_parent"
+                            android:orientation="vertical"
+                            app:layout_constraintGuide_end="@dimen/margin_side_layout" />
+
+                        <TextView
+                            android:id="@+id/tv_auction_category"
+                            style="@style/Caption"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@{AuctionDetailFormatter.INSTANCE.formatCategoryText(context, viewModel.auctionDetailModel.mainCategory,viewModel.auctionDetailModel.subCategory)}"
+                            android:textColor="@color/grey_500"
+                            android:textSize="12dp"
+                            app:layout_constraintStart_toStartOf="@id/gl_begin"
+                            app:layout_constraintTop_toBottomOf="@id/tl_indicator"
+                            tools:text="가전 > 노트북" />
+
+                        <TextView
+                            style="@style/Caption"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@{viewModel.auctionDetailModel.registerTime.toLocalDate().toString()}"
+                            android:textColor="@color/grey_500"
+                            android:textSize="12dp"
+                            app:layout_constraintBottom_toBottomOf="@id/tv_auction_category"
+                            app:layout_constraintEnd_toEndOf="@id/gl_end"
+                            app:layout_constraintTop_toTopOf="@id/tv_auction_category"
+                            tools:text="2023-07-11" />
+
+                        <TextView
+                            android:id="@+id/tv_auction_status"
+                            style="@style/Body"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="14dp"
+                            android:background="@drawable/bg_radius_8dp"
+                            android:backgroundTint="@{AuctionDetailFormatter.INSTANCE.formatAuctionStatusColor(context, viewModel.auctionDetailModel.auctionDetailStatusModel.colorId)}"
+                            android:paddingHorizontal="10dp"
+                            android:paddingVertical="4dp"
+                            android:text="@{viewModel.auctionDetailModel.auctionDetailStatusModel.progressStatus}"
+                            android:textColor="@color/grey_50"
+                            android:textFontWeight="700"
+                            android:textSize="14dp"
+                            app:layout_constraintStart_toStartOf="@id/gl_begin"
+                            app:layout_constraintTop_toBottomOf="@id/tv_auction_category"
+                            tools:backgroundTint="@color/red_300"
+                            tools:text="경매중" />
+
+                        <TextView
+                            android:id="@+id/tv_auction_closingTime"
+                            style="@style/Caption"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="14dp"
+                            android:text="@{AuctionDetailFormatter.INSTANCE.formatClosingTime(viewModel.auctionDetailModel.closingTime)}"
+                            android:textColor="@color/grey_500"
+                            android:textSize="12dp"
+                            app:layout_constraintBottom_toBottomOf="@id/tv_auction_status"
+                            app:layout_constraintStart_toEndOf="@id/tv_auction_status"
+                            app:layout_constraintTop_toTopOf="@id/tv_auction_status"
+                            tools:text="~ 2023.07.13 오후 12:00" />
+
+                        <TextView
+                            android:id="@+id/tv_remain_time"
+                            style="@style/Header2"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:drawablePadding="4dp"
+                            android:text="@{AuctionDetailFormatter.INSTANCE.formatClosingRemainDateText(context,viewModel.auctionDetailModel.closingTime)}"
+                            android:textColor="@color/primary"
+                            android:textSize="16dp"
+                            app:drawableStartCompat="@drawable/ic_alarm_24"
+                            app:layout_constraintBottom_toBottomOf="@id/tv_auction_closingTime"
+                            app:layout_constraintEnd_toEndOf="@id/gl_end"
+                            app:layout_constraintTop_toTopOf="@id/tv_auction_closingTime"
+                            tools:text="1시간 35분" />
+
+                        <TextView
+                            android:id="@+id/tv_last_bid_price"
+                            style="@style/Header1"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="16dp"
+                            android:ellipsize="marquee"
+                            android:marqueeRepeatLimit="marquee_forever"
+                            android:selected="@{true}"
+                            android:singleLine="true"
+                            android:text="@{AuctionDetailFormatter.INSTANCE.formatAuctionDetailStatus(context,viewModel.auctionDetailModel)}"
+                            android:textColor="@color/grey_900"
+                            app:layout_constraintEnd_toEndOf="@id/gl_end"
+                            app:layout_constraintStart_toStartOf="@id/gl_begin"
+                            app:layout_constraintTop_toBottomOf="@id/tv_auction_status"
+                            tools:text="현재가 400,000원" />
+
+                        <TextView
+                            android:id="@+id/tv_start_price"
+                            style="@style/Header2"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="2dp"
+                            android:text="@{@string/detail_auction_start_price(viewModel.auctionDetailModel.startPrice)}"
+                            android:textColor="@color/grey_700"
+                            android:textFontWeight="400"
+                            android:textSize="16dp"
+                            app:layout_constraintStart_toStartOf="@id/gl_begin"
+                            app:layout_constraintTop_toBottomOf="@id/tv_last_bid_price"
+                            tools:text="시작가 100,000원" />
+
+                        <ImageView
+                            android:id="@+id/iv_auctioneer_count_icon"
+                            android:layout_width="16dp"
+                            android:layout_height="16dp"
+                            android:layout_marginTop="12dp"
+                            android:contentDescription="@string/detail_auctioneer_count_icon_description"
+                            android:src="@drawable/ic_people_alt_24"
+                            app:layout_constraintStart_toStartOf="@id/gl_begin"
+                            app:layout_constraintTop_toBottomOf="@id/tv_start_price"
+                            app:tint="@color/grey_700" />
+
+                        <TextView
+                            android:id="@+id/tv_auctioneer_count"
+                            style="@style/Caption"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="4dp"
+                            android:text="@{@string/detail_auction_auctioneer_count(viewModel.auctionDetailModel.auctioneerCount)}"
+                            android:textColor="@color/grey_700"
+                            app:layout_constraintBottom_toBottomOf="@id/iv_auctioneer_count_icon"
+                            app:layout_constraintStart_toEndOf="@id/iv_auctioneer_count_icon"
+                            app:layout_constraintTop_toTopOf="@id/iv_auctioneer_count_icon"
+                            tools:text="26명 경매 참여중" />
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+                </com.google.android.material.appbar.CollapsingToolbarLayout>
+
+                <com.google.android.material.tabs.TabLayout
+                    android:id="@+id/tb_detail_info"
+                    android:layout_width="match_parent"
+                    android:layout_height="48dp"
+                    android:background="@color/grey_50"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_auctioneer_count"
+                    app:tabGravity="fill"
+                    app:tabIndicatorFullWidth="true"
+                    app:tabMaxWidth="0dp"
+                    app:tabMode="fixed" />
+
+            </com.google.android.material.appbar.AppBarLayout>
+
+            <androidx.viewpager2.widget.ViewPager2
+                android:id="@+id/vp_detail_info"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+        </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+        <Button
+            android:id="@+id/btn_auction_detail_bottom_button"
+            style="@style/BigButton"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/height_submit_button"
+            android:layout_marginHorizontal="@dimen/margin_side_layout"
+            android:enabled="@{viewModel.auctionDetailBottomButtonStatus.enabled}"
+            android:minHeight="@dimen/height_submit_button"
+            android:onClick="@{()->viewModel.handleAuctionDetailBottomButton()}"
+            android:padding="0dp"
+            android:text="@{AuctionDetailFormatter.INSTANCE.getAuctionBottomButtonText(context,viewModel.auctionDetailBottomButtonStatus)}"
+            android:textColor="@color/text_active_fixed"
+            android:textSize="18dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            tools:text="입찰하기" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/activity_auction_detail.xml
+++ b/android/app/src/main/res/layout/activity_auction_detail.xml
@@ -14,90 +14,126 @@
             type="com.ddangddangddang.android.feature.detail.AuctionDetailViewModel" />
     </data>
 
-    <FrameLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/clAuctionDetailContainer"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:background="@color/grey_50">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/tb_detail_auction"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginBottom="@dimen/height_submit_button">
+            android:layout_height="?attr/actionBarSize"
+            android:layout_gravity="top"
+            app:contentInsetLeft="0dp"
+            app:contentInsetStart="0dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-            <androidx.appcompat.widget.Toolbar
-                android:id="@+id/tb_detail_auction"
+            <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize"
-                android:layout_gravity="top"
-                app:contentInsetLeft="0dp"
-                app:contentInsetStart="0dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
+                android:layout_height="match_parent"
+                android:gravity="center_vertical|start"
+                android:orientation="horizontal">
 
-                <LinearLayout
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginStart="@dimen/margin_side_layout"
+                    android:contentDescription="@string/all_app_bar_back_key_description"
+                    android:onClick="@{()->viewModel.setExitEvent()}"
+                    android:src="@drawable/ic_left_24"
+                    app:tint="@color/grey_900" />
+
+                <TextView
+                    android:id="@+id/tv_detail_title"
+                    style="@style/Header1"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="20dp"
+                    android:layout_marginEnd="20dp"
+                    android:layout_weight="1"
+                    android:ellipsize="marquee"
+                    android:marqueeRepeatLimit="marquee_forever"
+                    android:maxLines="1"
+                    android:selected="@{true}"
+                    android:singleLine="true"
+                    android:text="@{viewModel.auctionDetailModel.title}"
+                    tools:text="M1 맥북 에어" />
+
+                <ImageView
+                    android:id="@+id/iv_report"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_gravity="center_vertical|end"
+                    android:layout_marginEnd="@dimen/margin_side_layout"
+                    android:onClick="@{() -> viewModel.reportAuction()}"
+                    android:src="@drawable/ic_report_24"
+                    android:visibility="@{viewModel.auctionDetailModel.owner ? View.GONE : View.VISIBLE}" />
+
+                <ImageView
+                    android:id="@+id/iv_delete"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_gravity="center_vertical|end"
+                    android:layout_marginEnd="@dimen/margin_side_layout"
+                    android:onClick="@{() -> viewModel.setDeleteAuctionEvent()}"
+                    android:src="@drawable/ic_delete_24"
+                    android:visibility="@{viewModel.auctionDetailModel.owner ? View.VISIBLE : View.GONE}" />
+
+            </LinearLayout>
+        </androidx.appcompat.widget.Toolbar>
+
+        <androidx.coordinatorlayout.widget.CoordinatorLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toTopOf="@id/btn_auction_detail_bottom_button"
+            app:layout_constraintTop_toBottomOf="@id/tb_detail_auction">
+
+            <com.google.android.material.appbar.AppBarLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <com.google.android.material.appbar.CollapsingToolbarLayout
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:gravity="center_vertical|start"
-                    android:orientation="horizontal">
+                    android:layout_height="wrap_content"
+                    android:background="@color/grey_50"
+                    app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
-
-                    <ImageView
-                        android:layout_width="24dp"
-                        android:layout_height="24dp"
-                        android:layout_marginStart="@dimen/margin_side_layout"
-                        android:contentDescription="@string/all_app_bar_back_key_description"
-                        android:onClick="@{()->viewModel.setExitEvent()}"
-                        android:src="@drawable/ic_left_24"
-                        app:tint="@color/grey_900" />
-
-                    <TextView
-                        android:id="@+id/tv_detail_title"
-                        style="@style/Header1"
-                        android:layout_width="0dp"
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="20dp"
-                        android:layout_marginEnd="20dp"
-                        android:layout_weight="1"
-                        android:ellipsize="marquee"
-                        android:marqueeRepeatLimit="marquee_forever"
-                        android:maxLines="1"
-                        android:selected="@{true}"
-                        android:singleLine="true"
-                        android:text="@{viewModel.auctionDetailModel.title}"
-                        tools:text="M1 맥북 에어" />
+                        app:layout_collapseMode="parallax">
 
-                    <ImageView
-                        android:id="@+id/iv_report"
-                        android:layout_width="24dp"
-                        android:layout_height="24dp"
-                        android:layout_gravity="center_vertical|end"
-                        android:layout_marginEnd="@dimen/margin_side_layout"
-                        android:onClick="@{() -> viewModel.reportAuction()}"
-                        android:src="@drawable/ic_report_24"
-                        android:visibility="@{viewModel.auctionDetailModel.owner ? View.GONE : View.VISIBLE}" />
+                        <androidx.viewpager2.widget.ViewPager2
+                            android:id="@+id/vp_image_list"
+                            android:layout_width="match_parent"
+                            android:layout_height="250dp"
+                            android:clipChildren="false"
+                            android:clipToPadding="false"
+                            app:layout_constraintTop_toTopOf="parent" />
 
-                    <ImageView
-                        android:id="@+id/iv_delete"
-                        android:layout_width="24dp"
-                        android:layout_height="24dp"
-                        android:layout_gravity="center_vertical|end"
-                        android:layout_marginEnd="@dimen/margin_side_layout"
-                        android:onClick="@{() -> viewModel.setDeleteAuctionEvent()}"
-                        android:src="@drawable/ic_delete_24"
-                        android:visibility="@{viewModel.auctionDetailModel.owner ? View.VISIBLE : View.GONE}" />
+                        <com.google.android.material.tabs.TabLayout
+                            android:id="@+id/tl_indicator"
+                            style="@style/Widget.Design.TabLayout"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            app:layout_constraintTop_toBottomOf="@id/vp_image_list"
+                            app:tabBackground="@drawable/bg_detail_normal_dot_to_selected_dot"
+                            app:tabGravity="center"
+                            app:tabIndicatorHeight="0dp" />
 
-                </LinearLayout>
-            </androidx.appcompat.widget.Toolbar>
+                    </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <androidx.core.widget.NestedScrollView
-                android:layout_width="match_parent"
-                android:layout_height="0dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tb_detail_auction">
+
+                </com.google.android.material.appbar.CollapsingToolbarLayout>
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                    android:layout_height="wrap_content"
+                    android:background="@color/grey_50"
+                    android:paddingBottom="24dp">
 
                     <androidx.constraintlayout.widget.Guideline
                         android:id="@+id/gl_begin"
@@ -113,24 +149,6 @@
                         android:orientation="vertical"
                         app:layout_constraintGuide_end="@dimen/margin_side_layout" />
 
-                    <androidx.viewpager2.widget.ViewPager2
-                        android:id="@+id/vp_image_list"
-                        android:layout_width="match_parent"
-                        android:layout_height="250dp"
-                        android:clipChildren="false"
-                        android:clipToPadding="false"
-                        app:layout_constraintTop_toTopOf="parent" />
-
-                    <com.google.android.material.tabs.TabLayout
-                        android:id="@+id/tl_indicator"
-                        style="@style/Widget.Design.TabLayout"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        app:layout_constraintTop_toBottomOf="@id/vp_image_list"
-                        app:tabBackground="@drawable/bg_detail_normal_dot_to_selected_dot"
-                        app:tabGravity="center"
-                        app:tabIndicatorHeight="0dp" />
-
                     <TextView
                         android:id="@+id/tv_auction_category"
                         style="@style/Caption"
@@ -140,7 +158,7 @@
                         android:textColor="@color/grey_500"
                         android:textSize="12dp"
                         app:layout_constraintStart_toStartOf="@id/gl_begin"
-                        app:layout_constraintTop_toBottomOf="@id/tl_indicator"
+                        app:layout_constraintTop_toTopOf="parent"
                         tools:text="가전 > 노트북" />
 
                     <TextView
@@ -258,45 +276,46 @@
                         app:layout_constraintTop_toTopOf="@id/iv_auctioneer_count_icon"
                         tools:text="26명 경매 참여중" />
 
-                    <com.google.android.material.tabs.TabLayout
-                        android:id="@+id/tb_detail_info"
-                        android:layout_width="0dp"
-                        android:layout_height="48dp"
-                        android:layout_marginTop="24dp"
-                        android:backgroundTint="@color/grey_50"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/tv_auctioneer_count"
-                        app:tabGravity="fill"
-                        app:tabIndicatorFullWidth="true"
-                        app:tabMaxWidth="0dp"
-                        app:tabMode="fixed" />
-
-                    <androidx.viewpager2.widget.ViewPager2
-                        android:id="@+id/vp_detail_info"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        app:layout_constraintTop_toBottomOf="@id/tb_detail_info" />
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
-            </androidx.core.widget.NestedScrollView>
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                <com.google.android.material.tabs.TabLayout
+                    android:id="@+id/tb_detail_info"
+                    android:layout_width="match_parent"
+                    android:layout_height="48dp"
+                    android:background="@color/grey_50"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_auctioneer_count"
+                    app:tabGravity="fill"
+                    app:tabIndicatorFullWidth="true"
+                    app:tabMaxWidth="0dp"
+                    app:tabMode="fixed" />
+
+            </com.google.android.material.appbar.AppBarLayout>
+
+            <androidx.viewpager2.widget.ViewPager2
+                android:id="@+id/vp_detail_info"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+        </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
         <Button
             android:id="@+id/btn_auction_detail_bottom_button"
             style="@style/BigButton"
             android:layout_width="match_parent"
             android:layout_height="@dimen/height_submit_button"
-            android:layout_gravity="bottom"
             android:layout_marginHorizontal="@dimen/margin_side_layout"
             android:enabled="@{viewModel.auctionDetailBottomButtonStatus.enabled}"
-            android:gravity="center"
             android:minHeight="@dimen/height_submit_button"
             android:onClick="@{()->viewModel.handleAuctionDetailBottomButton()}"
             android:padding="0dp"
             android:text="@{AuctionDetailFormatter.INSTANCE.getAuctionBottomButtonText(context,viewModel.auctionDetailBottomButtonStatus)}"
             android:textColor="@color/text_active_fixed"
             android:textSize="18dp"
+            app:layout_constraintBottom_toBottomOf="parent"
             tools:text="입찰하기" />
-    </FrameLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/activity_auction_detail.xml
+++ b/android/app/src/main/res/layout/activity_auction_detail.xml
@@ -21,7 +21,8 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:layout_marginBottom="@dimen/height_submit_button">
 
             <androidx.appcompat.widget.Toolbar
                 android:id="@+id/tb_detail_auction"
@@ -260,7 +261,7 @@
                     <com.google.android.material.tabs.TabLayout
                         android:id="@+id/tb_detail_info"
                         android:layout_width="0dp"
-                        android:layout_height="wrap_content"
+                        android:layout_height="48dp"
                         android:layout_marginTop="24dp"
                         android:backgroundTint="@color/grey_50"
                         app:layout_constraintEnd_toEndOf="parent"
@@ -282,7 +283,7 @@
             android:id="@+id/btn_auction_detail_bottom_button"
             style="@style/BigButton"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="@dimen/height_submit_button"
             android:layout_gravity="bottom"
             android:layout_marginHorizontal="@dimen/margin_side_layout"
             android:enabled="@{viewModel.auctionDetailBottomButtonStatus.enabled}"
@@ -292,6 +293,7 @@
             android:padding="0dp"
             android:text="@{AuctionDetailFormatter.INSTANCE.getAuctionBottomButtonText(context,viewModel.auctionDetailBottomButtonStatus)}"
             android:textColor="@color/text_active_fixed"
+            android:textSize="18dp"
             tools:text="입찰하기" />
     </FrameLayout>
 </layout>

--- a/android/app/src/main/res/layout/activity_auction_detail.xml
+++ b/android/app/src/main/res/layout/activity_auction_detail.xml
@@ -267,7 +267,10 @@
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/tv_auctioneer_count"
-                        app:tabIndicatorFullWidth="true" />
+                        app:tabGravity="fill"
+                        app:tabIndicatorFullWidth="true"
+                        app:tabMaxWidth="0dp"
+                        app:tabMode="fixed" />
 
                     <androidx.viewpager2.widget.ViewPager2
                         android:id="@+id/vp_detail_info"

--- a/android/app/src/main/res/layout/fragment_auction_info.xml
+++ b/android/app/src/main/res/layout/fragment_auction_info.xml
@@ -116,11 +116,12 @@
             <TextView
                 android:id="@+id/tv_seller_nickname"
                 style="@style/Body"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:text="@{activityViewModel.auctionDetailModel.sellerModel.nickname}"
                 app:layout_constraintBottom_toTopOf="@id/iv_reliability_icon"
+                app:layout_constraintEnd_toStartOf="@id/gl_end"
                 app:layout_constraintStart_toEndOf="@id/cv_profile"
                 app:layout_constraintTop_toTopOf="@id/cv_profile"
                 app:layout_constraintVertical_chainStyle="packed"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="detail_auction_chat_room_create">쪽지방 생성</string>
     <string name="detail_auction_chat_room_entrance">쪽지방 입장</string>
     <string name="detail_auction_my_auction">내꺼 입찰금지</string>
+    <string name="detail_auction_already_last_bidder">현재까지 최고입찰자</string>
     <string name="detail_auction_category">%s > %s</string>
     <string name="detail_auction_price_status">%s %,d원</string>
     <string name="detail_auction_start_price">시작가 %,d원</string>

--- a/android/data/src/main/java/com/ddangddangddang/data/model/response/AuctionDetailResponse.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/model/response/AuctionDetailResponse.kt
@@ -8,4 +8,5 @@ data class AuctionDetailResponse(
     val seller: SellerResponse,
     val chat: ChatAuctionDetailResponse,
     val isOwner: Boolean,
+    val isLastBidder: Boolean,
 )

--- a/android/data/src/main/java/com/ddangddangddang/data/model/response/AuctionResponse.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/model/response/AuctionResponse.kt
@@ -17,7 +17,6 @@ data class AuctionResponse(
     val closingTime: String,
     val directRegions: List<DirectRegionResponse>,
     val auctioneerCount: Int,
-    val hasLastBidder: Boolean? = false, // 아직 api 수정 안돼서 일단 이걸로 설정함.
 ) {
     fun toPreview(): AuctionPreviewResponse = AuctionPreviewResponse(
         id,

--- a/android/data/src/main/java/com/ddangddangddang/data/model/response/AuctionResponse.kt
+++ b/android/data/src/main/java/com/ddangddangddang/data/model/response/AuctionResponse.kt
@@ -17,6 +17,7 @@ data class AuctionResponse(
     val closingTime: String,
     val directRegions: List<DirectRegionResponse>,
     val auctioneerCount: Int,
+    val hasLastBidder: Boolean? = false, // 아직 api 수정 안돼서 일단 이걸로 설정함.
 ) {
     fun toPreview(): AuctionPreviewResponse = AuctionPreviewResponse(
         id,


### PR DESCRIPTION
## 📄 작업 내용 요약
경매 상세 페이지 수정

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
![image](https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/b1cb7546-f6af-4d10-b18b-9ab0db7289f8)
=> 우선, 여기서 파란색 박스는 기존에 있던 로직에서 액션바의 속성을 잘못 선택해서 오차가 발생하고 있던 것입니다. 그 이유는 다음과 같습니다. 요약하자면, 액션바 속성이 두 개가 있는데 그 중 다른걸 사용하고 있어서 수정했습니다.
https://stackoverflow.com/questions/26449195/new-theme-appcompat-actionbar-height

빨간색 박스 로직에 대한 설명)
=> 여기서, getRemainHeight에서 Context.resources.displayMetrics.heightPixels 는 상태바 높이 + 액티비티 높이(이 안에 툴바도 포함)를 반환합니다. 이 메소드는 네비게이션 바의 높이를 안주기 때문에 큰 장점이 있습니다. 네비게이션 바는 모드가 기종마다 혹은 회사마다 여러 가지라서 개발자가 신경쓰기 힘든 부분인데 이를 고려대상에서 제외한 사이즈를 주기 때문에 아주 나이스합니다.

또한, 안드로이드에서 상태바의 높이는 24dp입니다. 
그렇다면, 저희는 다음과 같이 빼면 정말 딱 맞는 뷰페이저의 높이를 구할 수 있습니다.

Context.resources.displayMetrics.heightPixels - 상태바 높이 - 툴바 높이 - 탭레이아웃 높이 - 상세페이지의 하단 입찰 버튼 높이
하지만, 여기서 문제가 있습니다. 
갤럭시의 경우, 펀치홀이 상태바에 있는 세로모드의 경우, Context.resources.displayMetrics.heightPixels 에서 상태바 높이가 이미 빠진 상태로 나오게 된다는 결론을 내리게 되었습니다(api28, 33 버전의 픽셀2 휴대폰에서는 세로모드와 가로모드에서 모두 상태바가 포함된 높이가 나왔습니다. 또한, 갤럭시의 가로모드에서도 상태바 높이가 포함된 상태로 나오는 것을 확인했습니다. 오직, 갤럭시의 세로모드에서만 상태바 높이가 빠진 상태로 높이가 나오는 것을 실험 결과로 알게 되었습니다).
그렇다고, 로직을 아래와 같이 수정하기에는 다른 기종이나 갤럭시의 가로모드에서 대응이 안됩니다.
Context.resources.displayMetrics.heightPixels - 툴바 높이 - 탭레이아웃 높이 - 상세페이지의 하단 입찰 버튼 높이

때문에, 그냥 상태바 높이인 24dp~25dp 중 더 작은 값인 24dp로 빼주기로 했습니다. (여기서 더 작은 값을 빼는 이유는, 뷰페이저가 1dp 길어지는 것은 상관없으나, 1dp가 짧아지면 보기 안좋기 때문입니다. 모든 기종에서 고르게 보이기 위해 더 작은 24dp를 빼주기로 했습니다. 
(만약 25dp를 빼면, 뷰페이저가 그만큼 짧아지게 되고, 그로인해 탭 레이아웃 위에있는 'x명 경매중' 이라는 텍스특뷰의 하단 부분이 튀어나오게 되어서 미관상 보기 안좋습니다.)

그나마 다행인 점은 저희가 탭레이아웃의 마진톱을 24dp로 해놔서, 펀치홀이 있는 갤럭시 세로모드에서도 그렇게 부자연스럽지 않습니다. 
실기기 사진은 필요하면, 내일 현장에서 보여드리겠습니다.

위와 같은 결론을 제가 내린 다음에, 자료를 찾아보다가 다음과 같은 저와 같은 결론을 내린 사람의 글을 발견했습니다. 우선, 저희 minSdk가 28 P인 점을 고려하고 확인하시면 될 것 같습니다.
![image](https://github.com/woowacourse-teams/2023-3-ddang/assets/67176829/3feb80d6-7246-43e4-b0b6-aa1c532a91ae)
https://black-jin0427.tistory.com/230

 
추가적으로, 경매 상세 페이지에서 바텀 하단 버튼과 뷰페이저 스크롤 영역이 겹치지 않도록 했습니다. marginBottom 값을 주어서 해결했습니다. 이 과정에서 바텀 버튼의 높이가 커지면 안되기 때문에 글자 크기를 고정으로 18dp로 설정했습니다. 

## 📎 Issue 번호
- close: #691 
