### PR TITLE
PR 코드 분석 시 suggestion 태그를 위한 로직 추가

### DIFF
--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -8,13 +8,14 @@ on:
 permissions: write-all
 
 jobs:
-  author-info:
+  build:
+    if: contains(github.event.pull_request.labels.*.name, 'backend')
     runs-on: ubuntu-latest
-    outputs:
-      AUTHOR_NAME: ${{ steps.set-author-slack-id.outputs.AUTHOR_NAME }}
-      AUTHOR_ID: ${{ steps.set-author-slack-id.outputs.AUTHOR_ID }}
+
     steps:
-      - name: set-author-slack-id
+      - uses: actions/checkout@v3
+
+      - name: set author slack id
         if: always()
         id: author-slack
         run: |
@@ -32,18 +33,14 @@ jobs:
             AUTHOR_ID="${{ secrets.kwonyj1022_slack_id }}"
           fi
 
-          echo "::set-output name=AUTHOR_NAME::${AUTHOR_NAME}"
-          echo "::set-output name=AUTHOR_ID::${AUTHOR_ID}"
-
-  suggestion:
-    if: contains(github.event.pull_request.labels.*.name, 'backend') && contains(github.event.pull_request.labels.*.name, 'suggestion')
-    runs-on: ubuntu-latest
-    steps:
+          echo "AUTHOR_NAME=${AUTHOR_NAME}" >> $GITHUB_OUTPUT
+          echo "AUTHOR_ID=${AUTHOR_ID}" >> $GITHUB_OUTPUT
+      
       - name: slack suggestion notification
-        if: github.event_name == 'pull_request' && github.event.action != 'synchronize'
+        if: github.event_name == 'pull_request' && github.event.action != 'synchronize' && contains(github.event.pull_request.labels.*.name, 'suggestion')
         run: |
           SLACK_MESSAGE='{"text":"제안 PR","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*제안 PR* \n>\n>*PR Author*\n>'
-          SLACK_MESSAGE+="${{ needs.author-info.outputs.AUTHOR_NAME }}"
+          SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_ID }}"
           SLACK_MESSAGE+="\n>\n>*PR 링크*\n><"
           SLACK_MESSAGE+="${{ github.event.pull_request.html_url }} "
           SLACK_MESSAGE+="> \n>\n>*PR 제목*\n>"
@@ -52,14 +49,9 @@ jobs:
           SLACK_MESSAGE+='"}}]}'
 
           curl -X POST ${{ secrets.SLACK_WEBHOOK }} -d "${SLACK_MESSAGE}" 
-
-  build:
-    if: contains(github.event.pull_request.labels.*.name, 'backend') && !contains(github.event.pull_request.labels.*.name, 'suggestion')
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
+      
       - name: settings java
+        if: failure()
         uses: actions/setup-java@v3
         with:
           java-version: '17'
@@ -84,10 +76,9 @@ jobs:
           ./gradlew jacocoTestCoverage 
 
       - name: slack notification
-        if: github.event_name == 'pull_request' && github.event.action != 'synchronize'
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
-          SLACK_MESSAGE+="${{ needs.author-info.outputs.AUTHOR_NAME }}"
+          SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_NAME }}"
           SLACK_MESSAGE+="\n>\n>*PR 링크*\n><"
           SLACK_MESSAGE+="${{ github.event.pull_request.html_url }} "
           SLACK_MESSAGE+="> \n>\n>*PR 제목*\n>"
@@ -104,7 +95,7 @@ jobs:
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="<@"
-          SLACK_MESSAGE+="${{ needs.author-info.outputs.AUTHOR_ID }}"
+          SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_ID }}"
           SLACK_MESSAGE+=">"
           SLACK_MESSAGE+="\n>\n>*PR 링크*\n><"
           SLACK_MESSAGE+="${{ github.event.pull_request.html_url }} "
@@ -122,7 +113,7 @@ jobs:
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="<@"
-          SLACK_MESSAGE+="${{ needs.author-info.outputs.AUTHOR_ID }}"
+          SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_ID }}"
           SLACK_MESSAGE+=">"
           SLACK_MESSAGE+="\n>\n>*PR 링크*\n><"
           SLACK_MESSAGE+="${{ github.event.pull_request.html_url }} "

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -84,7 +84,7 @@ jobs:
           ./gradlew jacocoTestCoverage 
 
       - name: slack notification
-        if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
+        if: github.event_name == 'pull_request' && github.event.action == 'synchronize' 
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="<@"

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -62,7 +62,7 @@ jobs:
           echo "AUTHOR_ID=${AUTHOR_ID}" >> $GITHUB_OUTPUT
 
       - name: slack notification
-        if: github.event_name == 'pull_request' && github.event.action != 'synchronize'
+        if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_NAME }}"

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -62,7 +62,7 @@ jobs:
           echo "AUTHOR_ID=${AUTHOR_ID}" >> $GITHUB_OUTPUT
 
       - name: slack notification
-        if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
+        if: github.event_name == 'pull_request' && github.event.action != 'synchronize'
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_NAME }}"

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -55,14 +55,14 @@ jobs:
           curl -X POST ${{ secrets.SLACK_WEBHOOK }} -d "${SLACK_MESSAGE}" 
       
       - name: settings java
-        if: cancelled()
+        if: failure()
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: cache gradle
-        if: success()
+        if: failure()
         uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -9,14 +9,37 @@ permissions: write-all
 
 jobs:
   build:
-    if: contains(github.event.pull_request.labels.*.name, 'backend')
+    if: contains(github.event.pull_request.labels.*.name, 'backend') && !contains(github.event.pull_request.labels.*.name, 'suggestion')
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
+      - name: settings java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: cache gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: chmod gradle
+        run: chmod +x backend/ddang/gradlew
+
+      - name: run jacocoTestCoverage
+        run: |
+          cd backend/ddang
+          ./gradlew jacocoTestCoverage 
 
       - name: set author slack id
-        if: github.event_name == 'pull_request' && github.event.action != 'synchronize'
+        if: always()
         id: author-slack
         run: |
           GIT_ID=${{ github.event.pull_request.user.login }}
@@ -34,62 +57,15 @@ jobs:
             AUTHOR_NAME="${{ secrets.kwonyj1022_slack_display_name }}"
             AUTHOR_ID="${{ secrets.kwonyj1022_slack_id }}"
           fi
-
+          
           echo "AUTHOR_NAME=${AUTHOR_NAME}" >> $GITHUB_OUTPUT
           echo "AUTHOR_ID=${AUTHOR_ID}" >> $GITHUB_OUTPUT
-      
-      - name: slack suggestion notification
-        if: github.event_name == 'pull_request' && github.event.action != 'synchronize' && contains(github.event.pull_request.labels.*.name, 'suggestion')
-        id: slack-suggestion-notification
-        run: |
-          SLACK_MESSAGE='{"text":"제안 PR","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*제안 PR* \n>\n>*PR Author*\n>'
-          SLACK_MESSAGE+="<@"
-          SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_ID }}"
-          SLACK_MESSAGE+=">"
-          SLACK_MESSAGE+="\n>\n>*PR 링크*\n><"
-          SLACK_MESSAGE+="${{ github.event.pull_request.html_url }} "
-          SLACK_MESSAGE+="> \n>\n>*PR 제목*\n>"
-          SLACK_MESSAGE+="${{ github.event.pull_request.title }}"
-          SLACK_MESSAGE+="\n\n제안 사항에 대한 PR입니다.\n리뷰 요청은 스레드로 직접 멘션해주세요."
-          SLACK_MESSAGE+='"}}]}'
-
-          curl -X POST ${{ secrets.SLACK_WEBHOOK }} -d "${SLACK_MESSAGE}" 
-      
-      - name: settings java
-        if: steps.slack-suggestion-notification.outcome == 'skipped'
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: cache gradle
-        if: steps.slack-suggestion-notification.outcome == 'skipped'
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: chmod gradle
-        if: steps.slack-suggestion-notification.outcome == 'skipped'
-        run: chmod +x backend/ddang/gradlew
-
-      - name: run jacocoTestCoverage
-        if: steps.slack-suggestion-notification.outcome == 'skipped'
-        run: |
-          cd backend/ddang
-          ./gradlew jacocoTestCoverage 
 
       - name: slack notification
-        if: github.event_name == 'pull_request' && github.event.action != 'synchronize' && steps.slack-suggestion-notification.outcome == 'skipped'
+        if: github.event_name == 'pull_request' && github.event.action != 'synchronize'
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
-          SLACK_MESSAGE+="<@"
-          SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_ID }}"
-          SLACK_MESSAGE+=">"
+          SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_NAME }}"
           SLACK_MESSAGE+="\n>\n>*PR 링크*\n><"
           SLACK_MESSAGE+="${{ github.event.pull_request.html_url }} "
           SLACK_MESSAGE+="> \n>\n>*PR 제목*\n>"

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -79,11 +79,11 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: chmod gradle
-        if: steps.slack-suggestion-notification.outcome == 'failure'
+        if: steps.slack-suggestion-notification.outcome == 'skipped'
         run: chmod +x backend/ddang/gradlew
 
       - name: run jacocoTestCoverage
-        if: steps.slack-notification.outcome == 'failure'
+        if: steps.slack-notification.outcome == 'skipped'
         run: |
           cd backend/ddang
           ./gradlew jacocoTestCoverage 

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: set author slack id
-        if: always()
+        if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
         id: author-slack
         run: |
           GIT_ID=${{ github.event.pull_request.user.login }}
@@ -83,7 +83,7 @@ jobs:
           ./gradlew jacocoTestCoverage 
 
       - name: slack notification
-        if: success()
+        if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="<@"

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -37,7 +37,7 @@ jobs:
           echo "AUTHOR_ID=${AUTHOR_ID}" >> $GITHUB_OUTPUT
       
       - name: slack suggestion notification
-        if: github.event_name == 'pull_request' && github.event.action != 'synchronize' && contains(github.event.pull_request.labels.*.name, 'suggestion')
+        if: github.event_name == 'pull_request' && github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'suggestion')
         run: |
           SLACK_MESSAGE='{"text":"제안 PR","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*제안 PR* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_ID }}"

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -42,7 +42,9 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'suggestion')
         run: |
           SLACK_MESSAGE='{"text":"제안 PR","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*제안 PR* \n>\n>*PR Author*\n>'
+          SLACK_MESSAGE+="<@"
           SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_ID }}"
+          SLACK_MESSAGE+=">"
           SLACK_MESSAGE+="\n>\n>*PR 링크*\n><"
           SLACK_MESSAGE+="${{ github.event.pull_request.html_url }} "
           SLACK_MESSAGE+="> \n>\n>*PR 제목*\n>"
@@ -83,7 +85,9 @@ jobs:
       - name: slack notification
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
+          SLACK_MESSAGE+="<@"
           SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_ID }}"
+          SLACK_MESSAGE+=">"
           SLACK_MESSAGE+="\n>\n>*PR 링크*\n><"
           SLACK_MESSAGE+="${{ github.event.pull_request.html_url }} "
           SLACK_MESSAGE+="> \n>\n>*PR 제목*\n>"

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -55,14 +55,14 @@ jobs:
           curl -X POST ${{ secrets.SLACK_WEBHOOK }} -d "${SLACK_MESSAGE}" 
       
       - name: settings java
-        if: failure()
+        if: cancelled()
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: cache gradle
-        if: failure()
+        if: success()
         uses: actions/cache@v2
         with:
           path: |
@@ -83,6 +83,7 @@ jobs:
           ./gradlew jacocoTestCoverage 
 
       - name: slack notification
+        if: success()
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="<@"

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -61,14 +61,14 @@ jobs:
           echo "${{ steps.slack-suggestion-notification.outcome }}"
       
       - name: settings java
-        if: steps.slack-suggestion-notification.outcome == 'failure'
+        if: steps.slack-suggestion-notification.outcome == 'skipped'
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: cache gradle
-        if: steps.slack-suggestion-notification.outcome == 'failure'
+        if: steps.slack-suggestion-notification.outcome == 'skipped'
         uses: actions/cache@v2
         with:
           path: |
@@ -89,7 +89,7 @@ jobs:
           ./gradlew jacocoTestCoverage 
 
       - name: slack notification
-        if: github.event_name == 'pull_request' && github.event.action == 'synchronize' && steps.slack-suggestion-notification.outcome == 'failure'
+        if: github.event_name == 'pull_request' && github.event.action == 'synchronize' && steps.slack-suggestion-notification.outcome == 'skipped'
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="<@"

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -40,6 +40,7 @@ jobs:
       
       - name: slack suggestion notification
         if: contains(github.event.pull_request.labels.*.name, 'suggestion')
+        id: slack-notification
         run: |
           SLACK_MESSAGE='{"text":"제안 PR","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*제안 PR* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="<@"
@@ -55,7 +56,7 @@ jobs:
           curl -X POST ${{ secrets.SLACK_WEBHOOK }} -d "${SLACK_MESSAGE}" 
       
       - name: settings java
-        if: success()
+        if: steps.slack-notification.outcome == 'failure'
         uses: actions/setup-java@v3
         with:
           java-version: '17'

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: set author slack id
-        if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
+        if: github.event_name == 'pull_request' && github.event.action != 'synchronize'
         id: author-slack
         run: |
           GIT_ID=${{ github.event.pull_request.user.login }}
@@ -39,7 +39,7 @@ jobs:
           echo "AUTHOR_ID=${AUTHOR_ID}" >> $GITHUB_OUTPUT
       
       - name: slack suggestion notification
-        if: contains(github.event.pull_request.labels.*.name, 'suggestion')
+        if: github.event_name == 'pull_request' && github.event.action != 'synchronize' && contains(github.event.pull_request.labels.*.name, 'suggestion')
         id: slack-suggestion-notification
         run: |
           SLACK_MESSAGE='{"text":"제안 PR","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*제안 PR* \n>\n>*PR Author*\n>'
@@ -84,7 +84,7 @@ jobs:
           ./gradlew jacocoTestCoverage 
 
       - name: slack notification
-        if: github.event_name == 'pull_request' && github.event.action == 'synchronize' && steps.slack-suggestion-notification.outcome == 'skipped'
+        if: github.event_name == 'pull_request' && github.event.action != 'synchronize' && steps.slack-suggestion-notification.outcome == 'skipped'
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="<@"

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -63,7 +63,7 @@ jobs:
           distribution: 'temurin'
 
       - name: cache gradle
-        if: success()
+        if: steps.slack-notification.outcome == 'failure'
         uses: actions/cache@v2
         with:
           path: |
@@ -74,11 +74,11 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: chmod gradle
-        if: success()
+        if: steps.slack-notification.outcome == 'failure'
         run: chmod +x backend/ddang/gradlew
 
       - name: run jacocoTestCoverage
-        if: success()
+        if: steps.slack-notification.outcome == 'failure'
         run: |
           cd backend/ddang
           ./gradlew jacocoTestCoverage 

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -8,8 +8,53 @@ on:
 permissions: write-all
 
 jobs:
+  author-info:
+    runs-on: ubuntu-latest
+    outputs:
+      AUTHOR_NAME: ${{ steps.set-author-slack-id.outputs.AUTHOR_NAME }}
+      AUTHOR_ID: ${{ steps.set-author-slack-id.outputs.AUTHOR_ID }}
+    steps:
+      - name: set-author-slack-id
+        if: always()
+        id: author-slack
+        run: |
+          if [ "$GIT_ID" == "apptie" ]; then
+            AUTHOR_NAME="${{ secrets.apptie_slack_display_name }}"
+            AUTHOR_ID="${{ secrets.apptie_slack_id }}"
+          elif [ "$GIT_ID" == "swonny" ]; then
+            AUTHOR_NAME="${{ secrets.swonny_slack_display_name }}"
+            AUTHOR_ID="${{ secrets.swonny_slack_id }}"
+          elif [ "$GIT_ID" == "JJ503" ]; then
+            AUTHOR_NAME="${{ secrets.JJ503_slack_display_name }}"
+            AUTHOR_ID="${{ secrets.JJ503_slack_id }}"
+          elif [ "$GIT_ID" == "kwonyj1022" ]; then
+            AUTHOR_NAME="${{ secrets.kwonyj1022_slack_display_name }}"
+            AUTHOR_ID="${{ secrets.kwonyj1022_slack_id }}"
+          fi
+
+          echo "::set-output name=AUTHOR_NAME::${AUTHOR_NAME}"
+          echo "::set-output name=AUTHOR_ID::${AUTHOR_ID}"
+
+  suggestion:
+    if: contains(github.event.pull_request.labels.*.name, 'backend') && contains(github.event.pull_request.labels.*.name, 'suggestion')
+    runs-on: ubuntu-latest
+    steps:
+      - name: slack suggestion notification
+        if: github.event_name == 'pull_request' && github.event.action != 'synchronize'
+        run: |
+          SLACK_MESSAGE='{"text":"제안 PR","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*제안 PR* \n>\n>*PR Author*\n>'
+          SLACK_MESSAGE+="${{ needs.author-info.outputs.AUTHOR_NAME }}"
+          SLACK_MESSAGE+="\n>\n>*PR 링크*\n><"
+          SLACK_MESSAGE+="${{ github.event.pull_request.html_url }} "
+          SLACK_MESSAGE+="> \n>\n>*PR 제목*\n>"
+          SLACK_MESSAGE+="${{ github.event.pull_request.title }}"
+          SLACK_MESSAGE+="\n\n제안 사항에 대한 PR입니다.\n리뷰 요청은 스레드로 직접 멘션해주세요."
+          SLACK_MESSAGE+='"}}]}'
+
+          curl -X POST ${{ secrets.SLACK_WEBHOOK }} -d "${SLACK_MESSAGE}" 
+
   build:
-    if: contains(github.event.pull_request.labels.*.name, 'backend')
+    if: contains(github.event.pull_request.labels.*.name, 'backend') && !contains(github.event.pull_request.labels.*.name, 'suggestion')
     runs-on: ubuntu-latest
 
     steps:
@@ -38,34 +83,11 @@ jobs:
           cd backend/ddang
           ./gradlew jacocoTestCoverage 
 
-      - name: set author slack id
-        if: always()
-        id: author-slack
-        run: |
-          GIT_ID=${{ github.event.pull_request.user.login }}
-          
-          if [ "$GIT_ID" == "apptie" ]; then
-            AUTHOR_NAME="${{ secrets.apptie_slack_display_name }}"
-            AUTHOR_ID="${{ secrets.apptie_slack_id }}"
-          elif [ "$GIT_ID" == "swonny" ]; then
-            AUTHOR_NAME="${{ secrets.swonny_slack_display_name }}"
-            AUTHOR_ID="${{ secrets.swonny_slack_id }}"
-          elif [ "$GIT_ID" == "JJ503" ]; then
-            AUTHOR_NAME="${{ secrets.JJ503_slack_display_name }}"
-            AUTHOR_ID="${{ secrets.JJ503_slack_id }}"
-          elif [ "$GIT_ID" == "kwonyj1022" ]; then
-            AUTHOR_NAME="${{ secrets.kwonyj1022_slack_display_name }}"
-            AUTHOR_ID="${{ secrets.kwonyj1022_slack_id }}"
-          fi
-          
-          echo "AUTHOR_NAME=${AUTHOR_NAME}" >> $GITHUB_OUTPUT
-          echo "AUTHOR_ID=${AUTHOR_ID}" >> $GITHUB_OUTPUT
-
       - name: slack notification
         if: github.event_name == 'pull_request' && github.event.action != 'synchronize'
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
-          SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_NAME }}"
+          SLACK_MESSAGE+="${{ needs.author-info.outputs.AUTHOR_NAME }}"
           SLACK_MESSAGE+="\n>\n>*PR 링크*\n><"
           SLACK_MESSAGE+="${{ github.event.pull_request.html_url }} "
           SLACK_MESSAGE+="> \n>\n>*PR 제목*\n>"
@@ -82,7 +104,7 @@ jobs:
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="<@"
-          SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_ID }}"
+          SLACK_MESSAGE+="${{ needs.author-info.outputs.AUTHOR_ID }}"
           SLACK_MESSAGE+=">"
           SLACK_MESSAGE+="\n>\n>*PR 링크*\n><"
           SLACK_MESSAGE+="${{ github.event.pull_request.html_url }} "
@@ -100,7 +122,7 @@ jobs:
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="<@"
-          SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_ID }}"
+          SLACK_MESSAGE+="${{ needs.author-info.outputs.AUTHOR_ID }}"
           SLACK_MESSAGE+=">"
           SLACK_MESSAGE+="\n>\n>*PR 링크*\n><"
           SLACK_MESSAGE+="${{ github.event.pull_request.html_url }} "

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -40,7 +40,7 @@ jobs:
       
       - name: slack suggestion notification
         if: contains(github.event.pull_request.labels.*.name, 'suggestion')
-        id: slack-notification
+        id: slack-suggestion-notification
         run: |
           SLACK_MESSAGE='{"text":"제안 PR","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*제안 PR* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="<@"
@@ -56,14 +56,14 @@ jobs:
           curl -X POST ${{ secrets.SLACK_WEBHOOK }} -d "${SLACK_MESSAGE}" 
       
       - name: settings java
-        if: steps.slack-notification.outcome == 'failure'
+        if: steps.slack-suggestion-notification.outcome == 'failure'
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: cache gradle
-        if: steps.slack-notification.outcome == 'failure'
+        if: steps.slack-suggestion-notification.outcome == 'failure'
         uses: actions/cache@v2
         with:
           path: |
@@ -74,7 +74,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: chmod gradle
-        if: steps.slack-notification.outcome == 'failure'
+        if: steps.slack-suggestion-notification.outcome == 'failure'
         run: chmod +x backend/ddang/gradlew
 
       - name: run jacocoTestCoverage
@@ -84,7 +84,7 @@ jobs:
           ./gradlew jacocoTestCoverage 
 
       - name: slack notification
-        if: github.event_name == 'pull_request' && github.event.action == 'synchronize' && steps.slack-notification.outcome == 'failure'
+        if: github.event_name == 'pull_request' && github.event.action == 'synchronize' && steps.slack-suggestion-notification.outcome == 'failure'
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="<@"

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -55,7 +55,7 @@ jobs:
           curl -X POST ${{ secrets.SLACK_WEBHOOK }} -d "${SLACK_MESSAGE}" 
       
       - name: settings java
-        if: failure()
+        if: success()
         uses: actions/setup-java@v3
         with:
           java-version: '17'

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -54,11 +54,6 @@ jobs:
           SLACK_MESSAGE+='"}}]}'
 
           curl -X POST ${{ secrets.SLACK_WEBHOOK }} -d "${SLACK_MESSAGE}" 
-
-      - name: test
-        if: always()
-        run: |
-          echo "${{ steps.slack-suggestion-notification.outcome }}"
       
       - name: settings java
         if: steps.slack-suggestion-notification.outcome == 'skipped'

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -19,6 +19,8 @@ jobs:
         if: always()
         id: author-slack
         run: |
+          GIT_ID=${{ github.event.pull_request.user.login }}
+          
           if [ "$GIT_ID" == "apptie" ]; then
             AUTHOR_NAME="${{ secrets.apptie_slack_display_name }}"
             AUTHOR_ID="${{ secrets.apptie_slack_id }}"
@@ -37,7 +39,7 @@ jobs:
           echo "AUTHOR_ID=${AUTHOR_ID}" >> $GITHUB_OUTPUT
       
       - name: slack suggestion notification
-        if: github.event_name == 'pull_request' && github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'suggestion')
+        if: contains(github.event.pull_request.labels.*.name, 'suggestion')
         run: |
           SLACK_MESSAGE='{"text":"제안 PR","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*제안 PR* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_ID }}"
@@ -51,13 +53,14 @@ jobs:
           curl -X POST ${{ secrets.SLACK_WEBHOOK }} -d "${SLACK_MESSAGE}" 
       
       - name: settings java
-        if: failure()
+        if: cancelled()
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: cache gradle
+        if: success()
         uses: actions/cache@v2
         with:
           path: |
@@ -68,9 +71,11 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: chmod gradle
+        if: success()
         run: chmod +x backend/ddang/gradlew
 
       - name: run jacocoTestCoverage
+        if: success()
         run: |
           cd backend/ddang
           ./gradlew jacocoTestCoverage 
@@ -78,7 +83,7 @@ jobs:
       - name: slack notification
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
-          SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_NAME }}"
+          SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_ID }}"
           SLACK_MESSAGE+="\n>\n>*PR 링크*\n><"
           SLACK_MESSAGE+="${{ github.event.pull_request.html_url }} "
           SLACK_MESSAGE+="> \n>\n>*PR 제목*\n>"

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -84,7 +84,7 @@ jobs:
           ./gradlew jacocoTestCoverage 
 
       - name: slack notification
-        if: github.event_name == 'pull_request' && github.event.action == 'synchronize' 
+        if: github.event_name == 'pull_request' && github.event.action == 'synchronize' && steps.slack-notification.outcome == 'failure'
         run: |
           SLACK_MESSAGE='{"text":"PR 브랜치 분석","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*PR 브랜치 분석* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="<@"

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -78,7 +78,7 @@ jobs:
         run: chmod +x backend/ddang/gradlew
 
       - name: run jacocoTestCoverage
-        if: steps.slack-notification.outcome == 'skipped'
+        if: steps.slack-suggestion-notification.outcome == 'skipped'
         run: |
           cd backend/ddang
           ./gradlew jacocoTestCoverage 

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -54,6 +54,11 @@ jobs:
           SLACK_MESSAGE+='"}}]}'
 
           curl -X POST ${{ secrets.SLACK_WEBHOOK }} -d "${SLACK_MESSAGE}" 
+
+      - name: test
+        if: always()
+        run: |
+          echo "${{ steps.slack-suggestion-notification.outcome }}"
       
       - name: settings java
         if: steps.slack-suggestion-notification.outcome == 'failure'

--- a/.github/workflows/backend_pr_decorator.yml
+++ b/.github/workflows/backend_pr_decorator.yml
@@ -55,7 +55,7 @@ jobs:
           curl -X POST ${{ secrets.SLACK_WEBHOOK }} -d "${SLACK_MESSAGE}" 
       
       - name: settings java
-        if: cancelled()
+        if: failure()
         uses: actions/setup-java@v3
         with:
           java-version: '17'

--- a/.github/workflows/backend_suggestion_pr_decorator.yml
+++ b/.github/workflows/backend_suggestion_pr_decorator.yml
@@ -1,0 +1,53 @@
+name: 제안 PR 슬랙 메시지
+
+on:
+  pull_request:
+    types: [ opened, reopened ]
+    branches: [ main, develop, develop-be ]
+
+permissions: write-all
+
+jobs:
+  build:
+    if: contains(github.event.pull_request.labels.*.name, 'backend') && contains(github.event.pull_request.labels.*.name, 'suggestion')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: set author slack id
+        id: author-slack
+        run: |
+          GIT_ID=${{ github.event.pull_request.user.login }}
+          
+          if [ "$GIT_ID" == "apptie" ]; then
+            AUTHOR_NAME="${{ secrets.apptie_slack_display_name }}"
+            AUTHOR_ID="${{ secrets.apptie_slack_id }}"
+          elif [ "$GIT_ID" == "swonny" ]; then
+            AUTHOR_NAME="${{ secrets.swonny_slack_display_name }}"
+            AUTHOR_ID="${{ secrets.swonny_slack_id }}"
+          elif [ "$GIT_ID" == "JJ503" ]; then
+            AUTHOR_NAME="${{ secrets.JJ503_slack_display_name }}"
+            AUTHOR_ID="${{ secrets.JJ503_slack_id }}"
+          elif [ "$GIT_ID" == "kwonyj1022" ]; then
+            AUTHOR_NAME="${{ secrets.kwonyj1022_slack_display_name }}"
+            AUTHOR_ID="${{ secrets.kwonyj1022_slack_id }}"
+          fi
+
+          echo "AUTHOR_NAME=${AUTHOR_NAME}" >> $GITHUB_OUTPUT
+          echo "AUTHOR_ID=${AUTHOR_ID}" >> $GITHUB_OUTPUT
+      
+      - name: slack suggestion notification
+        run: |
+          SLACK_MESSAGE='{"text":"제안 PR","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*제안 PR* \n>\n>*PR Author*\n>'
+          SLACK_MESSAGE+="<@"
+          SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_ID }}"
+          SLACK_MESSAGE+=">"
+          SLACK_MESSAGE+="\n>\n>*PR 링크*\n><"
+          SLACK_MESSAGE+="${{ github.event.pull_request.html_url }} "
+          SLACK_MESSAGE+="> \n>\n>*PR 제목*\n>"
+          SLACK_MESSAGE+="${{ github.event.pull_request.title }}"
+          SLACK_MESSAGE+="\n\n제안 사항에 대한 PR입니다.\n리뷰 요청은 스레드로 직접 멘션해주세요."
+          SLACK_MESSAGE+='"}}]}'
+
+          curl -X POST ${{ secrets.SLACK_WEBHOOK }} -d "${SLACK_MESSAGE}" 

--- a/.github/workflows/backend_suggestion_pr_decorator.yml
+++ b/.github/workflows/backend_suggestion_pr_decorator.yml
@@ -2,7 +2,7 @@ name: 제안 PR 슬랙 메시지
 
 on:
   pull_request:
-    types: [ opened, reopened ]
+    types: [ opened, reopened, synchronize ]
     branches: [ main, develop, develop-be ]
 
 permissions: write-all
@@ -22,32 +22,29 @@ jobs:
           
           if [ "$GIT_ID" == "apptie" ]; then
             AUTHOR_NAME="${{ secrets.apptie_slack_display_name }}"
-            AUTHOR_ID="${{ secrets.apptie_slack_id }}"
           elif [ "$GIT_ID" == "swonny" ]; then
             AUTHOR_NAME="${{ secrets.swonny_slack_display_name }}"
-            AUTHOR_ID="${{ secrets.swonny_slack_id }}"
           elif [ "$GIT_ID" == "JJ503" ]; then
             AUTHOR_NAME="${{ secrets.JJ503_slack_display_name }}"
-            AUTHOR_ID="${{ secrets.JJ503_slack_id }}"
           elif [ "$GIT_ID" == "kwonyj1022" ]; then
             AUTHOR_NAME="${{ secrets.kwonyj1022_slack_display_name }}"
-            AUTHOR_ID="${{ secrets.kwonyj1022_slack_id }}"
           fi
 
           echo "AUTHOR_NAME=${AUTHOR_NAME}" >> $GITHUB_OUTPUT
-          echo "AUTHOR_ID=${AUTHOR_ID}" >> $GITHUB_OUTPUT
       
       - name: slack suggestion notification
         run: |
           SLACK_MESSAGE='{"text":"제안 PR","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*제안 PR* \n>\n>*PR Author*\n>'
-          SLACK_MESSAGE+="<@"
-          SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_ID }}"
-          SLACK_MESSAGE+=">"
+          SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_NAME }}"
           SLACK_MESSAGE+="\n>\n>*PR 링크*\n><"
           SLACK_MESSAGE+="${{ github.event.pull_request.html_url }} "
           SLACK_MESSAGE+="> \n>\n>*PR 제목*\n>"
           SLACK_MESSAGE+="${{ github.event.pull_request.title }}"
-          SLACK_MESSAGE+="\n\n제안 사항에 대한 PR입니다.\n리뷰 요청은 스레드로 직접 멘션해주세요."
+          SLACK_MESSAGE+="\n>\n>*리뷰어*\n>"
+          SLACK_MESSAGE+="<@channel>"
           SLACK_MESSAGE+='"}}]}'
 
           curl -X POST ${{ secrets.SLACK_WEBHOOK }} -d "${SLACK_MESSAGE}" 
+          
+      - name: Force failure
+        run: exit 1

--- a/.github/workflows/backend_suggestion_pr_decorator.yml
+++ b/.github/workflows/backend_suggestion_pr_decorator.yml
@@ -2,7 +2,7 @@ name: 제안 PR 슬랙 메시지
 
 on:
   pull_request:
-    types: [ opened, reopened, synchronize ]
+    types: [ opened, reopened ]
     branches: [ main, develop, develop-be ]
 
 permissions: write-all

--- a/.github/workflows/backend_suggestion_pr_decorator.yml
+++ b/.github/workflows/backend_suggestion_pr_decorator.yml
@@ -2,7 +2,7 @@ name: 제안 PR 슬랙 메시지
 
 on:
   pull_request:
-    types: [ opened, reopened ]
+    types: [ opened, reopened, synchronize ]
     branches: [ main, develop, develop-be ]
 
 permissions: write-all

--- a/.github/workflows/backend_suggestion_pr_decorator.yml
+++ b/.github/workflows/backend_suggestion_pr_decorator.yml
@@ -41,7 +41,7 @@ jobs:
           SLACK_MESSAGE+="> \n>\n>*PR 제목*\n>"
           SLACK_MESSAGE+="${{ github.event.pull_request.title }}"
           SLACK_MESSAGE+="\n>\n>*리뷰어*\n>"
-          SLACK_MESSAGE+="<@channel>"
+          SLACK_MESSAGE+="<!channel>"
           SLACK_MESSAGE+='"}}]}'
 
           curl -X POST ${{ secrets.SLACK_WEBHOOK }} -d "${SLACK_MESSAGE}" 

--- a/.github/workflows/backend_suggestion_pr_decorator.yml
+++ b/.github/workflows/backend_suggestion_pr_decorator.yml
@@ -33,6 +33,7 @@ jobs:
           echo "AUTHOR_NAME=${AUTHOR_NAME}" >> $GITHUB_OUTPUT
       
       - name: slack suggestion notification
+        if: github.event.action != 'synchronize'
         run: |
           SLACK_MESSAGE='{"text":"제안 PR","blocks":[{"type":"section","text":{"type":"mrkdwn","text":">*제안 PR* \n>\n>*PR Author*\n>'
           SLACK_MESSAGE+="${{ steps.author-slack.outputs.AUTHOR_NAME }}"


### PR DESCRIPTION
<!-- 반드시 Backend/Androiod 라벨과 리뷰어를 등록해주세요! -->

## 📄 작업 내용 요약
<!-- 작업한 내용을 간단히 요약해주세요. -->
PR 코드 분석 시 suggestion 태그를 위한 로직 추가
자세한 내용은 [이슈](https://github.com/woowacourse-teams/2023-3-ddang/issues/740) 내용 확인해주세요!

## 🙋🏻 리뷰 시 주의 깊게 확인해야 하는 코드
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
`author-info`라는 jobs가 동일되는 내용이라 분리해 봤는데 잘되길 바랍니다.
제안 pr 관련 workflow의 경우 `synchronize`는 작동하지 않도록 했기에, 현재 pr에서는 따로 체크가 되지 않는 것이 맞습니다.
`synchronize`도 체크  표시는 되고(하는 건 없음, 정말 체크만) 슬랙 메시지만 안 오길 바라신다면 의견 말씀해주시면 감사하겠습니다.

그리고 몇 가지 질문이 있습니다. 답변해주시면 감사하겠습니다!
1. 이제 직접 멘션을 해줘야 하다보니 pr 리뷰 요청에서도 author를 멘션하도록 했는데 어떤가요?
2. 조건이 더러운 것 보다는 workflow를 아예 나누는 것이 더 좋다고 판단해 그렇게 진행했는데 어떨까요?
3. 제안 pr의 경우 리뷰어들이 바로 멘션에 걸리는 것이 더 좋을까요?

## 📎 Issue 번호
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
- closed #740 
<!-- closed #번호 --> 
