### PR TITLE
알림 화면이 부모 화면 위에 쌓이는 기능 추가

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,8 +40,7 @@
         <activity
             android:name=".feature.messageRoom.MessageRoomActivity"
             android:exported="false"
-            android:windowSoftInputMode="adjustResize"
-            android:parentActivityName=".feature.main.MainActivity" />
+            android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".feature.report.ReportActivity"
             android:exported="false" />
@@ -65,8 +64,7 @@
             android:exported="false" />
         <activity
             android:name=".feature.detail.AuctionDetailActivity"
-            android:exported="false"
-            android:parentActivityName=".feature.main.MainActivity" />
+            android:exported="false" />
         <activity
             android:name=".feature.register.RegisterAuctionActivity"
             android:exported="false" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,7 +40,8 @@
         <activity
             android:name=".feature.messageRoom.MessageRoomActivity"
             android:exported="false"
-            android:windowSoftInputMode="adjustResize" />
+            android:windowSoftInputMode="adjustResize"
+            android:parentActivityName=".feature.main.MainActivity" />
         <activity
             android:name=".feature.report.ReportActivity"
             android:exported="false" />
@@ -64,7 +65,8 @@
             android:exported="false" />
         <activity
             android:name=".feature.detail.AuctionDetailActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:parentActivityName=".feature.main.MainActivity" />
         <activity
             android:name=".feature.register.RegisterAuctionActivity"
             android:exported="false" />

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainActivity.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainActivity.kt
@@ -23,6 +23,7 @@ import com.ddangddangddang.android.feature.mypage.MyPageFragment
 import com.ddangddangddang.android.feature.search.SearchFragment
 import com.ddangddangddang.android.global.screenViewLogEvent
 import com.ddangddangddang.android.util.binding.BindingActivity
+import com.ddangddangddang.android.util.compat.getSerializableExtraCompat
 import com.ddangddangddang.android.util.view.BackKeyHandler
 import com.ddangddangddang.android.util.view.showDialog
 import com.ddangddangddang.android.util.view.showSnackbar
@@ -62,6 +63,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         binding.viewModel = viewModel
 
         setupViewModel()
+        setupFragment()
         onBackPressedDispatcher.addCallback(this, callback)
     }
 
@@ -166,9 +168,22 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         startActivity(intent)
     }
 
+    private fun setupFragment() {
+        if (viewModel.currentFragmentType.value == null) {
+            val type =
+                intent.getSerializableExtraCompat(KEY_MAIN_FRAGMENT_TYPE) ?: MainFragmentType.HOME
+            binding.bnvNavigation.selectedItemId = type.id
+            viewModel.setupFragmentType(type)
+        }
+    }
+
     companion object {
-        fun getIntent(context: Context): Intent {
-            return Intent(context, MainActivity::class.java)
+        private const val KEY_MAIN_FRAGMENT_TYPE = "main_fragment_type"
+
+        fun getIntent(context: Context, type: MainFragmentType = MainFragmentType.HOME): Intent {
+            val intent = Intent(context, MainActivity::class.java)
+            intent.putExtra(KEY_MAIN_FRAGMENT_TYPE, type)
+            return intent
         }
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainBindingAdapter.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainBindingAdapter.kt
@@ -1,7 +1,6 @@
 package com.ddangddangddang.android.feature.main
 
 import androidx.databinding.BindingAdapter
-import com.ddangddangddang.android.R
 import com.google.android.material.bottomnavigation.BottomNavigationView
 
 @BindingAdapter("onNavigationItemSelected")
@@ -9,13 +8,7 @@ fun BottomNavigationView.bindOnNavigationItemSelectedListener(
     onFragmentChange: (MainFragmentType) -> Unit,
 ) {
     this.setOnItemSelectedListener { menuItem ->
-        val fragmentType = when (menuItem.itemId) {
-            R.id.menu_item_home -> MainFragmentType.HOME
-            R.id.menu_item_search -> MainFragmentType.SEARCH
-            R.id.menu_item_message -> MainFragmentType.MESSAGE
-            R.id.menu_item_my_page -> MainFragmentType.MY_PAGE
-            else -> throw IllegalArgumentException("Not found menu item")
-        }
+        val fragmentType = MainFragmentType.of(menuItem.itemId)
         onFragmentChange(fragmentType)
         true
     }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainFragmentType.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainFragmentType.kt
@@ -1,8 +1,18 @@
 package com.ddangddangddang.android.feature.main
 
-enum class MainFragmentType(val tag: String) {
-    HOME("fragment_home_tag"),
-    SEARCH("fragment_search_tag"),
-    MESSAGE("fragment_message_tag"),
-    MY_PAGE("fragment_my_page_tag"),
+import androidx.annotation.IdRes
+import com.ddangddangddang.android.R
+
+enum class MainFragmentType(@IdRes val id: Int, val tag: String) {
+    HOME(R.id.menu_item_home, "fragment_home_tag"),
+    SEARCH(R.id.menu_item_search, "fragment_search_tag"),
+    MESSAGE(R.id.menu_item_message, "fragment_message_tag"),
+    MY_PAGE(R.id.menu_item_my_page, "fragment_my_page_tag"), ;
+
+    companion object {
+        fun of(@IdRes menuId: Int): MainFragmentType {
+            return values().firstOrNull { it.id == menuId }
+                ?: throw IllegalArgumentException("No match type for menu item")
+        }
+    }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainViewModel.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/feature/main/MainViewModel.kt
@@ -9,8 +9,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor() : ViewModel() {
-    private val _currentFragmentType: MutableLiveData<MainFragmentType> =
-        MutableLiveData(MainFragmentType.HOME)
+    private val _currentFragmentType: MutableLiveData<MainFragmentType> = MutableLiveData()
     val currentFragmentType: LiveData<MainFragmentType>
         get() = _currentFragmentType
     private val _event: SingleLiveEvent<MainEvent> = SingleLiveEvent()
@@ -23,6 +22,10 @@ class MainViewModel @Inject constructor() : ViewModel() {
 
     init {
         _event.value = MainEvent.NotificationPermissionCheck
+    }
+
+    fun setupFragmentType(type: MainFragmentType) {
+        _currentFragmentType.value = type
     }
 
     private fun changeCurrentFragmentType(fragmentType: MainFragmentType) {

--- a/android/app/src/main/java/com/ddangddangddang/android/notification/type/MessageType.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/notification/type/MessageType.kt
@@ -6,6 +6,8 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import com.ddangddangddang.android.R
+import com.ddangddangddang.android.feature.main.MainActivity
+import com.ddangddangddang.android.feature.main.MainFragmentType
 import com.ddangddangddang.android.feature.messageRoom.MessageRoomActivity
 import com.ddangddangddang.android.global.DdangDdangDdang
 import com.ddangddangddang.android.global.getBitmapFromUrl
@@ -66,7 +68,8 @@ object MessageType : NotificationType() {
     }
 
     private fun getMessageRoomPendingIntent(context: Context, id: Long): PendingIntent? {
+        val parentIntent = MainActivity.getIntent(context, MainFragmentType.MESSAGE)
         val intent = MessageRoomActivity.getIntent(context.applicationContext, id)
-        return intent.getPendingIntent(context, id.toInt())
+        return intent.getPendingIntent(context, id.toInt(), parentIntent)
     }
 }

--- a/android/app/src/main/java/com/ddangddangddang/android/notification/type/NotificationType.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/notification/type/NotificationType.kt
@@ -4,6 +4,7 @@ import android.app.Notification
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import androidx.core.app.TaskStackBuilder
 import com.ddangddangddang.android.feature.detail.AuctionDetailActivity
 import com.google.firebase.messaging.RemoteMessage
 
@@ -26,12 +27,13 @@ abstract class NotificationType {
     ): Notification
 
     fun Intent.getPendingIntent(context: Context, requestCode: Int): PendingIntent? {
-        return PendingIntent.getActivity(
-            context.applicationContext,
-            requestCode,
-            this,
-            PendingIntent.FLAG_IMMUTABLE,
-        )
+        return TaskStackBuilder.create(context).run {
+            addNextIntentWithParentStack(this@getPendingIntent)
+            getPendingIntent(
+                requestCode,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+        }
     }
 }
 

--- a/android/app/src/main/java/com/ddangddangddang/android/notification/type/NotificationType.kt
+++ b/android/app/src/main/java/com/ddangddangddang/android/notification/type/NotificationType.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.app.TaskStackBuilder
 import com.ddangddangddang.android.feature.detail.AuctionDetailActivity
+import com.ddangddangddang.android.feature.main.MainActivity
 import com.google.firebase.messaging.RemoteMessage
 
 internal fun String.toNotificationType(): NotificationType {
@@ -26,9 +27,19 @@ abstract class NotificationType {
         remoteMessage: RemoteMessage,
     ): Notification
 
-    fun Intent.getPendingIntent(context: Context, requestCode: Int): PendingIntent? {
+    fun Intent.getPendingIntent(
+        context: Context,
+        requestCode: Int,
+        parentIntent: Intent? = null,
+    ): PendingIntent? {
         return TaskStackBuilder.create(context).run {
-            addNextIntentWithParentStack(this@getPendingIntent)
+            if (parentIntent != null) {
+                addNextIntentWithParentStack(parentIntent)
+                addNextIntent(this@getPendingIntent)
+            } else {
+                addNextIntentWithParentStack(this@getPendingIntent)
+            }
+
             getPendingIntent(
                 requestCode,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
@@ -45,7 +56,8 @@ abstract class AuctionDetailType : NotificationType() {
     ): Notification
 
     fun getAuctionDetailPendingIntent(context: Context, id: Long): PendingIntent? {
+        val parentIntent = MainActivity.getIntent(context)
         val intent = AuctionDetailActivity.getIntent(context.applicationContext, id)
-        return intent.getPendingIntent(context, id.toInt())
+        return intent.getPendingIntent(context, id.toInt(), parentIntent)
     }
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
알림을 클릭하면 알림 화면이 부모 화면 위에 쌓여서 알림 화면을 닫으면 부모 화면이 나옵니다.
현재 모든 알림의 부모 화면이 MainActivity여서 MainActivity 위에 알림 화면이 쌓입니다.
단, 유저가 앱을 사용하다가 알림을 누르면 이전 스택은 모두 사라지고 MainActivity와 알림 화면만 스택에 존재합니다.
~또한 부모 화면 지정은 가능하지만 부모 화면의 탭을 지정하는 것은 불가능하여 메시지룸을 나갔을 때 경매 목록이 보입니다 😢~
부모 화면의 탭 지정까지 현재는 가능한 상태입니다! 😉

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
없음.

## 📎 Issue 번호
- close: #702 
