### PR TITLE
경매 목록 조회 시 쿼리에 존재하는 비즈니스 로직 분리

### DIFF
--- a/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepository.java
+++ b/backend/ddang/src/main/java/com/ddang/ddang/auction/infrastructure/persistence/QuerydslAuctionRepository.java
@@ -1,5 +1,10 @@
 package com.ddang.ddang.auction.infrastructure.persistence;
 
+import static com.ddang.ddang.auction.domain.QAuction.auction;
+import static com.ddang.ddang.category.domain.QCategory.category;
+import static com.ddang.ddang.region.domain.QAuctionRegion.auctionRegion;
+import static com.ddang.ddang.region.domain.QRegion.region;
+
 import com.ddang.ddang.auction.configuration.util.AuctionSortConditionConsts;
 import com.ddang.ddang.auction.domain.Auction;
 import com.ddang.ddang.auction.infrastructure.persistence.exception.UnsupportedSortConditionException;
@@ -7,8 +12,10 @@ import com.ddang.ddang.auction.presentation.dto.request.ReadAuctionSearchConditi
 import com.ddang.ddang.common.helper.QuerydslSliceHelper;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -16,176 +23,171 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import static com.ddang.ddang.auction.domain.QAuction.auction;
-import static com.ddang.ddang.bid.domain.QBid.bid;
-import static com.ddang.ddang.category.domain.QCategory.category;
-import static com.ddang.ddang.region.domain.QAuctionRegion.auctionRegion;
-import static com.ddang.ddang.region.domain.QRegion.region;
-
 @Repository
 @RequiredArgsConstructor
 public class QuerydslAuctionRepository {
 
     private static final long SLICE_OFFSET = 1L;
-    private static final int HIGH_PRIORITY = 2;
-    private static final int LOW_PRIORITY = 1;
 
     private final JPAQueryFactory queryFactory;
 
-    public Slice<Auction> findAuctionsAllByCondition(
+    // 진행 중인 경매 목록 조회
+    public Slice<Auction> findProcessAuctionsAllByCondition(
             final ReadAuctionSearchCondition readAuctionSearchCondition,
             final Pageable pageable
     ) {
-        final List<OrderSpecifier<?>> orderSpecifiers = calculateOrderSpecifiers(pageable);
-        final List<BooleanExpression> booleanExpressions = calculateBooleanExpressions(readAuctionSearchCondition);
-        final List<Long> findAuctionIds = findAuctionIds(booleanExpressions, orderSpecifiers, pageable);
-        final List<Auction> findAuctions = findAuctionsByIdsAndOrderSpecifiers(findAuctionIds, orderSpecifiers);
-
-        return QuerydslSliceHelper.toSlice(findAuctions, pageable);
-    }
-
-    private List<OrderSpecifier<?>> calculateOrderSpecifiers(final Pageable pageable) {
-        final List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
-
-        orderSpecifiers.add(closingTimeOrderSpecifier());
-        orderSpecifiers.addAll(processOrderSpecifiers(pageable));
-        orderSpecifiers.add(auction.id.desc());
-
-        return orderSpecifiers;
-    }
-
-    private List<OrderSpecifier<?>> processOrderSpecifiers(final Pageable pageable) {
+        // 정렬 조건 생성
         final List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
         final Sort sort = pageable.getSort();
 
+        // Pageable 내부의 Sort는 다중 지정이 가능하므로 반복문을 통해 처리
         for (final Order order : sort) {
+            // 다른 정렬 조건에서도 id 기반의 정렬 조건은 무조건 포함되어야 함
+            // 66번째 줄에서 해당 부분을 수행하고 있으므로 이 조건문에서는 과정 생략
             if (AuctionSortConditionConsts.ID.equals(order.getProperty())) {
-                return Collections.emptyList();
+                continue ;
             }
 
-            orderSpecifiers.add(processOrderSpecifierByCondition(order));
+            // 신뢰도 기반 정렬
+            if (AuctionSortConditionConsts.RELIABILITY.equals(order.getProperty())) {
+                orderSpecifiers.add(auction.seller.reliability.value.desc());
+                continue ;
+            }
+            // 경매 참여 인원 수 기반 정렬
+            if (AuctionSortConditionConsts.AUCTIONEER_COUNT.equals(order.getProperty())) {
+                orderSpecifiers.add(auction.auctioneerCount.desc());
+                continue ;
+            }
+            // 마감 임박순 기반 정렬
+            // 진행 중인 경매 목록 조회의 경우 마감이 얼마 안남은 상품부터 정렬이 되어야 함
+            // 그러므로 closingTime.asc()를 통해 정렬
+            if (AuctionSortConditionConsts.CLOSING_TINE.equals(order.getProperty())) {
+                orderSpecifiers.add(auction.closingTime.asc());
+                continue ;
+            }
+
+            // 잘못된 정렬 요청으로 인한 예외 처리
+            throw new UnsupportedSortConditionException("지원하지 않는 정렬 방식입니다.");
         }
 
-        return orderSpecifiers;
-    }
+        // id 기반의 정렬 조건 추가
+        orderSpecifiers.add(auction.id.desc());
 
-    private OrderSpecifier<?> processOrderSpecifierByCondition(final Order order) {
-        if (AuctionSortConditionConsts.RELIABILITY.equals(order.getProperty())) {
-            return auction.seller.reliability.value.desc();
-        }
-        if (AuctionSortConditionConsts.AUCTIONEER_COUNT.equals(order.getProperty())) {
-            return auction.auctioneerCount.desc();
-        }
-        if (AuctionSortConditionConsts.CLOSING_TINE.equals(order.getProperty())) {
-            return auction.closingTime.asc();
-        }
-
-        throw new UnsupportedSortConditionException("지원하지 않는 정렬 방식입니다.");
-    }
-
-    private OrderSpecifier<Integer> closingTimeOrderSpecifier() {
-        final LocalDateTime now = LocalDateTime.now();
-
-        return new CaseBuilder()
-                .when(auction.closingTime.after(now)).then(LOW_PRIORITY)
-                .otherwise(HIGH_PRIORITY)
-                .asc();
-    }
-
-    private List<BooleanExpression> calculateBooleanExpressions(final ReadAuctionSearchCondition searchCondition) {
+        // 질의 조건 생성
         final List<BooleanExpression> booleanExpressions = new ArrayList<>();
 
-        booleanExpressions.add(auction.deleted.isFalse());
+        // 마감 일자가 현재 시간보다 이후의 시간인 경우 = 경매가 진행중인 경우
+        booleanExpressions.add(auction.closingTime.after(LocalDateTime.now()));
 
-        final BooleanExpression titleBooleanExpression = convertTitleSearchCondition(searchCondition);
-
-        if (titleBooleanExpression != null) {
-            booleanExpressions.add(titleBooleanExpression);
+        // 필터링 조건이 있는 경우 추가
+        if (readAuctionSearchCondition.title() != null) {
+            booleanExpressions.add(auction.title.like("%" + readAuctionSearchCondition.title() + "%"));
         }
 
-        return booleanExpressions;
-    }
+        // id만 조회
+        final List<Long> findAuctionIds = queryFactory.select(auction.id)
+                                             .from(auction)
+                                             .where(booleanExpressions.toArray(BooleanExpression[]::new))
+                                             .orderBy(orderSpecifiers.toArray(OrderSpecifier[]::new))
+                                             .limit(pageable.getPageSize() + SLICE_OFFSET)
+                                             .offset(pageable.getOffset())
+                                             .fetch();
 
-    private List<Long> findAuctionIds(
-            final List<BooleanExpression> booleanExpressions,
-            final List<OrderSpecifier<?>> orderSpecifiers,
-            final Pageable pageable
-    ) {
-        return queryFactory.select(auction.id)
-                           .from(auction)
-                           .where(booleanExpressions.toArray(BooleanExpression[]::new))
-                           .orderBy(orderSpecifiers.toArray(OrderSpecifier[]::new))
-                           .limit(pageable.getPageSize() + SLICE_OFFSET)
-                           .offset(pageable.getOffset())
-                           .fetch();
-    }
+        // 조회한 id를 기반으로 필요한 모든 Auction 정보 조회
+        final List<Auction> findAuctions = queryFactory.selectFrom(auction)
+                                                .leftJoin(auction.auctionRegions, auctionRegion).fetchJoin()
+                                                .leftJoin(auctionRegion.thirdRegion, region).fetchJoin()
+                                                .leftJoin(region.firstRegion).fetchJoin()
+                                                .leftJoin(region.secondRegion).fetchJoin()
+                                                .leftJoin(auction.lastBid).fetchJoin()
+                                                .join(auction.subCategory, category).fetchJoin()
+                                                .join(category.mainCategory).fetchJoin()
+                                                .join(auction.seller).fetchJoin()
+                                                .where(auction.id.in(findAuctionIds.toArray(Long[]::new)))
+                                                .orderBy(orderSpecifiers.toArray(OrderSpecifier[]::new))
+                                                .fetch();
 
-    private BooleanExpression convertTitleSearchCondition(final ReadAuctionSearchCondition readAuctionSearchCondition) {
-        final String titleSearchCondition = readAuctionSearchCondition.title();
-
-        if (titleSearchCondition == null) {
-            return null;
-        }
-
-        return auction.title.like("%" + titleSearchCondition + "%");
-    }
-
-    private List<Auction> findAuctionsByIdsAndOrderSpecifiers(
-            final List<Long> targetIds,
-            final List<OrderSpecifier<?>> orderSpecifiers
-    ) {
-        return queryFactory.selectFrom(auction)
-                           .leftJoin(auction.auctionRegions, auctionRegion).fetchJoin()
-                           .leftJoin(auctionRegion.thirdRegion, region).fetchJoin()
-                           .leftJoin(region.firstRegion).fetchJoin()
-                           .leftJoin(region.secondRegion).fetchJoin()
-                           .leftJoin(auction.lastBid).fetchJoin()
-                           .join(auction.subCategory, category).fetchJoin()
-                           .join(category.mainCategory).fetchJoin()
-                           .join(auction.seller).fetchJoin()
-                           .where(auction.id.in(targetIds.toArray(Long[]::new)))
-                           .orderBy(orderSpecifiers.toArray(OrderSpecifier[]::new))
-                           .fetch();
-    }
-
-    public Slice<Auction> findAuctionsAllByUserId(final Long userId, final Pageable pageable) {
-        final List<BooleanExpression> booleanExpressions = List.of(
-                auction.seller.id.eq(userId),
-                auction.deleted.isFalse()
-        );
-        final List<OrderSpecifier<?>> orderSpecifiers = List.of(auction.id.desc());
-        final List<Long> findAuctionIds = findAuctionIds(booleanExpressions, orderSpecifiers, pageable);
-        final List<Auction> findAuctions = findAuctionsByIdsAndOrderSpecifiers(
-                findAuctionIds,
-                List.of(auction.id.desc())
-        );
-
+        // Slice 형태로 변환해 반환
         return QuerydslSliceHelper.toSlice(findAuctions, pageable);
     }
 
-    public Slice<Auction> findAuctionsAllByBidderId(final Long bidderId, final Pageable pageable) {
-        final List<Long> findAuctionIds = queryFactory.select(bid.auction.id)
-                                                      .from(bid)
-                                                      .where(bid.bidder.id.eq(bidderId))
-                                                      .groupBy(bid.auction.id)
-                                                      .orderBy(bid.id.max().desc())
+    // 종료된 경매 목록 조회
+    public Slice<Auction> findEndAuctionsAllByCondition(
+            final ReadAuctionSearchCondition readAuctionSearchCondition,
+            final Pageable pageable
+    ) {
+        // 정렬 조건 생성
+        final List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+        final Sort sort = pageable.getSort();
+
+        // Pageable 내부의 Sort는 다중 지정이 가능하므로 반복문을 통해 처리
+        for (final Order order : sort) {
+            // 다른 정렬 조건에서도 id 기반의 정렬 조건은 무조건 포함되어야 함
+            // 147번째 줄에서 해당 부분을 수행하고 있으므로 이 조건문에서는 과정 생략
+            if (AuctionSortConditionConsts.ID.equals(order.getProperty())) {
+                continue ;
+            }
+
+            // 신뢰도 기반 정렬
+            if (AuctionSortConditionConsts.RELIABILITY.equals(order.getProperty())) {
+                orderSpecifiers.add(auction.seller.reliability.value.desc());
+                continue ;
+            }
+            // 경매 참여 인원 수 기반 정렬
+            if (AuctionSortConditionConsts.AUCTIONEER_COUNT.equals(order.getProperty())) {
+                orderSpecifiers.add(auction.auctioneerCount.desc());
+                continue ;
+            }
+            // 마감 임박순 기반 정렬
+            // 종료된 경매 목록 조회의 경우 현재 시간과 가장 가까운 마감 시간 상품부터 정렬되어야 함
+            // 그러므로 closingTime.desc()를 정렬
+            if (AuctionSortConditionConsts.CLOSING_TINE.equals(order.getProperty())) {
+                orderSpecifiers.add(auction.closingTime.desc());
+                continue ;
+            }
+
+            // 잘못된 정렬 요청으로 인한 예외 처리
+            throw new UnsupportedSortConditionException("지원하지 않는 정렬 방식입니다.");
+        }
+
+        // id 기반의 정렬 조건 추가
+        orderSpecifiers.add(auction.id.desc());
+
+        // 질의 조건 생성
+        final List<BooleanExpression> booleanExpressions = new ArrayList<>();
+
+        // 마감 일자가 현재 시간보다 이전의 시간인 경우 = 경매가 종료된 된우
+        booleanExpressions.add(auction.closingTime.before(LocalDateTime.now()));
+
+        // 필터링 조건이 있는 경우 추가
+        if (readAuctionSearchCondition.title() != null) {
+            booleanExpressions.add(auction.title.like("%" + readAuctionSearchCondition.title() + "%"));
+        }
+
+        // id만 조회
+        final List<Long> findAuctionIds = queryFactory.select(auction.id)
+                                                      .from(auction)
+                                                      .where(booleanExpressions.toArray(BooleanExpression[]::new))
+                                                      .orderBy(orderSpecifiers.toArray(OrderSpecifier[]::new))
                                                       .limit(pageable.getPageSize() + SLICE_OFFSET)
                                                       .offset(pageable.getOffset())
                                                       .fetch();
-        final List<Auction> findAuctions = findAuctionsByIdsAndOrderSpecifiers(findAuctionIds, Collections.emptyList());
 
-        findAuctions.sort((firstAuction, secondAuction) -> {
-            int firstAuctionIndex = findAuctionIds.indexOf(firstAuction.getId());
-            int secondAuctionIndex = findAuctionIds.indexOf(secondAuction.getId());
+        // 조회한 id를 기반으로 필요한 모든 Auction 정보 조회
+        final List<Auction> findAuctions = queryFactory.selectFrom(auction)
+                                                       .leftJoin(auction.auctionRegions, auctionRegion).fetchJoin()
+                                                       .leftJoin(auctionRegion.thirdRegion, region).fetchJoin()
+                                                       .leftJoin(region.firstRegion).fetchJoin()
+                                                       .leftJoin(region.secondRegion).fetchJoin()
+                                                       .leftJoin(auction.lastBid).fetchJoin()
+                                                       .join(auction.subCategory, category).fetchJoin()
+                                                       .join(category.mainCategory).fetchJoin()
+                                                       .join(auction.seller).fetchJoin()
+                                                       .where(auction.id.in(findAuctionIds.toArray(Long[]::new)))
+                                                       .orderBy(orderSpecifiers.toArray(OrderSpecifier[]::new))
+                                                       .fetch();
 
-            return Integer.compare(firstAuctionIndex, secondAuctionIndex);
-        });
-
+        // Slice 형태로 변환해 반환
         return QuerydslSliceHelper.toSlice(findAuctions, pageable);
     }
 }


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->
현재 경매 목록 조회 시 경매 상태가 종료(FAILURE, SUCCESS)인 경매와 진행 중(UNBIDDEN, ONGOING)인 경매를 하나의 쿼리로 조회 중입니다
이 과정에서 분기 처리를 통한 정렬의 우선순위를 부여해야하기 때문에 case when을 사용하고 있습니다
이는 쿼리에서 비즈니스 로직을 수행하고 있어 문제가 생길 수 있는 부분이라고 생각합니다 
그래서 이를 리펙토링해야한다고 생각하고, 관련해 간단하게 수도 코드를 작성했습니다 

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
설명을 위해 주석 + 나머지 로직을 모두 지워서 테스트도 깨지고 실행도 안되는 상황입니다 
그냥 이런 식으로 진행되는구나라고 봐주시면 될 것 같습니다 

관련해 자세한 내용은 [디스커션](https://github.com/woowacourse-teams/2023-3-ddang/discussions/738)을 참고해주시면 될 것 같습니다 

## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
- closed #737 
<!-- closed #번호 --> 
